### PR TITLE
Add user profile management and logout

### DIFF
--- a/Northeast/DTOs/DeleteAccountDTO.cs
+++ b/Northeast/DTOs/DeleteAccountDTO.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Northeast.DTOs
+{
+    public class DeleteAccountDTO
+    {
+        [Required]
+        public string Password { get; set; }
+    }
+}

--- a/Northeast/DTOs/UserUpdateDTO.cs
+++ b/Northeast/DTOs/UserUpdateDTO.cs
@@ -1,0 +1,9 @@
+namespace Northeast.DTOs
+{
+    public class UserUpdateDTO
+    {
+        public string? UserName { get; set; }
+        public string? PhoneNumber { get; set; }
+        public DateOnly? DOB { get; set; }
+    }
+}

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -9,11 +9,15 @@ export const API_ROUTES = {
   AUTH: {
     LOGIN: `${API_BASE_URL}/api/UserAuth/login`,
     REGISTER: `${API_BASE_URL}/api/UserRegistration`,
+    LOGOUT: `${API_BASE_URL}/api/UserAuth/logout`,
   },
 
   USERS: {
     GET_ALL: `${API_BASE_URL}/User`,
     GET_BY_EMAIL: (email: string) => `${API_BASE_URL}/User/${email}`,
+    ME: `${API_BASE_URL}/User/me`,
+    UPDATE: `${API_BASE_URL}/User`,
+    DELETE: `${API_BASE_URL}/User`,
   },
 
   ARTICLE: {

--- a/WT4Q/src/app/profile/Profile.module.css
+++ b/WT4Q/src/app/profile/Profile.module.css
@@ -1,0 +1,61 @@
+.form {
+  max-width: 500px;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  border: 2px solid transparent;
+  border-image: var(--metal-gradient) 1;
+  border-radius: 12px;
+}
+
+.title {
+  font-size: 1.5rem;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-weight: 700;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 600;
+}
+
+.input {
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--text-light);
+}
+
+.button {
+  padding: 0.75rem;
+  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.deleteSection {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.deleteButton {
+  background: var(--wt4q-red);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.message {
+  text-align: center;
+  margin-top: 2rem;
+}

--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+import { useEffect, useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import styles from './Profile.module.css';
+import { API_ROUTES } from '@/lib/api';
+
+interface User {
+  userName: string;
+  phone?: string;
+  dob?: string;
+}
+
+export default function Profile() {
+  const [user, setUser] = useState<User | null>(null);
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch(API_ROUTES.USERS.ME, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setUser(data))
+      .catch(() => setUser(null));
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    await fetch(API_ROUTES.USERS.UPDATE, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userName: user.userName,
+        phoneNumber: user.phone,
+        dob: user.dob,
+      }),
+    });
+    router.refresh();
+  };
+
+  const handleDelete = async () => {
+    if (!password) return;
+    if (!confirm('Delete account?')) return;
+    await fetch(API_ROUTES.USERS.DELETE, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+    router.replace('/');
+  };
+
+  if (!user) return <p className={styles.message}>Please log in</p>;
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <h1 className={styles.title}>Profile</h1>
+      <label className={styles.label}>
+        Name
+        <input
+          className={styles.input}
+          value={user.userName}
+          onChange={(e) => setUser({ ...user, userName: e.target.value })}
+        />
+      </label>
+      <label className={styles.label}>
+        Phone
+        <input
+          className={styles.input}
+          value={user.phone || ''}
+          onChange={(e) => setUser({ ...user, phone: e.target.value })}
+        />
+      </label>
+      <label className={styles.label}>
+        Date of birth
+        <input
+          type="date"
+          className={styles.input}
+          value={user.dob || ''}
+          onChange={(e) => setUser({ ...user, dob: e.target.value })}
+        />
+      </label>
+      <button type="submit" className={styles.button}>Save</button>
+      <div className={styles.deleteSection}>
+        <input
+          type="password"
+          placeholder="Password"
+          className={styles.input}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={handleDelete}
+          className={styles.deleteButton}
+        >
+          Delete account
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import CategoryNavbar from './CategoryNavbar';
 import SearchBar from './SearchBar';
+import UserMenu from './UserMenu';
 import styles from './Header.module.css';
 
 export default function Header() {
@@ -24,6 +25,7 @@ export default function Header() {
         <div className={styles.search}>
           <SearchBar />
         </div>
+        <UserMenu />
       </div>
       <div className={styles.categories}>
         <CategoryNavbar />

--- a/WT4Q/src/components/UserMenu.module.css
+++ b/WT4Q/src/components/UserMenu.module.css
@@ -1,0 +1,57 @@
+.wrapper {
+  position: relative;
+}
+
+.icon {
+  font-family: var(--font-geist-mono);
+  font-weight: 700;
+  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect);
+  cursor: pointer;
+}
+
+.loginLink {
+  font-weight: 600;
+  text-decoration: none;
+  border: 2px solid transparent;
+  border-image: var(--metal-gradient) 1;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+}
+
+.dropdown {
+  position: absolute;
+  top: 110%;
+  right: 0;
+  background: var(--background);
+  border: 2px solid transparent;
+  border-image: var(--metal-gradient) 1;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+  z-index: 10;
+}
+
+.item {
+  display: block;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}
+
+.item:hover {
+  background: var(--wt4q-yellow);
+  color: #000;
+}

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import styles from './UserMenu.module.css';
+import { API_ROUTES } from '@/lib/api';
+
+interface User {
+  id: string;
+  userName: string;
+  email: string;
+}
+
+export default function UserMenu() {
+  const [user, setUser] = useState<User | null>(null);
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch(API_ROUTES.USERS.ME, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setUser(data))
+      .catch(() => setUser(null));
+  }, []);
+
+  const initials = user?.userName
+    ? user.userName
+        .split(/\s+/)
+        .map((w) => w[0])
+        .join('')
+        .toUpperCase()
+    : '';
+
+  const handleLogout = async () => {
+    if (!confirm('Log out?')) return;
+    await fetch(API_ROUTES.AUTH.LOGOUT, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    router.refresh();
+  };
+
+  if (!user) {
+    return (
+      <Link href="/login" className={styles.loginLink}>
+        Login
+      </Link>
+    );
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className={styles.icon}
+        aria-label="User menu"
+      >
+        {initials}
+      </button>
+      {open && (
+        <div className={styles.dropdown}>
+          <Link href="/profile" className={styles.item} onClick={() => setOpen(false)}>
+            Profile
+          </Link>
+          <button onClick={handleLogout} className={styles.item}>
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose new DTOs for user updates and deletion
- extend `UserController` with profile, update, delete endpoints
- add logout endpoint in `UserAuthController`
- update API routes for profile and logout
- show user menu in header with glossy initials and logout option
- allow editing and deleting user profile in new page

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `dotnet build Northeast/Northeast.csproj` *(fails: AppDbContext missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b587f68f88327baa89b1b2229fb79