### PR TITLE
Fix npm dev script for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ npm install
 npm run dev
 ```
 
+This project uses `cross-env` to set the `HTTPS` environment variable so the
+development server runs correctly on all platforms, including Windows.
+
 This starts the Next.js development server on https://localhost:3000.
 
 Authentication cookies from the API are issued with the `Secure` and

--- a/WT4Q/README.md
+++ b/WT4Q/README.md
@@ -14,6 +14,9 @@ pnpm dev
 bun dev
 ```
 
+`npm run dev` relies on `cross-env` to set the `HTTPS` environment variable so
+the development server works on Windows and Unix-based systems alike.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/WT4Q/package-lock.json
+++ b/WT4Q/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "cross-env": "^7.0.3",
         "eslint": "^9",
         "eslint-config-next": "15.3.4",
         "typescript": "^5"
@@ -2010,6 +2011,25 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/WT4Q/package.json
+++ b/WT4Q/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "HTTPS=true next dev --turbopack",
+    "dev": "cross-env HTTPS=true next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -18,6 +18,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "cross-env": "^7.0.3",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- install `cross-env`
- call `cross-env` from the `dev` script so it works on Windows
- document the new behavior in both READMEs

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687be729718c8327a7e59b9918807ad7