### PR TITLE
Implement article filter API and advanced search UI

### DIFF
--- a/Northeast/Controllers/ArticleFilterController.cs
+++ b/Northeast/Controllers/ArticleFilterController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Northeast.Models;
+using Northeast.Services;
+
+namespace Northeast.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ArticleFilterController : ControllerBase
+    {
+        private readonly ArticleServices _articleServices;
+        public ArticleFilterController(ArticleServices articleServices)
+        {
+            _articleServices = articleServices;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Filter(
+            [FromQuery] Guid? id,
+            [FromQuery] string? title,
+            [FromQuery] string? description,
+            [FromQuery] DateTime? date,
+            [FromQuery] ArticleType? type,
+            [FromQuery] Category? category,
+            [FromQuery] Guid? authorId,
+            [FromQuery] string? countryName,
+            [FromQuery] string? countryCode,
+            [FromQuery] string? keyword)
+        {
+            var results = await _articleServices.FilterArticles(id, title, description, date, type, category, authorId, countryName, countryCode, keyword);
+            if (!results.Any())
+            {
+                return NotFound(new { message = "No articles found" });
+            }
+            return Ok(results);
+        }
+    }
+}

--- a/Northeast/Repository/ArticleRepository.cs
+++ b/Northeast/Repository/ArticleRepository.cs
@@ -86,6 +86,71 @@ namespace Northeast.Repository
                 .ToListAsync();
         }
 
+        public async Task<IEnumerable<Article>> Filter(Guid? id, string? title, string? description,
+            DateTime? date, ArticleType? type, Category? category, Guid? authorId,
+            string? countryName, string? countryCode, string? keyword)
+        {
+            var queryable = _context.Articles.AsNoTracking().AsQueryable();
+
+            if (id.HasValue)
+            {
+                queryable = queryable.Where(a => a.Id == id.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                var lower = title.ToLower();
+                queryable = queryable.Where(a => a.Title.ToLower().Contains(lower));
+            }
+
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                var lower = description.ToLower();
+                queryable = queryable.Where(a => a.Description.ToLower().Contains(lower));
+            }
+
+            if (date.HasValue)
+            {
+                var d = date.Value.Date;
+                queryable = queryable.Where(a => a.CreatedDate.Date == d);
+            }
+
+            if (type.HasValue)
+            {
+                queryable = queryable.Where(a => a.ArticleType == type.Value);
+            }
+
+            if (category.HasValue)
+            {
+                queryable = queryable.Where(a => a.Category == category.Value);
+            }
+
+            if (authorId.HasValue)
+            {
+                queryable = queryable.Where(a => a.AuthorId == authorId.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(countryName))
+            {
+                var lower = countryName.ToLower();
+                queryable = queryable.Where(a => a.CountryName != null && a.CountryName.ToLower().Contains(lower));
+            }
+
+            if (!string.IsNullOrWhiteSpace(countryCode))
+            {
+                var lower = countryCode.ToLower();
+                queryable = queryable.Where(a => a.CountryCode != null && a.CountryCode.ToLower().Contains(lower));
+            }
+
+            if (!string.IsNullOrWhiteSpace(keyword))
+            {
+                var lower = keyword.ToLower();
+                queryable = queryable.Where(a => a.Keywords != null && a.Keywords.Any(k => k.ToLower().Contains(lower)));
+            }
+
+            return await queryable.ToListAsync();
+        }
+
         public async Task<IEnumerable<Article>> GetRecommendedArticles(Guid articleId, int count = 5)
         {
             var source = await _context.Articles.AsNoTracking().FirstOrDefaultAsync(a => a.Id == articleId);

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -83,6 +83,13 @@ namespace Northeast.Services
             return await _articleRepository.SearchByAuthor(authorId);
         }
 
+        public async Task<IEnumerable<Article>> FilterArticles(Guid? id, string? title, string? description,
+            DateTime? date, ArticleType? type, Category? category, Guid? authorId,
+            string? countryName, string? countryCode, string? keyword)
+        {
+            return await _articleRepository.Filter(id, title, description, date, type, category, authorId, countryName, countryCode, keyword);
+        }
+
         public async Task<IEnumerable<Article>> GetRelatedArticles(Guid articleId, int count = 5)
         {
             return await _articleRepository.GetRecommendedArticles(articleId, count);

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -25,6 +25,7 @@ export const API_ROUTES = {
     SEARCH: (query: string) =>
       `${API_BASE_URL}/api/ArticleSearch?query=${encodeURIComponent(query)}`,
     SEARCH_ADVANCED: `${API_BASE_URL}/api/ArticleSearch/advanced`,
+    FILTER: `${API_BASE_URL}/api/ArticleFilter`,
     UPDATE: `${API_BASE_URL}/api/Article`,
     DELETE: `${API_BASE_URL}/api/Article`,
     LIKE: `${API_BASE_URL}/api/Article/Like`,

--- a/WT4Q/lib/articleTypes.ts
+++ b/WT4Q/lib/articleTypes.ts
@@ -1,0 +1,1 @@
+export const ARTICLE_TYPES = ['News', 'Article', 'QnA'];

--- a/WT4Q/src/app/search/advanced/page.tsx
+++ b/WT4Q/src/app/search/advanced/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import ArticleCard, { Article } from '@/components/ArticleCard';
+import { API_ROUTES } from '@/lib/api';
+import { CATEGORIES } from '@/lib/categories';
+import { ARTICLE_TYPES } from '@/lib/articleTypes';
+import styles from '../search.module.css';
+
+export default function AdvancedSearchPage() {
+  const [title, setTitle] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [date, setDate] = useState('');
+  const [type, setType] = useState('');
+  const [category, setCategory] = useState('');
+  const [results, setResults] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (title) params.append('title', title);
+    if (keyword) params.append('keyword', keyword);
+    if (date) params.append('date', date);
+    if (type) params.append('type', type);
+    if (category) params.append('category', category);
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_ROUTES.ARTICLE.FILTER}?${params.toString()}`);
+      if (res.ok) {
+        setResults(await res.json());
+      } else {
+        setResults([]);
+      }
+    } catch {
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <input
+          type="text"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className={styles.input}
+        />
+        <input
+          type="text"
+          placeholder="Keyword"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          className={styles.input}
+        />
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className={styles.input}
+        />
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className={styles.input}
+        >
+          <option value="">Any Type</option>
+          {ARTICLE_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className={styles.input}
+        >
+          <option value="">Any Category</option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <button type="submit" disabled={loading} className={styles.button}>
+          Search
+        </button>
+      </form>
+      <div className={styles.results}>
+        {results.map((a) => (
+          <ArticleCard key={a.id} article={a} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ArticleFilterController` for querying articles by any property
- implement filtering logic in the repository and service layers
- expose new `FILTER` endpoint to the frontend API config
- add client-side advanced search page consuming the new endpoint
- provide article type constants for the new page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b14829ee48327a6ab803b76390d5d