### PR TITLE
Add admin logout feature

### DIFF
--- a/Northeast/Controllers/AdminController.cs
+++ b/Northeast/Controllers/AdminController.cs
@@ -52,5 +52,21 @@ namespace Northeast.Controllers
 
         }
 
+        [HttpPost("Adminlogout")]
+        public IActionResult AdminLogout()
+        {
+            if (Request.Cookies.ContainsKey("AdminToken"))
+            {
+                Response.Cookies.Delete("AdminToken", new CookieOptions
+                {
+                    Secure = true,
+                    SameSite = SameSiteMode.None
+                });
+            }
+
+            return Ok(new { message = "logged out successfully" });
+
+        }
+
     }
 }

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -4,6 +4,7 @@ export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhos
 export const API_ROUTES = {
   ADMIN_AUTH: {
     LOGIN: `${API_BASE_URL}/api/Admin/Adminlogin`,
+    LOGOUT: `${API_BASE_URL}/api/Admin/Adminlogout`,
   },
 
   AUTH: {

--- a/WT4Q/src/app/admin/dashboard/dashboard.module.css
+++ b/WT4Q/src/app/admin/dashboard/dashboard.module.css
@@ -79,6 +79,38 @@
   cursor: not-allowed;
 }
 
+.logoutButton {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  align-self: flex-end;
+  background: linear-gradient(145deg, var(--error-red), #9b0000);
+  color: #fff;
+  border: none;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 6px 15px rgba(0, 0, 0, 0.4);
+  transition: transform 0.1s, box-shadow 0.2s;
+}
+
+.logoutButton:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 12px 25px rgba(0, 0, 0, 0.45);
+}
+
+.logoutButton:active {
+  transform: translateY(1px);
+  box-shadow:
+    inset 2px 2px 4px var(--metal-shadow),
+    inset -2px -2px 4px var(--metal-reflect),
+    0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
 .error {
   color: var(--error-red);
   font-weight: bold;

--- a/WT4Q/src/app/admin/dashboard/page.tsx
+++ b/WT4Q/src/app/admin/dashboard/page.tsx
@@ -23,6 +23,15 @@ export default function AdminDashboard() {
     }
   }, [router]);
 
+  const handleLogout = async () => {
+    await fetch(API_ROUTES.ADMIN_AUTH.LOGOUT, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    document.cookie = 'AdminToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    router.replace('/admin-login');
+  };
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
@@ -64,6 +73,9 @@ export default function AdminDashboard() {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Admin Dashboard</h1>
+      <button onClick={handleLogout} className={styles.logoutButton}>
+        Logout
+      </button>
       {error && <p className={styles.error}>{error}</p>}
       <form onSubmit={handleSubmit} className={styles.form}>
         <input


### PR DESCRIPTION
## Summary
- implement POST `Adminlogout` endpoint in backend
- expose `API_ROUTES.ADMIN_AUTH.LOGOUT`
- add logout button and function to admin dashboard
- style logout button

## Testing
- `npm run lint`
- `dotnet build` *(fails: AppDbContext missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b574099288327abcea03cef343114