### PR TITLE
Enable Google sign-in redirects

### DIFF
--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -65,7 +65,8 @@ const LoginClient: FC = () => {
   };
 
   const handleGoogleSignIn = () => {
-    window.location.href = API_ROUTES.GOOGLE_SIGN_IN.AUTH;
+    const returnUrl = window.location.origin;
+    window.location.href = `${API_ROUTES.GOOGLE_SIGN_IN.AUTH}?returnUrl=${encodeURIComponent(returnUrl)}`;
   };
 
   return (

--- a/WT4Q/src/app/register/page.tsx
+++ b/WT4Q/src/app/register/page.tsx
@@ -78,7 +78,8 @@ const Register: FC = () => {
   };
 
   const handleGoogleSignIn = () => {
-    window.location.href = API_ROUTES.GOOGLE_SIGN_IN.AUTH;
+    const returnUrl = window.location.origin;
+    window.location.href = `${API_ROUTES.GOOGLE_SIGN_IN.AUTH}?returnUrl=${encodeURIComponent(returnUrl)}`;
   };
 
   return (


### PR DESCRIPTION
## Summary
- allow returning a URL for the Google login endpoint
- redirect to the provided URL after successful Google auth
- include `returnUrl` when starting Google sign-in from login and register pages

## Testing
- `npm run build`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_687fe8d08c9c8327b1c2103bcd3a2ca0