### PR TITLE
Fix missing Secure attribute on AdminToken cookie

### DIFF
--- a/Northeast/Controllers/AdminController.cs
+++ b/Northeast/Controllers/AdminController.cs
@@ -43,7 +43,7 @@ namespace Northeast.Controllers
             var cookieOptions = new CookieOptions
             {
                 HttpOnly = true, // Prevents JavaScript access
-                Secure = !_env.IsDevelopment(),   // Use secure cookies only in production
+                Secure = true,   // Required when SameSite=None
                 SameSite = SameSiteMode.None, // allows cross-site cookies; use Strict/Lax to mitigate CSRF
                 Expires = DateTime.UtcNow.AddMinutes(Convert.ToInt32(_configuration["Jwt:ExpireMinutes"]))
             };
@@ -61,7 +61,7 @@ namespace Northeast.Controllers
             {
                 Response.Cookies.Delete("AdminToken", new CookieOptions
                 {
-                    Secure = !_env.IsDevelopment(),
+                    Secure = true,
                     SameSite = SameSiteMode.None
                 });
             }

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -148,9 +148,7 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
 app.UseCookiePolicy(new CookiePolicyOptions
 {
     MinimumSameSitePolicy = SameSiteMode.None,
-    Secure = builder.Environment.IsDevelopment()
-        ? CookieSecurePolicy.None
-        : CookieSecurePolicy.Always
+    Secure = CookieSecurePolicy.Always
 });
 
 app.UseHttpsRedirection();

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ This starts the Next.js development server on https://localhost:3000.
 
 Authentication cookies from the API are issued with the `Secure` and
 `SameSite=None` attributes (see
-`Northeast/Controllers/AdminController.cs`). Browsers will not send
-these cookies from an insecure (HTTP) page. If you start the front end
-over plain HTTP, the authentication cookies will be rejected and you'll
-be redirected back to the login page. Always run the development server
-over HTTPS to avoid this issue.
+`Northeast/Controllers/AdminController.cs`). Browsers require the
+`Secure` flag whenever `SameSite=None` is used, so the front end **must**
+be served over HTTPS. If you start the front end over plain HTTP, these
+cookies will be rejected and you'll be redirected back to the login
+page. Always run the development server over HTTPS to avoid this issue.
 
 If your environment requires it, generate a local certificate and set
 the `SSL_CERT_FILE` and `SSL_KEY_FILE` environment variables as


### PR DESCRIPTION
## Summary
- set `Secure` attribute on AdminToken cookie in all environments
- enforce cookie policy to always require `Secure`
- clarify HTTPS requirement in the README

## Testing
- `npm run lint`
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bdef7d7e48327a9aca7d44fc29d8a