### PR TITLE
Add article detail page

### DIFF
--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -19,6 +19,9 @@ export const API_ROUTES = {
   ARTICLE: {
     CREATE: `${API_BASE_URL}/api/Article`,
     GET_ALL: `${API_BASE_URL}/api/Article`,
+    GET_BY_ID: (id: string) => `${API_BASE_URL}/api/Article/${id}`,
+    GET_RECOMMENDATIONS: (id: string, count = 5) =>
+      `${API_BASE_URL}/api/Article/${id}/recommendations?count=${count}`,
     SEARCH: (query: string) =>
       `${API_BASE_URL}/api/ArticleSearch?query=${encodeURIComponent(query)}`,
     SEARCH_ADVANCED: `${API_BASE_URL}/api/ArticleSearch/advanced`,

--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -1,0 +1,56 @@
+import ArticleCard, { Article } from '@/components/ArticleCard';
+import { API_ROUTES } from '@/lib/api';
+import styles from '../article.module.css';
+
+interface ArticleDetails {
+  id: string;
+  title: string;
+  description: string;
+  createdDate: string;
+}
+
+async function fetchArticle(id: string): Promise<ArticleDetails | null> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.GET_BY_ID(id), { cache: 'no-store' });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchRelated(id: string): Promise<Article[]> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.GET_RECOMMENDATIONS(id), { cache: 'no-store' });
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+export default async function ArticlePage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const article = await fetchArticle(id);
+  if (!article) {
+    return <div className={styles.container}>Article not found.</div>;
+  }
+  const related = await fetchRelated(id);
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>{article.title}</h1>
+      <p className={styles.meta}>{new Date(article.createdDate).toLocaleDateString()}</p>
+      <p className={styles.content}>{article.description}</p>
+      {related.length > 0 && (
+        <section>
+          <h2 className={styles.relatedHeading}>Related Articles</h2>
+          <div className={styles.grid}>
+            {related.map((a) => (
+              <ArticleCard key={a.id} article={a} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -1,0 +1,45 @@
+.container {
+  font-family: 'Times New Roman', serif;
+  padding: 1rem;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+  background: var(--metal-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.meta {
+  color: #666;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}
+
+.content {
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.relatedHeading {
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+  font-weight: bold;
+  background: var(--metal-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 700px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- implement article details page
- allow fetching related articles
- expose new article API routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b0b9b5d3c832799d04a2b13015ba7