### PR TITLE
Add user login and registration pages

### DIFF
--- a/WT4Q/src/app/login/Login.module.css
+++ b/WT4Q/src/app/login/Login.module.css
@@ -1,0 +1,208 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;700&display=swap');
+
+/* Container: metal background + WT4Q logo watermark */
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--metal-base);
+  background-image:
+    url('/images/wt4q-logo.png'),
+    radial-gradient(circle at center, rgba(255,255,255,0.6), transparent 70%);
+  background-repeat: no-repeat;
+  background-position: center top 20px;
+  background-size: 300px auto;
+  padding: 1rem;
+}
+
+/* Card: deep bevel effect, no border to impede clicks */
+.card {
+  position: relative;
+  background: var(--metal-base);
+  border-radius: 24px;
+  padding: 3rem;
+  width: 100%;
+  max-width: 450px;
+  box-shadow:
+    inset 4px 4px 8px var(--metal-shadow),
+    inset -4px -4px 8px var(--metal-reflect),
+    0 8px 20px rgba(0,0,0,0.3);
+}
+
+/* Decorative gradient bevel overlay without blocking clicks */
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  border-radius: 24px;
+  background: linear-gradient(
+    135deg,
+    rgba(255,255,255,0.4) 0%,
+    rgba(0,0,0,0.2) 100%
+  );
+  pointer-events: none;
+}
+
+.title {
+  margin: 0 0 2rem;
+  font-size: 2.25rem;
+  font-weight: 700;
+  text-align: center;
+  background: linear-gradient(
+    90deg,
+    var(--wt4q-yellow) 0%,
+    var(--wt4q-red)    30%,
+    var(--wt4q-blue)   60%,
+    var(--wt4q-green)  100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+
+.error {
+  background: var(--error-red);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.label {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  color: var(--text-light);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* Input fields: strong 3D inset effect, full clickable, responsive */
+.input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 12px;
+  background: var(--metal-base);
+  color: var(--text-default);
+  box-shadow:
+    inset 5px 5px 8px var(--metal-shadow),
+    inset -5px -5px 8px var(--metal-reflect);
+  transition: box-shadow 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  box-shadow:
+    inset 5px 5px 8px var(--metal-shadow),
+    inset -5px -5px 8px var(--metal-reflect),
+    0 0 0 3px rgba(30,136,229,0.4);
+}
+
+.fieldError {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--error-red);
+}
+
+/* Password wrapper: responsive and positions toggle inside */
+.passwordWrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* Add right padding to input so button doesn’t overlap text */
+.passwordWrapper .input {
+  padding-right: 3rem;
+}
+
+/* Toggle button inside input */
+.toggleButton {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  color: var(--text-light);
+}
+
+.toggleButton:hover {
+  color: var(--text-default);
+}
+
+.toggleButton:focus {
+  outline: none;
+  color: var(--wt4q-blue);
+}
+
+.button {
+  padding: 0.9rem;
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
+  color: #fff;
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 6px 15px rgba(0,0,0,0.4);
+  transition: transform 0.1s, box-shadow 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 12px 25px rgba(0,0,0,0.45);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(1px);
+  box-shadow:
+    inset 2px 2px 4px var(--metal-shadow),
+    inset -2px -2px 4px var(--metal-reflect),
+    0 4px 8px rgba(0,0,0,0.3);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid rgba(255,255,255,0.6);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/WT4Q/src/app/login/page.tsx
+++ b/WT4Q/src/app/login/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+import { FC, useState, FormEvent, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import styles from './Login.module.css';
+import { API_ROUTES } from '@/lib/api';
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/;
+
+const Login: FC = () => {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const isLoading = isPending;
+
+  const validate = (): boolean => {
+    let valid = true;
+    if (!EMAIL_REGEX.test(email)) {
+      setEmailError('Please enter a valid email address');
+      valid = false;
+    } else {
+      setEmailError(null);
+    }
+    return valid;
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!validate()) return;
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(API_ROUTES.AUTH.LOGIN, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ email, password } as LoginRequest),
+        });
+        const data: { message?: string } = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.message || 'Login failed');
+        }
+
+        router.replace('/');
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('An unexpected error occurred');
+        }
+      }
+    });
+  };
+
+  const handleGoogleSignIn = () => {
+    window.location.href = API_ROUTES.GOOGLE_SIGN_IN.AUTH;
+  };
+
+  return (
+    <main className={styles.container}>
+      <section className={styles.card} aria-labelledby="user-login-title">
+        <h1 id="user-login-title" className={styles.title}>
+          User Login
+        </h1>
+        {error && (
+          <div role="alert" className={styles.error}>
+            {error}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className={styles.form} noValidate>
+          <div className={styles.field}>
+            <label htmlFor="email" className={styles.label}>
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="username"
+              autoFocus
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={styles.input}
+              aria-invalid={!!emailError}
+              aria-describedby={emailError ? 'email-error' : undefined}
+            />
+            {emailError && (
+              <p id="email-error" className={styles.fieldError} role="alert">
+                {emailError}
+              </p>
+            )}
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="password" className={styles.label}>
+              Password
+            </label>
+            <div className={styles.passwordWrapper}>
+              <input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className={styles.input}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className={styles.toggleButton}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? '🙈' : '👁️'}
+              </button>
+            </div>
+          </div>
+
+          <button type="submit" disabled={isLoading} className={styles.button}>
+            {isLoading ? (
+              <span className={styles.spinner} aria-hidden="true" />
+            ) : (
+              'Sign In'
+            )}
+          </button>
+        </form>
+        <button onClick={handleGoogleSignIn} className={styles.button}>
+          Sign in with Google
+        </button>
+      </section>
+    </main>
+  );
+};
+
+export default Login;

