### PR TITLE
Add weather widget using visitor location

### DIFF
--- a/Northeast/Controllers/UserLocController.cs
+++ b/Northeast/Controllers/UserLocController.cs
@@ -41,4 +41,4 @@ public class UserLocationController : ControllerBase
             return BadRequest($"Error retrieving location: {ex.Message}");
         }
     }
-}
+

--- a/Northeast/Controllers/WeatherController.cs
+++ b/Northeast/Controllers/WeatherController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using Northeast.Services;
+using System.Text.Json;
+
+namespace Northeast.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class WeatherController : ControllerBase
+    {
+        private readonly SiteVisitorServices _siteVisitorServices;
+        private readonly HttpClient _httpClient;
+
+        public WeatherController(SiteVisitorServices siteVisitorServices, HttpClient httpClient)
+        {
+            _siteVisitorServices = siteVisitorServices;
+            _httpClient = httpClient;
+        }
+
+        [HttpGet("current")]
+        public async Task<IActionResult> GetCurrent()
+        {
+            var visitor = await _siteVisitorServices.VisitorLog();
+            if (visitor == null || string.IsNullOrEmpty(visitor.Location))
+            {
+                return BadRequest(new { message = "Unable to determine location." });
+            }
+
+            var parts = visitor.Location.Split(',');
+            if (parts.Length != 2 ||
+                !double.TryParse(parts[0], out var lat) ||
+                !double.TryParse(parts[1], out var lon))
+            {
+                return BadRequest(new { message = "Invalid location." });
+            }
+
+            var url = $"https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}&current_weather=true";
+            var json = await _httpClient.GetStringAsync(url);
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("current_weather", out var current))
+            {
+                return BadRequest(new { message = "Weather data unavailable" });
+            }
+
+            var result = new
+            {
+                temperature = current.GetProperty("temperature").GetDecimal(),
+                weathercode = current.GetProperty("weathercode").GetInt32()
+            };
+
+            return Ok(result);
+        }
+    }
+}
+

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -66,4 +66,8 @@ export const API_ROUTES = {
   USER_LOCATION: {
     GET: `${API_BASE_URL}/api/UserLocation/get-location`,
   },
+
+  WEATHER: {
+    CURRENT: `${API_BASE_URL}/api/Weather/current`,
+  },
 };

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -1,5 +1,6 @@
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import Hero from '@/components/Hero';
+import WeatherWidget from '@/components/WeatherWidget';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
 import styles from './page.module.css';
@@ -27,6 +28,7 @@ export default async function Home() {
   return (
     <>
       <Hero />
+      <WeatherWidget />
       {categoriesWithArticles.map(({ category, articles }) => (
         <section key={category} className={styles.section}>
           <h2 className={styles.heading}>{category}</h2>

--- a/WT4Q/src/components/WeatherIcon.tsx
+++ b/WT4Q/src/components/WeatherIcon.tsx
@@ -1,0 +1,116 @@
+interface Props {
+  code: number;
+  className?: string;
+}
+
+function Sun({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="5" fill="currentColor" />
+      <g stroke="currentColor" strokeWidth="2">
+        <line x1="12" y1="1" x2="12" y2="3" />
+        <line x1="12" y1="21" x2="12" y2="23" />
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+        <line x1="1" y1="12" x2="3" y2="12" />
+        <line x1="21" y1="12" x2="23" y2="12" />
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+      </g>
+    </svg>
+  );
+}
+
+function Cloud({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M19 18H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 18z"
+      />
+    </svg>
+  );
+}
+
+function Rain({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M19 17H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 17z"
+      />
+      <line x1="8" y1="20" x2="8" y2="22" stroke="currentColor" strokeWidth="2" />
+      <line x1="12" y1="20" x2="12" y2="22" stroke="currentColor" strokeWidth="2" />
+      <line x1="16" y1="20" x2="16" y2="22" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function Snow({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M19 16H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 16z"
+      />
+      <g fill="currentColor">
+        <circle cx="8" cy="20" r="1" />
+        <circle cx="12" cy="20" r="1" />
+        <circle cx="16" cy="20" r="1" />
+      </g>
+    </svg>
+  );
+}
+
+function Storm({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M19 16H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 16z"
+      />
+      <polyline
+        points="13 16 11 22 15 22 13 28"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+export default function WeatherIcon({ code, className }: Props) {
+  if (code === 0) return <Sun className={className} />;
+  if (code >= 1 && code <= 3) return <Cloud className={className} />;
+  if ((code >= 45 && code <= 48) || (code >= 51 && code <= 67))
+    return <Rain className={className} />;
+  if ((code >= 71 && code <= 86)) return <Snow className={className} />;
+  if (code >= 95) return <Storm className={className} />;
+  return <Cloud className={className} />;
+}
+

--- a/WT4Q/src/components/WeatherWidget.module.css
+++ b/WT4Q/src/components/WeatherWidget.module.css
@@ -1,0 +1,15 @@
+.weather {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  font-family: 'Inter', sans-serif;
+}
+
+.icon {
+  width: 24px;
+  height: 24px;
+  color: var(--primary);
+}
+

--- a/WT4Q/src/components/WeatherWidget.tsx
+++ b/WT4Q/src/components/WeatherWidget.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useEffect, useState } from 'react';
+import WeatherIcon from './WeatherIcon';
+import styles from './WeatherWidget.module.css';
+import { API_ROUTES } from '@/lib/api';
+
+interface Weather {
+  temperature: number;
+  weathercode: number;
+}
+
+export default function WeatherWidget() {
+  const [weather, setWeather] = useState<Weather | null>(null);
+
+  useEffect(() => {
+    fetch(API_ROUTES.WEATHER.CURRENT)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) setWeather(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  if (!weather) return null;
+
+  return (
+    <div className={styles.weather} aria-label="Current weather">
+      <WeatherIcon code={weather.weathercode} className={styles.icon} />
+      <span>{Math.round(weather.temperature)}&deg;C</span>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- track weather on the backend using Open‑Meteo
- expose new `/api/Weather/current` endpoint
- show weather on the home page with SVG icons
- update API routes constants
- clean up UserLocation controller

## Testing
- `npm run lint`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68820de73eb88327b3c97c07a11f218e