### PR TITLE
Update CORS origins

### DIFF
--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -111,7 +111,7 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy(originsPolicy, policy =>
     {
-        policy.WithOrigins("https://localhost:7122","http://localhost:3000", "http://localhost:3001")
+        policy.WithOrigins("https://localhost:7122", "http://localhost:3000", "http://localhost:3001", "https://localhost:3001")
               .AllowAnyMethod()
               .AllowAnyHeader()
               .AllowCredentials();


### PR DESCRIPTION
## Summary
- add `https://localhost:3001` to CORS origins list for local HTTPS dev

## Testing
- `dotnet restore`
- `dotnet build` *(fails: AppDbContext not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9059fe048327b847f7c88f855235