### PR TITLE
Replace header logo with image

### DIFF
--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -15,19 +15,15 @@
   gap: 1rem;
 }
 
+
 .logo {
-  font-size: 1.5rem;
-  font-weight: bold;
-  text-transform: uppercase;
-  letter-spacing: 1px;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
 }
 
 .logoImage {
   width: 40px;
-  height: auto;
+  height: 40px;
   border-radius: 50%;
 }
 

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import CategoryNavbar from './CategoryNavbar';
 import SearchBar from './SearchBar';
 import styles from './Header.module.css';
@@ -8,8 +9,14 @@ export default function Header() {
     <header className={styles.header}>
       <div className={styles.inner}>
         <Link href="/" className={styles.logo}>
-          <img src="/images/wt4q-logo.png" alt="WT4Q logo" className={styles.logoImage} />
-          WT4Q News
+          <Image
+            src="/images/wt4q-logo.png"
+            alt="WT4Q logo"
+            width={40}
+            height={40}
+            className={styles.logoImage}
+            priority
+          />
         </Link>
         <nav className={styles.nav}>
           <Link href="/" className={styles.navLink}>Home</Link>


### PR DESCRIPTION
## Summary
- use `next/image` in Header
- tweak header styling for new logo

## Testing
- `npm run build` *(fails: CategoryPageProps does not satisfy PageProps)*

------
https://chatgpt.com/codex/tasks/task_e_687aa01986608327a64f4fc76ab458e4