### PR TITLE
Fix namespace typo for SendEmail

### DIFF
--- a/Northeast/Controllers/OTPController.cs
+++ b/Northeast/Controllers/OTPController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Northast.Services;
+using Northeast.Services;
 using Northeast.Models;
 using Northeast.Repository;
 using Northeast.Services;

--- a/Northeast/Controllers/UserRegistrationController.cs
+++ b/Northeast/Controllers/UserRegistrationController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Northast.Services;
+using Northeast.Services;
 using Northeast.Data;
 using Northeast.DTOs;
 using Northeast.Models;

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Tokens;
-using Northast.Services;
+using Northeast.Services;
 using Northeast.Data;
 using Northeast.Interface;
 using Northeast.Middlewares;

--- a/Northeast/Services/OTPservices.cs
+++ b/Northeast/Services/OTPservices.cs
@@ -1,5 +1,5 @@
 ﻿using NavXpert.Utilities;
-using Northast.Services;
+using Northeast.Services;
 using Northeast.Models;
 using Northeast.Repository;
 

--- a/Northeast/Services/UserRegistration.cs
+++ b/Northeast/Services/UserRegistration.cs
@@ -4,7 +4,7 @@ using BCrypt;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Xml.Linq;
-using Northast.Services;
+using Northeast.Services;
 using Northeast.Repository;
 
 namespace Northeast.Services

--- a/Northeast/Utilities/SendEmail.cs
+++ b/Northeast/Utilities/SendEmail.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Northeast.Models;
 
-namespace Northast.Services
+namespace Northeast.Services
 {
     public class SendEmail
     {


### PR DESCRIPTION
## Summary
- correct `Northast.Services` namespace usage
- update `SendEmail` class namespace

## Testing
- `dotnet build -c Release` *(fails: AppDbContext missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b12b18d3c8327bffb1b11302c5d28