### PR TITLE
Enable automatic migrations

### DIFF
--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.EntityFrameworkCore;
 using Northeast.Services;
 using Northeast.Data;
 using Northeast.Interface;
@@ -129,6 +130,13 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 });
 
 var app = builder.Build();
+
+// Apply any pending migrations at startup
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    context.Database.Migrate();
+}
 
 // --- Middleware Pipeline ---
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- enable EF Core migrations at startup

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688221983d548327b648d4dafbac84c6