### PR TITLE
Add admin article list and cocktail link

### DIFF
--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -5,6 +5,7 @@ export const API_ROUTES = {
   ADMIN_AUTH: {
     LOGIN: `${API_BASE_URL}/api/Admin/Adminlogin`,
     LOGOUT: `${API_BASE_URL}/api/Admin/Adminlogout`,
+    ME: `${API_BASE_URL}/api/Admin/me`,
   },
 
   AUTH: {
@@ -36,6 +37,7 @@ export const API_ROUTES = {
     LIKE: `${API_BASE_URL}/api/Article/Like`,
     COMMENT: `${API_BASE_URL}/api/Article/Comment`,
     MODIFY_COMMENT: `${API_BASE_URL}/api/Article/ModifyComment`,
+    SEARCH_BY_AUTHOR: (id: string) => `${API_BASE_URL}/api/ArticleSearch/by-author/${id}`,
   },
 
   COCKTAIL: {

--- a/WT4Q/src/app/admin/dashboard/dashboard.module.css
+++ b/WT4Q/src/app/admin/dashboard/dashboard.module.css
@@ -108,3 +108,26 @@
   font-weight: bold;
   text-align: center;
 }
+
+.subtitle {
+  margin-top: 2rem;
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+}
+
+.articleItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--muted);
+}
+
+.articleActions button {
+  margin-left: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- show admin details endpoint on backend
- expose admin info and article search by author to frontend API client
- list admin-authored articles on the dashboard with edit/delete options
- add link from dashboard to cocktail upload

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68820cb0c78c832792cbb0581faf77d2