### PR TITLE
Align frontend categories with backend enum

### DIFF
--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -1,9 +1,10 @@
 export const CATEGORIES = [
-  'StockMarket',
+  'News',
+  'Articles',
   'Politics',
   'Crime',
-  'Celebrities',
+  'Enetrtainment',
   'Business',
-  'Space',
+  'Technology',
   'Adult',
 ];


### PR DESCRIPTION
## Summary
- sync categories list with the enum used on the backend

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f88d32da0832783291c90ce83adb0