### PR TITLE
Fix HTTPS requirement for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,15 @@ npm install
 npm run dev
 ```
 
-This starts the Next.js development server on http://localhost:3000.
+This starts the Next.js development server on https://localhost:3000.
 
 Authentication cookies from the API are issued with the `Secure` and
 `SameSite=None` attributes (see
 `Northeast/Controllers/AdminController.cs`). Browsers will not send
-these cookies from an insecure (HTTP) page. For local development run
-the front end over HTTPS:
-
-```bash
-cd WT4Q/WT4Q
-HTTPS=true npm run dev
-```
+these cookies from an insecure (HTTP) page. If you start the front end
+over plain HTTP, the authentication cookies will be rejected and you'll
+be redirected back to the login page. Always run the development server
+over HTTPS to avoid this issue.
 
 If your environment requires it, generate a local certificate and set
 the `SSL_CERT_FILE` and `SSL_KEY_FILE` environment variables as

--- a/WT4Q/package.json
+++ b/WT4Q/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "HTTPS=true next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- ensure the Next.js dev server always runs with HTTPS
- clarify instructions about HTTPS in README

## Testing
- `npm run lint`
- `dotnet build` *(fails: The type or namespace name 'Data' does not exist in the namespace 'Northeast')*

------
https://chatgpt.com/codex/tasks/task_e_687b93286e3c8327b7dbc89b650d1794