### PR TITLE
Fix success message spelling

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -135,7 +135,7 @@ namespace Northeast.Controllers
             }
             await articleUpload.addComment(ArticleId, Comment);
 
-            return Ok(new { message = "comment added sucessfully" });
+            return Ok(new { message = "comment added successfully" });
 
         }
         [Authorize]
@@ -155,7 +155,7 @@ namespace Northeast.Controllers
             }
             await articleUpload.ModifyComment(CommentId, Comment);
 
-            return Ok(new { message = "comment added sucessfully" });
+            return Ok(new { message = "comment added successfully" });
 
         }
 

--- a/Northeast/Controllers/OTPController.cs
+++ b/Northeast/Controllers/OTPController.cs
@@ -178,7 +178,7 @@ namespace Northeast.Controllers
                 }
                 await _userReg.ChangePassword(user, Password);
                 await _oTPservices.DeleteOTP(otp);
-                return Ok(new { message = "password changed sucessfully" });
+                return Ok(new { message = "password changed successfully" });
             }
             catch (Exception ex)
             {

--- a/Northeast/Controllers/UserAuthController.cs
+++ b/Northeast/Controllers/UserAuthController.cs
@@ -63,7 +63,7 @@ namespace Northeast.Controllers
                 };
 
                 Response.Cookies.Append("JwtToken", token, cookieOptions);
-                return Ok(new {message= "logged in sucessfully" });
+                return Ok(new {message= "logged in successfully" });
             }
             return Unauthorized(new { message = "opps! unable to log in " });
         }


### PR DESCRIPTION
## Summary
- correct the spelling of "successfully" in controllers

## Testing
- `grep -R "sucessfully" -R Northeast/Controllers || true`

------
https://chatgpt.com/codex/tasks/task_e_6874ed9e2c6883278451e045175241b6