### PR TITLE
Improve docs on HTTPS cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ npm run dev
 
 This starts the Next.js development server on http://localhost:3000.
 
+Authentication cookies from the API are issued with the `Secure` and
+`SameSite=None` attributes (see
+`Northeast/Controllers/AdminController.cs`). Browsers will not send
+these cookies from an insecure (HTTP) page. For local development run
+the front end over HTTPS:
+
+```bash
+cd WT4Q/WT4Q
+HTTPS=true npm run dev
+```
+
+If your environment requires it, generate a local certificate and set
+the `SSL_CERT_FILE` and `SSL_KEY_FILE` environment variables as
+described in the Next.js documentation.
+
 ### Backend
 
 ```bash


### PR DESCRIPTION
## Summary
- add instructions for running Next.js dev server with HTTPS

## Testing
- `dotnet build Northeast/Northeast.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b59c9289083279f3f036f0065cf70