### PR TITLE
Add category navigation and search bar

### DIFF
--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -20,7 +20,8 @@ export const API_ROUTES = {
     CREATE: `${API_BASE_URL}/api/Article`,
     GET_ALL: `${API_BASE_URL}/api/Article`,
     SEARCH: (query: string) =>
-      `${API_BASE_URL}/api/Article/search/${encodeURIComponent(query)}`,
+      `${API_BASE_URL}/api/ArticleSearch?query=${encodeURIComponent(query)}`,
+    SEARCH_ADVANCED: `${API_BASE_URL}/api/ArticleSearch/advanced`,
     UPDATE: `${API_BASE_URL}/api/Article`,
     DELETE: `${API_BASE_URL}/api/Article`,
     LIKE: `${API_BASE_URL}/api/Article/Like`,

--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -1,0 +1,8 @@
+export const CATEGORIES = [
+  'StockMarket',
+  'Politics',
+  'Crime',
+  'Celebrities',
+  'Business',
+  'Space',
+];

--- a/WT4Q/src/app/admin-login/AdminLogin.module.css
+++ b/WT4Q/src/app/admin-login/AdminLogin.module.css
@@ -1,28 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;700&display=swap');
 
-:root {
-  /* WT4Q brand metallic hues */
-  --wt4q-yellow: #E6C200;
-  --wt4q-red:    #C5281B;
-  --wt4q-blue:   #005D9E;
-  --wt4q-green:  #3A7D24;
-
-  /* Metallic base tones */
-  --metal-base:      #D1D1D3;
-  --metal-reflect:   #FFFFFF;
-  --metal-shadow:    rgba(0,0,0,0.4);
-
-  --text-default:    #212121;
-  --text-light:      #555555;
-  --error-red:       #D32F2F;
-}
-
-body, html {
-  margin: 0;
-  padding: 0;
-  font-family: 'Roboto Slab', serif;
-}
-
 /* Container: metal background + WT4Q logo watermark */
 .container {
   min-height: 100vh;

--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -1,0 +1,31 @@
+import ArticleCard, { Article } from '@/components/ArticleCard';
+import { API_ROUTES } from '@/lib/api';
+import styles from '../category.module.css';
+
+async function fetchArticles(cat: string): Promise<Article[]> {
+  try {
+    const res = await fetch(
+      `${API_ROUTES.ARTICLE.SEARCH_ADVANCED}?category=${encodeURIComponent(cat)}`,
+      { cache: 'no-store' }
+    );
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function CategoryPage({ params }: any) {
+  const articles = await fetchArticles(params.category);
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>{params.category}</h1>
+      <div className={styles.grid}>
+        {articles.map((a) => (
+          <ArticleCard key={a.id} article={a} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/WT4Q/src/app/category/category.module.css
+++ b/WT4Q/src/app/category/category.module.css
@@ -1,0 +1,20 @@
+.container {
+  font-family: 'Times New Roman', serif;
+}
+
+.title {
+  text-transform: capitalize;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 700px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/WT4Q/src/app/globals.css
+++ b/WT4Q/src/app/globals.css
@@ -46,3 +46,16 @@ a {
     color-scheme: dark;
   }
 }
+/* Admin Login theme */
+:root {
+  --wt4q-yellow: #E6C200;
+  --wt4q-red: #C5281B;
+  --wt4q-blue: #005D9E;
+  --wt4q-green: #3A7D24;
+  --metal-base: #D1D1D3;
+  --metal-reflect: #FFFFFF;
+  --metal-shadow: rgba(0,0,0,0.4);
+  --text-default: #212121;
+  --text-light: #555555;
+  --error-red: #D32F2F;
+}

--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -1,0 +1,15 @@
+.nav {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding: 0.5rem 1rem;
+  font-family: 'Times New Roman', serif;
+  border-bottom: 1px solid #ddd;
+}
+
+.link {
+  text-decoration: none;
+  color: inherit;
+  white-space: nowrap;
+  font-size: 0.875rem;
+}

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { CATEGORIES } from '@/lib/categories';
+import styles from './CategoryNavbar.module.css';
+
+export default function CategoryNavbar() {
+  return (
+    <nav className={styles.nav} aria-label="categories">
+      {CATEGORIES.map((c) => (
+        <Link key={c} href={`/category/${c}`} className={styles.link}>
+          {c}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -11,6 +11,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
 }
 
 .logo {
@@ -29,4 +30,15 @@
   color: inherit;
   text-decoration: none;
   font-weight: 500;
+}
+
+.categories {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.search {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
 }

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import CategoryNavbar from './CategoryNavbar';
+import SearchBar from './SearchBar';
 import styles from './Header.module.css';
 
 export default function Header() {
@@ -10,8 +12,13 @@ export default function Header() {
         </Link>
         <nav className={styles.nav}>
           <Link href="/" className={styles.navLink}>Home</Link>
-          <Link href="/search" className={styles.navLink}>Search</Link>
         </nav>
+        <div className={styles.search}>
+          <SearchBar />
+        </div>
+      </div>
+      <div className={styles.categories}>
+        <CategoryNavbar />
       </div>
     </header>
   );

--- a/WT4Q/src/components/SearchBar.module.css
+++ b/WT4Q/src/components/SearchBar.module.css
@@ -1,0 +1,21 @@
+.form {
+  display: flex;
+  border: 1px solid #ccc;
+  height: 1.75rem;
+}
+
+.input {
+  flex: 1;
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  border: none;
+  outline: none;
+}
+
+.button {
+  padding: 0 0.75rem;
+  background: #000;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}

--- a/WT4Q/src/components/SearchBar.tsx
+++ b/WT4Q/src/components/SearchBar.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import styles from './SearchBar.module.css';
+
+export default function SearchBar() {
+  const [query, setQuery] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+    router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form} role="search">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search..."
+        className={styles.input}
+      />
+      <button type="submit" className={styles.button} aria-label="search">
+        🔍
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- extend article API to include ArticleSearch endpoints
- add constant list of article categories
- build reusable `SearchBar` and `CategoryNavbar` components
- extend header with search bar and category links
- add category page layout and styling
- move admin login CSS variables to global stylesheet

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a932466888327a963fed6117b1340