### PR TITLE
Fix default challenge scheme to prevent Google redirect

### DIFF
--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -47,10 +47,11 @@ builder.Services.AddScoped<VisitorsRepository>();
 // --- Configure Authentication ---
 builder.Services.AddAuthentication(options =>
 {
-    // Default to Cookies, but Challenge with Google
+    // Default to JWT for API requests and use cookies to persist tokens.
+    // Avoid redirecting API calls to Google when not authenticated.
     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
     options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
 })
 .AddCookie(options =>
 {


### PR DESCRIPTION
## Summary
- avoid redirecting API calls to Google during auth failures

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687baa6d53108327b9baefa0320a88f7