### PR TITLE
Add cookie consent banner and update policies

### DIFF
--- a/TERMS_AND_COOKIE_POLICY.md
+++ b/TERMS_AND_COOKIE_POLICY.md
@@ -1,17 +1,18 @@
 # Terms and Conditions & Cookie Policy
 
-This document outlines the terms of use for the WT4Q application and describes how cookies are handled in accordance with EU Regulation RSPD. By using this service you agree to the following:
+This document describes the terms of use for the WT4Q application and how we handle cookies in accordance with EU Regulation RSPD. By using this service you agree to these terms.
 
 ## Terms of Use
 
-1. Content provided through WT4Q is for informational purposes only.
-2. You may not use the service for unlawful activities.
-3. WT4Q reserves the right to modify or discontinue the service at any time without notice.
-4. Use of this service is at your own risk; WT4Q is provided "as is" without warranties of any kind.
+1. Content is provided for informational purposes only and may change without notice.
+2. You agree not to use the service for unlawful activities.
+3. WT4Q may modify or discontinue the service at any time without notice.
+4. The service is provided "as is" without warranties of any kind.
 
 ## Cookie Policy
 
 WT4Q uses cookies to enhance the user experience. Cookies are small text files stored on your device. According to EU Regulation RSPD you have the right to know how cookies are used and to give or withdraw consent.
+On your first visit a banner appears allowing you to accept, manage or refuse non-essential cookies.
 
 ### Types of Cookies We Use
 
@@ -20,6 +21,6 @@ WT4Q uses cookies to enhance the user experience. Cookies are small text files s
 
 ### Your Choices
 
-You can manage your cookie preferences through your web browser settings. You may delete existing cookies or block new ones, but some features of WT4Q may not function properly if you do so.
+You can use the on-site cookie banner to accept all cookies, refuse analytics cookies or manage your preferences. You may also use your web browser settings to delete or block cookies; however some features of WT4Q may not function properly if you do so.
 
 For more details or requests related to your personal data under EU Regulation RSPD, please contact us at `privacy@wt4q.example.com`.

--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import CookieBanner from "@/components/CookieBanner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
         <Header />
         <main>{children}</main>
         <Footer />
+        <CookieBanner />
       </body>
     </html>
   );

--- a/WT4Q/src/app/terms/page.module.css
+++ b/WT4Q/src/app/terms/page.module.css
@@ -6,12 +6,12 @@
   line-height: 1.6;
 }
 
-h1 {
+.title {
   font-size: 2rem;
   margin-bottom: 1rem;
 }
 
-h2 {
+.heading {
   margin-top: 1.5rem;
   font-size: 1.5rem;
 }

--- a/WT4Q/src/app/terms/page.tsx
+++ b/WT4Q/src/app/terms/page.tsx
@@ -7,22 +7,25 @@ export const metadata = {
 export default function TermsPage() {
   return (
     <div className={styles.container}>
-      <h1>Terms and Conditions &amp; Cookie Policy</h1>
+      <h1 className={styles.title}>Terms and Conditions &amp; Cookie Policy</h1>
       <p>
-        This page summarizes how WT4Q handles cookies and outlines the basic
-        terms of use. Cookies are used in accordance with EU Regulation RSPD.
+        By using WT4Q you agree to the following terms. These summaries are
+        provided for convenience and do not replace the full policy.
       </p>
-      <h2>Terms of Use</h2>
+      <h2 className={styles.heading}>Terms of Use</h2>
       <ul>
-        <li>Content is provided for informational purposes only.</li>
-        <li>Do not use the service for unlawful activities.</li>
+        <li>Content is for informational purposes only and may change.</li>
+        <li>You agree not to use the service for unlawful activities.</li>
         <li>WT4Q may modify or discontinue the service without notice.</li>
-        <li>Use the service at your own risk.</li>
+        <li>The service is provided &quot;as is&quot; without warranties.</li>
       </ul>
-      <h2>Cookie Policy</h2>
+      <h2 className={styles.heading}>Cookie Policy</h2>
       <p>
-        WT4Q stores essential and analytics cookies to operate and improve the
-        site. You may manage your cookie preferences in your browser settings.
+        WT4Q uses essential cookies for basic functionality and optional
+        analytics cookies to improve the site. On your first visit you can
+        accept, manage or refuse these cookies via the banner shown at the
+        bottom of the page. You can update your preference at any time by
+        clearing browser storage.
       </p>
     </div>
   );

--- a/WT4Q/src/components/CookieBanner.module.css
+++ b/WT4Q/src/components/CookieBanner.module.css
@@ -1,0 +1,31 @@
+.banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #f5f5f5;
+  border-top: 1px solid #ccc;
+  padding: 1rem;
+  font-size: 0.9rem;
+  z-index: 1000;
+}
+
+.message,
+.manage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.actions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.button {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid #555;
+  background: white;
+  cursor: pointer;
+}

--- a/WT4Q/src/components/CookieBanner.tsx
+++ b/WT4Q/src/components/CookieBanner.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useEffect, useState } from 'react';
+import styles from './CookieBanner.module.css';
+
+type CookiePrefs = {
+  analytics: boolean;
+};
+
+export default function CookieBanner() {
+  const [show, setShow] = useState(false);
+  const [manage, setManage] = useState(false);
+  const [prefs, setPrefs] = useState<CookiePrefs>({ analytics: true });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('cookiePrefs');
+    if (!stored) {
+      setShow(true);
+    } else {
+      try {
+        const parsed: CookiePrefs = JSON.parse(stored);
+        setPrefs(parsed);
+      } catch {
+        setShow(true);
+      }
+    }
+  }, []);
+
+  const savePrefs = (p: CookiePrefs) => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('cookiePrefs', JSON.stringify(p));
+    setShow(false);
+    setManage(false);
+  };
+
+  const accept = () => savePrefs({ analytics: true });
+  const refuse = () => savePrefs({ analytics: false });
+
+  if (!show) return null;
+
+  return (
+    <div className={styles.banner}>
+      {!manage ? (
+        <div className={styles.message}>
+          <p>
+            WT4Q uses cookies to personalize content and analyze traffic.
+          </p>
+          <div className={styles.actions}>
+            <button className={styles.button} onClick={accept}>Accept</button>
+            <button className={styles.button} onClick={() => setManage(true)}>Manage</button>
+            <button className={styles.button} onClick={refuse}>Refuse</button>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.manage}>
+          <label>
+            <input
+              type="checkbox"
+              checked={prefs.analytics}
+              onChange={(e) =>
+                setPrefs({ ...prefs, analytics: e.target.checked })
+              }
+            />
+            Allow analytics cookies
+          </label>
+          <div className={styles.actions}>
+            <button className={styles.button} onClick={() => savePrefs(prefs)}>Save</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a `CookieBanner` component to allow accepting, managing or refusing cookies
- include the banner in the app layout
- refine terms page styling and text
- update terms and cookie policy document

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b5b3b6f1083278b2b2e8f226c1842