### PR TITLE
Fix user login cookie

### DIFF
--- a/Northeast/Controllers/UserAuthController.cs
+++ b/Northeast/Controllers/UserAuthController.cs
@@ -61,8 +61,8 @@ namespace Northeast.Controllers
                 var cookieOptions = new CookieOptions
                 {
                     HttpOnly = true, // Prevents JavaScript access
-                    Secure = true,   // Ensures the cookie is sent only over HTTPS
-                    SameSite = SameSiteMode.Strict, // Prevents CSRF attacks
+                    Secure = true,   // Required when SameSite=None
+                    SameSite = SameSiteMode.None, // allows cross-site cookies; use Strict/Lax to mitigate CSRF
                     Expires = DateTime.UtcNow.AddMinutes(Convert.ToInt32(_configuration["Jwt:ExpireMinutes"]))
                 };
 


### PR DESCRIPTION
## Summary
- allow user auth cookie in `UserAuthController` to be sent cross-site

## Testing
- `npm run lint`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_687fc6b1ef8c8327ac0a4e9d060a4e33