--- a/WT4Q/src/app/register/Register.module.css
+++ b/WT4Q/src/app/register/Register.module.css
@@ -1,0 +1,208 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;700&display=swap');
+
+/* Container: metal background + WT4Q logo watermark */
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--metal-base);
+  background-image:
+    url('/images/wt4q-logo.png'),
+    radial-gradient(circle at center, rgba(255,255,255,0.6), transparent 70%);
+  background-repeat: no-repeat;
+  background-position: center top 20px;
+  background-size: 300px auto;
+  padding: 1rem;
+}
+
+/* Card: deep bevel effect, no border to impede clicks */
+.card {
+  position: relative;
+  background: var(--metal-base);
+  border-radius: 24px;
+  padding: 3rem;
+  width: 100%;
+  max-width: 450px;
+  box-shadow:
+    inset 4px 4px 8px var(--metal-shadow),
+    inset -4px -4px 8px var(--metal-reflect),
+    0 8px 20px rgba(0,0,0,0.3);
+}
+
+/* Decorative gradient bevel overlay without blocking clicks */
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  border-radius: 24px;
+  background: linear-gradient(
+    135deg,
+    rgba(255,255,255,0.4) 0%,
+    rgba(0,0,0,0.2) 100%
+  );
+  pointer-events: none;
+}
+
+.title {
+  margin: 0 0 2rem;
+  font-size: 2.25rem;
+  font-weight: 700;
+  text-align: center;
+  background: linear-gradient(
+    90deg,
+    var(--wt4q-yellow) 0%,
+    var(--wt4q-red)    30%,
+    var(--wt4q-blue)   60%,
+    var(--wt4q-green)  100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+
+.error {
+  background: var(--error-red);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.label {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  color: var(--text-light);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* Input fields: strong 3D inset effect, full clickable, responsive */
+.input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 12px;
+  background: var(--metal-base);
+  color: var(--text-default);
+  box-shadow:
+    inset 5px 5px 8px var(--metal-shadow),
+    inset -5px -5px 8px var(--metal-reflect);
+  transition: box-shadow 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  box-shadow:
+    inset 5px 5px 8px var(--metal-shadow),
+    inset -5px -5px 8px var(--metal-reflect),
+    0 0 0 3px rgba(30,136,229,0.4);
+}
+
+.fieldError {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--error-red);
+}
+
+/* Password wrapper: responsive and positions toggle inside */
+.passwordWrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* Add right padding to input so button doesn’t overlap text */
+.passwordWrapper .input {
+  padding-right: 3rem;
+}
+
+/* Toggle button inside input */
+.toggleButton {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  color: var(--text-light);
+}
+
+.toggleButton:hover {
+  color: var(--text-default);
+}
+
+.toggleButton:focus {
+  outline: none;
+  color: var(--wt4q-blue);
+}
+
+.button {
+  padding: 0.9rem;
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
+  color: #fff;
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 6px 15px rgba(0,0,0,0.4);
+  transition: transform 0.1s, box-shadow 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 12px 25px rgba(0,0,0,0.45);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(1px);
+  box-shadow:
+    inset 2px 2px 4px var(--metal-shadow),
+    inset -2px -2px 4px var(--metal-reflect),
+    0 4px 8px rgba(0,0,0,0.3);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid rgba(255,255,255,0.6);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/WT4Q/src/app/register/page.tsx
+++ b/WT4Q/src/app/register/page.tsx
@@ -1,0 +1,208 @@
+'use client';
+import { FC, useState, FormEvent, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import styles from './Register.module.css';
+import { API_ROUTES } from '@/lib/api';
+
+interface RegisterRequest {
+  username: string;
+  email: string;
+  phoneNumber?: string;
+  password: string;
+  confirmPassword: string;
+  dob: string;
+}
+
+const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/;
+
+const Register: FC = () => {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [dob, setDob] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const isLoading = isPending;
+
+  const validate = (): boolean => {
+    let valid = true;
+    if (!EMAIL_REGEX.test(email)) {
+      setEmailError('Please enter a valid email address');
+      valid = false;
+    } else {
+      setEmailError(null);
+    }
+    return valid;
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!validate()) return;
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(API_ROUTES.AUTH.REGISTER, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            username,
+            email,
+            phoneNumber: phone || undefined,
+            password,
+            confirmPassword,
+            dob,
+          } as RegisterRequest),
+        });
+        const data: { message?: string; Error?: string } = await response.json();
+        if (!response.ok) {
+          throw new Error(data.message || data.Error || 'Registration failed');
+        }
+        router.replace('/');
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('An unexpected error occurred');
+        }
+      }
+    });
+  };
+
+  const handleGoogleSignIn = () => {
+    window.location.href = API_ROUTES.GOOGLE_SIGN_IN.AUTH;
+  };
+
+  return (
+    <main className={styles.container}>
+      <section className={styles.card} aria-labelledby="register-title">
+        <h1 id="register-title" className={styles.title}>
+          Register
+        </h1>
+        {error && (
+          <div role="alert" className={styles.error}>
+            {error}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className={styles.form} noValidate>
+          <div className={styles.field}>
+            <label htmlFor="username" className={styles.label}>
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              required
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="email" className={styles.label}>
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={styles.input}
+              aria-invalid={!!emailError}
+              aria-describedby={emailError ? 'email-error' : undefined}
+            />
+            {emailError && (
+              <p id="email-error" className={styles.fieldError} role="alert">
+                {emailError}
+              </p>
+            )}
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="phone" className={styles.label}>
+              Phone Number
+            </label>
+            <input
+              id="phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="dob" className={styles.label}>
+              Date of Birth
+            </label>
+            <input
+              id="dob"
+              type="date"
+              required
+              value={dob}
+              onChange={(e) => setDob(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="password" className={styles.label}>
+              Password
+            </label>
+            <div className={styles.passwordWrapper}>
+              <input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className={styles.input}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className={styles.toggleButton}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? '🙈' : '👁️'}
+              </button>
+            </div>
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="confirm-password" className={styles.label}>
+              Confirm Password
+            </label>
+            <input
+              id="confirm-password"
+              type={showPassword ? 'text' : 'password'}
+              autoComplete="new-password"
+              required
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <button type="submit" disabled={isLoading} className={styles.button}>
+            {isLoading ? (
+              <span className={styles.spinner} aria-hidden="true" />
+            ) : (
+              'Register'
+            )}
+          </button>
+        </form>
+        <button onClick={handleGoogleSignIn} className={styles.button}>
+          Sign in with Google
+        </button>
+      </section>
+    </main>
+  );
+};
+
+export default Register;


### PR DESCRIPTION
## Summary
- add Login and Register pages for users
- reuse AdminLogin CSS for consistent style
- allow Google sign-in from both forms

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b1934150483279898965ffadbfa64