### PR TITLE
Fix CategoryPage params typing

### DIFF
--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -15,9 +15,12 @@ async function fetchArticles(cat: string): Promise<Article[]> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function CategoryPage({ params }: { params: any }) {
-  const { category } = params as { category: string };
+export default async function CategoryPage({
+  params,
+}: {
+  params: Promise<{ category: string }>;
+}) {
+  const { category } = await params;
   const articles = await fetchArticles(category);
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## Summary
- update CategoryPage to await `params`
- remove eslint disable comment

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687aa9e6a69483278b4ea236559f41e8