### PR TITLE
Improve nav and user sign-in UI

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -5,6 +5,9 @@ import styles from './CategoryNavbar.module.css';
 export default function CategoryNavbar() {
   return (
     <nav className={styles.nav} aria-label="categories">
+      <Link href="/" className={styles.link}>
+        Home
+      </Link>
       {CATEGORIES.map((c) => (
         <Link key={c} href={`/category/${c}`} className={styles.link}>
           {c}

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -24,30 +24,11 @@
 }
 
 .logoImage {
-  width: 60px;
-  height: 60px;
+  height: 3rem;
+  width: auto;
   border-radius: 50%;
 }
 
-.nav {
-  display: flex;
-  gap: 1rem;
-}
-
-.navLink {
-  color: #ffffff;
-  text-decoration: none;
-  font-weight: 500;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  border: 2px solid transparent;
-  transition: background 0.2s, transform 0.2s;
-}
-
-.navLink:hover {
-  background: var(--secondary);
-  transform: translateY(-2px);
-}
 
 .categories {
   max-width: 960px;

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -13,15 +13,13 @@ export default function Header() {
           <Image
             src="/images/wt4q-logo.png"
             alt="WT4Q logo"
-            width={60}
-            height={60}
+            width={0}
+            height={0}
+            sizes="3rem"
             className={styles.logoImage}
             priority
           />
         </Link>
-        <nav className={styles.nav}>
-          <Link href="/" className={styles.navLink}>Home</Link>
-        </nav>
         <div className={styles.search}>
           <SearchBar />
         </div>

--- a/WT4Q/src/components/UserMenu.module.css
+++ b/WT4Q/src/components/UserMenu.module.css
@@ -16,6 +16,9 @@
 }
 
 .loginLink {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
   font-weight: 600;
   text-decoration: none;
   padding: 0.25rem 0.75rem;

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -44,7 +44,20 @@ export default function UserMenu() {
   if (!user) {
     return (
       <Link href="/login" className={styles.loginLink}>
-        Login
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width="20"
+          height="20"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            fill="currentColor"
+            d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"
+          />
+        </svg>
+        <span>Sign In</span>
       </Link>
     );
   }


### PR DESCRIPTION
## Summary
- move Home link into `CategoryNavbar`
- remove unused nav element in `Header`
- scale logo responsively
- show user icon and `Sign In` when logged out
- update sign-in styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f757c0cd883279a0c92a32d5aeaa6