### PR TITLE
Set CreatedDate to UTC now

### DIFF
--- a/Northeast/DTOs/ArticleDto.cs
+++ b/Northeast/DTOs/ArticleDto.cs
@@ -15,7 +15,7 @@ namespace Northeast.DTOs
         public ArticleType ArticleType { get; set; }
 
         [Required]
-        public DateTime CreatedDate { get; set; }
+        public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
 
         [Required]
         public string Description { get; set; }

--- a/Northeast/Models/Article.cs
+++ b/Northeast/Models/Article.cs
@@ -20,7 +20,7 @@ namespace Northeast.Models
         [Required]
         public string Title { get; set; }
         [Required]
-        public DateTime CreatedDate { get; set; }
+        public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
         [Required]
         public string Description { get; set; }
        

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -38,7 +38,7 @@ namespace Northeast.Services
                 AuthorId = userId,
                 Title = articleDto.Title,
                 Category= articleDto.Category,
-                CreatedDate = articleDto.CreatedDate,
+                CreatedDate = DateTime.UtcNow,
                 ArticleType= articleDto.ArticleType,
                 Description= articleDto.Description,
                 Photo = articleDto.Photo ?? null,
@@ -120,7 +120,6 @@ namespace Northeast.Services
             article.Category = articleDto.Category;
             article.ArticleType = articleDto.ArticleType;
             article.Description = articleDto.Description;
-            article.CreatedDate = articleDto.CreatedDate;
             article.Photo = articleDto.Photo;
             article.PhotoLink = articleDto.PhotoLink;
             article.EmbededCode = articleDto.EmbededCode;

--- a/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
+++ b/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
@@ -15,7 +15,6 @@ export default function DashboardClient() {
   const [type, setType] = useState('');
   const [category, setCategory] = useState('');
   const [keywords, setKeywords] = useState('');
-  const [createdDate, setCreatedDate] = useState('');
   const [photos, setPhotos] = useState<FileList | null>(null);
   const [photoLink, setPhotoLink] = useState('');
   const [embededCode, setEmbededCode] = useState('');
@@ -62,9 +61,7 @@ export default function DashboardClient() {
           title,
           category: category ? CATEGORIES.indexOf(category) + 1 : 0,
           articleType: type ? ARTICLE_TYPES.indexOf(type) : 0,
-          createdDate: createdDate
-            ? new Date(createdDate).toISOString()
-            : new Date().toISOString(),
+          createdDate: new Date().toISOString(),
           description,
           photo: photosBase64,
           photoLink: photoLink || undefined,
@@ -92,7 +89,6 @@ export default function DashboardClient() {
         setType('');
         setCategory('');
         setKeywords('');
-        setCreatedDate('');
         setPhotos(null);
         setPhotoLink('');
         setEmbededCode('');
@@ -121,12 +117,6 @@ export default function DashboardClient() {
           onChange={(e) => setTitle(e.target.value)}
           className={styles.input}
           required
-        />
-        <input
-          type="datetime-local"
-          value={createdDate}
-          onChange={(e) => setCreatedDate(e.target.value)}
-          className={styles.input}
         />
         <textarea
           placeholder="Description"

--- a/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
@@ -92,9 +92,7 @@ export default function EditArticleClient({ id }: { id: string }) {
           title,
           category: category ? CATEGORIES.indexOf(category) + 1 : 0,
           articleType: type ? ARTICLE_TYPES.indexOf(type) : 0,
-          createdDate: createdDate
-            ? new Date(createdDate).toISOString()
-            : new Date().toISOString(),
+          createdDate: new Date(createdDate).toISOString(),
           description,
           photo: photosBase64,
           photoLink: photoLink || undefined,
@@ -142,7 +140,7 @@ export default function EditArticleClient({ id }: { id: string }) {
         <input
           type="datetime-local"
           value={createdDate}
-          onChange={(e) => setCreatedDate(e.target.value)}
+          readOnly
           className={styles.input}
         />
         <textarea


### PR DESCRIPTION
## Summary
- default CreatedDate to `DateTime.UtcNow` in models and DTOs
- record UTC time when publishing articles on the backend
- keep existing CreatedDate when editing articles
- drop CreatedDate field from dashboard form
- show non-editable CreatedDate in edit form

## Testing
- `npm run lint`
- `npm run build`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e759a36988327ae1842cd4218b7e4