### PR TITLE
Fix Admin login cookie for cross-origin access

### DIFF
--- a/WT4Q/src/app/admin-login/page.tsx
+++ b/WT4Q/src/app/admin-login/page.tsx
@@ -51,6 +51,7 @@ const AdminLogin: FC = () => {
         const response = await fetch(API_ROUTES.ADMIN_AUTH.LOGIN, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
           body: JSON.stringify({ email, password } as LoginRequest),
         });
         const data: { token?: string; message?: string } = await response.json();
@@ -58,9 +59,6 @@ const AdminLogin: FC = () => {
         if (!response.ok ) {
           throw new Error(data.message || 'Login failed');
         }
-
-        // Securely set cookie
-        document.cookie = `AdminToken=${data.token}; path=/; Secure; SameSite=Strict`;
 
         router.replace('/admin/dashboard');
       } catch (err) {


### PR DESCRIPTION
## Summary
- ensure admin login request stores cookie from the backend

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b555c36c8832794d3311f7b899e13