### PR TITLE
Move weather widget to header

### DIFF
--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -1,6 +1,5 @@
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import Hero from '@/components/Hero';
-import WeatherWidget from '@/components/WeatherWidget';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
 import styles from './page.module.css';
@@ -28,7 +27,6 @@ export default async function Home() {
   return (
     <>
       <Hero />
-      <WeatherWidget />
       {categoriesWithArticles.map(({ category, articles }) => (
         <section key={category} className={styles.section}>
           <h2 className={styles.heading}>{category}</h2>

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import CategoryNavbar from './CategoryNavbar';
 import SearchBar from './SearchBar';
 import UserMenu from './UserMenu';
+import WeatherWidget from './WeatherWidget';
 import styles from './Header.module.css';
 
 export default function Header() {
@@ -23,6 +24,7 @@ export default function Header() {
         <div className={styles.search}>
           <SearchBar />
         </div>
+        <WeatherWidget />
         <UserMenu />
       </div>
       <div className={styles.categories}>

--- a/WT4Q/src/components/WeatherWidget.module.css
+++ b/WT4Q/src/components/WeatherWidget.module.css
@@ -1,15 +1,17 @@
 .weather {
   display: flex;
-  justify-content: center;
   align-items: center;
-  gap: 0.5rem;
-  padding: 1rem;
+  gap: 0.25rem;
   font-family: 'Inter', sans-serif;
 }
 
 .icon {
   width: 24px;
   height: 24px;
-  color: var(--primary);
+  color: currentColor;
+}
+
+.location {
+  font-size: 0.875rem;
 }
 

--- a/WT4Q/src/components/WeatherWidget.tsx
+++ b/WT4Q/src/components/WeatherWidget.tsx
@@ -9,14 +9,29 @@ interface Weather {
   weathercode: number;
 }
 
+interface Location {
+  city: string;
+  country: string;
+}
+
 export default function WeatherWidget() {
   const [weather, setWeather] = useState<Weather | null>(null);
+  const [location, setLocation] = useState<Location | null>(null);
 
   useEffect(() => {
     fetch(API_ROUTES.WEATHER.CURRENT)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data) setWeather(data);
+      })
+      .catch(() => {});
+
+    fetch(API_ROUTES.USER_LOCATION.GET)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && data.city && data.country) {
+          setLocation({ city: data.city, country: data.country });
+        }
       })
       .catch(() => {});
   }, []);
@@ -27,6 +42,11 @@ export default function WeatherWidget() {
     <div className={styles.weather} aria-label="Current weather">
       <WeatherIcon code={weather.weathercode} className={styles.icon} />
       <span>{Math.round(weather.temperature)}&deg;C</span>
+      {location && (
+        <span className={styles.location}>
+          {location.city}, {location.country}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show weather widget in the site header
- display user city and country with the weather

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6882248310488327a0e31f3010f7baf1