### PR TITLE
Fix duplicate using directive

### DIFF
--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -9,7 +9,6 @@ using Northeast.Data;
 using Northeast.Interface;
 using Northeast.Middlewares;
 using Northeast.Repository;
-using Northeast.Services;
 using Northeast.Utilities;
 using System.Security.Claims;
 using System.Text;


### PR DESCRIPTION
## Summary
- remove duplicated `using Northeast.Services` in Program.cs

## Testing
- `dotnet build Northeast/Northeast.sln -c Release` *(fails: `Northeast.Data` namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b905cf8708327a0accd31cfe48c87