### PR TITLE
Add EU cookie policy

### DIFF
--- a/TERMS_AND_COOKIE_POLICY.md
+++ b/TERMS_AND_COOKIE_POLICY.md
@@ -1,0 +1,25 @@
+# Terms and Conditions & Cookie Policy
+
+This document outlines the terms of use for the WT4Q application and describes how cookies are handled in accordance with EU Regulation RSPD. By using this service you agree to the following:
+
+## Terms of Use
+
+1. Content provided through WT4Q is for informational purposes only.
+2. You may not use the service for unlawful activities.
+3. WT4Q reserves the right to modify or discontinue the service at any time without notice.
+4. Use of this service is at your own risk; WT4Q is provided "as is" without warranties of any kind.
+
+## Cookie Policy
+
+WT4Q uses cookies to enhance the user experience. Cookies are small text files stored on your device. According to EU Regulation RSPD you have the right to know how cookies are used and to give or withdraw consent.
+
+### Types of Cookies We Use
+
+- **Essential Cookies** – Necessary for basic site functionality such as navigation and access to secure areas.
+- **Analytics Cookies** – Help us understand how the service is used so we can improve the experience.
+
+### Your Choices
+
+You can manage your cookie preferences through your web browser settings. You may delete existing cookies or block new ones, but some features of WT4Q may not function properly if you do so.
+
+For more details or requests related to your personal data under EU Regulation RSPD, please contact us at `privacy@wt4q.example.com`.

--- a/WT4Q/src/app/terms/page.module.css
+++ b/WT4Q/src/app/terms/page.module.css
@@ -1,0 +1,17 @@
+.container {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+  font-family: 'Times New Roman', serif;
+  line-height: 1.6;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+h2 {
+  margin-top: 1.5rem;
+  font-size: 1.5rem;
+}

--- a/WT4Q/src/app/terms/page.tsx
+++ b/WT4Q/src/app/terms/page.tsx
@@ -1,0 +1,29 @@
+import styles from './page.module.css';
+
+export const metadata = {
+  title: 'Terms & Cookie Policy',
+};
+
+export default function TermsPage() {
+  return (
+    <div className={styles.container}>
+      <h1>Terms and Conditions &amp; Cookie Policy</h1>
+      <p>
+        This page summarizes how WT4Q handles cookies and outlines the basic
+        terms of use. Cookies are used in accordance with EU Regulation RSPD.
+      </p>
+      <h2>Terms of Use</h2>
+      <ul>
+        <li>Content is provided for informational purposes only.</li>
+        <li>Do not use the service for unlawful activities.</li>
+        <li>WT4Q may modify or discontinue the service without notice.</li>
+        <li>Use the service at your own risk.</li>
+      </ul>
+      <h2>Cookie Policy</h2>
+      <p>
+        WT4Q stores essential and analytics cookies to operate and improve the
+        site. You may manage your cookie preferences in your browser settings.
+      </p>
+    </div>
+  );
+}

--- a/WT4Q/src/components/Footer.tsx
+++ b/WT4Q/src/components/Footer.tsx
@@ -1,10 +1,13 @@
+import Link from 'next/link';
 import styles from './Footer.module.css';
 
 export default function Footer() {
   return (
     <footer className={styles.footer}>
       <div className={styles.inner}>
-        &copy; {new Date().getFullYear()} WT4Q News
+        &copy; {new Date().getFullYear()} WT4Q News{' '}
+        <span aria-hidden="true">|</span>{' '}
+        <Link href="/terms">Terms &amp; Cookies</Link>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- add Terms and Conditions & Cookie Policy document
- create `/terms` page in Next.js frontend with terms text
- link to the new page in the footer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b58a499fc83278201d1320f8b215b