### PR TITLE
Add login/register navigation links

### DIFF
--- a/WT4Q/src/app/login/Login.module.css
+++ b/WT4Q/src/app/login/Login.module.css
@@ -206,3 +206,18 @@
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+.switch {
+  margin-top: 1rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.switchLink {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.switchLink:hover {
+  text-decoration: underline;
+}

--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import styles from './Login.module.css';
 import { API_ROUTES } from '@/lib/api';
 
@@ -138,6 +139,12 @@ const LoginClient: FC = () => {
         <button onClick={handleGoogleSignIn} className={styles.button}>
           Sign in with Google
         </button>
+        <p className={styles.switch}>
+          Don&apos;t have an account?{' '}
+          <Link href="/register" className={styles.switchLink}>
+            Register
+          </Link>
+        </p>
       </section>
     </main>
   );

--- a/WT4Q/src/app/register/Register.module.css
+++ b/WT4Q/src/app/register/Register.module.css
@@ -206,3 +206,18 @@
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+.switch {
+  margin-top: 1rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.switchLink {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.switchLink:hover {
+  text-decoration: underline;
+}

--- a/WT4Q/src/app/register/page.tsx
+++ b/WT4Q/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import styles from './Register.module.css';
 import { API_ROUTES } from '@/lib/api';
 
@@ -200,6 +201,12 @@ const Register: FC = () => {
         <button onClick={handleGoogleSignIn} className={styles.button}>
           Sign in with Google
         </button>
+        <p className={styles.switch}>
+          Already have an account?{' '}
+          <Link href="/login" className={styles.switchLink}>
+            Sign In
+          </Link>
+        </p>
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- add registration link below sign in form
- add sign in link below registration form
- style new navigation links

## Testing
- `npm run lint`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdf00d6848327acc63827eb193453