### PR TITLE
Fix AdminToken cookie usage

### DIFF
--- a/WT4Q/src/app/admin-login/page.tsx
+++ b/WT4Q/src/app/admin-login/page.tsx
@@ -60,7 +60,7 @@ const AdminLogin: FC = () => {
         }
 
         // Securely set cookie
-        document.cookie = `adminToken=${data.token}; path=/; Secure; SameSite=Strict`;
+        document.cookie = `AdminToken=${data.token}; path=/; Secure; SameSite=Strict`;
 
         router.replace('/admin/dashboard');
       } catch (err) {


### PR DESCRIPTION
## Summary
- align frontend cookie name with backend expectations

## Testing
- `npm run lint`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b129ba3588327bdf7b3e85d0030be