### PR TITLE
Add hero and 3D styling to homepage

### DIFF
--- a/WT4Q/src/app/page.module.css
+++ b/WT4Q/src/app/page.module.css
@@ -3,7 +3,8 @@
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 2rem;
   font-family: 'Times New Roman', serif;
-  padding: 1rem;
+  padding: 2rem 1rem;
+  margin-top: 2rem;
 }
 
 @media (max-width: 700px) {

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ArticleCard, { Article } from '@/components/ArticleCard';
+import Hero from '@/components/Hero';
 import { API_ROUTES } from '@/lib/api';
 import styles from './page.module.css';
 
@@ -15,10 +16,13 @@ async function fetchArticles(): Promise<Article[]> {
 export default async function Home() {
   const articles = await fetchArticles();
   return (
-    <div className={styles.container}>
-      {articles.map((a) => (
-        <ArticleCard key={a.id} article={a} />
-      ))}
-    </div>
+    <>
+      <Hero />
+      <div className={styles.container}>
+        {articles.map((a) => (
+          <ArticleCard key={a.id} article={a} />
+        ))}
+      </div>
+    </>
   );
 }

--- a/WT4Q/src/components/ArticleCard.module.css
+++ b/WT4Q/src/components/ArticleCard.module.css
@@ -4,6 +4,13 @@
   background: var(--metal-base);
   font-family: 'Times New Roman', serif;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  transition: transform 0.3s, box-shadow 0.3s;
+  transform-style: preserve-3d;
+}
+
+.card:hover {
+  transform: translateY(-4px) rotateX(4deg) rotateY(-2deg);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
 }
 
 .title {

--- a/WT4Q/src/components/Hero.module.css
+++ b/WT4Q/src/components/Hero.module.css
@@ -1,0 +1,23 @@
+.hero {
+  perspective: 1000px;
+  background: var(--metal-gradient);
+  color: var(--metal-reflect);
+  padding: 4rem 1rem;
+  text-align: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.inner {
+  transform: rotateX(5deg);
+}
+
+.title {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 4px 10px var(--metal-shadow);
+}
+
+.subtitle {
+  font-size: 1.25rem;
+  text-shadow: 0 2px 6px var(--metal-shadow);
+}

--- a/WT4Q/src/components/Hero.tsx
+++ b/WT4Q/src/components/Hero.tsx
@@ -1,0 +1,12 @@
+import styles from './Hero.module.css';
+
+export default function Hero() {
+  return (
+    <section className={styles.hero} aria-label="WT4Q introduction">
+      <div className={styles.inner}>
+        <h1 className={styles.title}>WT4Q News</h1>
+        <p className={styles.subtitle}>Where every story pops.</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Hero` component with 3D styled logo section
- update homepage layout to include new hero section
- give article cards a hover transform for a slight 3D feel
- adjust homepage spacing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687aa55e2ef48327b6640ff5beaaea3a