### PR TITLE
Improve SEO with metadata and sitemap

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import CommentsSection, { Comment } from '@/components/CommentsSection';
 import LikeButton from '@/components/LikeButton';
 import { API_ROUTES } from '@/lib/api';
+import type { Metadata } from 'next';
 import styles from '../article.module.css';
 
 interface ArticleDetails {
@@ -38,6 +39,28 @@ async function fetchRelated(id: string): Promise<Article[]> {
   } catch {
     return [];
   }
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params;
+  const article = await fetchArticle(id);
+  if (!article) return {};
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const url = `${siteUrl}/articles/${id}`;
+  const description = article.description.slice(0, 160);
+  const image = article.photoLink || (article.photo && article.photo.length > 0 ? `data:image/jpeg;base64,${article.photo[0]}` : undefined);
+  return {
+    title: article.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: article.title,
+      description,
+      url,
+      type: 'article',
+      images: image ? [{ url: image }] : undefined,
+    },
+  };
 }
 
 

--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -1,6 +1,7 @@
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import AgeGate from '@/components/AgeGate';
 import { API_ROUTES } from '@/lib/api';
+import type { Metadata } from 'next';
 import styles from '../category.module.css';
 
 async function fetchArticles(cat: string): Promise<Article[]> {
@@ -14,6 +15,22 @@ async function fetchArticles(cat: string): Promise<Article[]> {
   } catch {
     return [];
   }
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ category: string }> }): Promise<Metadata> {
+  const { category } = await params;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const url = `${siteUrl}/category/${encodeURIComponent(category)}`;
+  const title = `${category} - WT4Q`;
+  return {
+    title,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      url,
+      type: 'website',
+    },
+  };
 }
 
 export default async function CategoryPage({

--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -15,9 +15,29 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+
 export const metadata: Metadata = {
-  title: "WT4Q News",
-  description: "Latest news and updates from WT4Q",
+  title: {
+    default: 'WT4Q News',
+    template: '%s | WT4Q'
+  },
+  description: 'Latest news and updates from WT4Q',
+  metadataBase: new URL(siteUrl),
+  openGraph: {
+    title: 'WT4Q News',
+    description: 'Latest news and updates from WT4Q',
+    url: siteUrl,
+    siteName: 'WT4Q News',
+    type: 'website',
+  },
+  alternates: {
+    canonical: '/',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -2,7 +2,18 @@ import ArticleCard, { Article } from '@/components/ArticleCard';
 import Hero from '@/components/Hero';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
+import type { Metadata } from 'next';
 import styles from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'Home',
+  alternates: { canonical: '/' },
+  openGraph: {
+    title: 'WT4Q News',
+    url: '/',
+    type: 'website',
+  },
+};
 
 async function fetchArticlesByCategory(cat: string): Promise<Article[]> {
   try {

--- a/WT4Q/src/app/robots.txt/route.ts
+++ b/WT4Q/src/app/robots.txt/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-static';
+
+export function GET() {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const content = `User-agent: *\nAllow: /\nSitemap: ${siteUrl}/sitemap.xml`;
+  return new NextResponse(content, {
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}

--- a/WT4Q/src/app/sitemap.xml/route.ts
+++ b/WT4Q/src/app/sitemap.xml/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { API_ROUTES } from '@/lib/api';
+
+export const dynamic = 'force-static';
+
+async function fetchUrls(): Promise<string[]> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.GET_ALL, { cache: 'no-store' });
+    if (!res.ok) return [];
+    const articles: { id: string }[] = await res.json();
+    return articles.map(a => `/articles/${a.id}`);
+  } catch {
+    return [];
+  }
+}
+
+export async function GET() {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const articlePaths = await fetchUrls();
+  const pages = ['/', '/search', '/terms', '/profile'];
+  const urls = [...pages, ...articlePaths];
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+    urls.map(p => `\n  <url><loc>${siteUrl}${p}</loc></url>`).join('') +
+    '\n</urlset>';
+  return new NextResponse(body, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
+}


### PR DESCRIPTION
## Summary
- define rich metadata in the root layout
- add per-article and category metadata
- add metadata to the home page
- expose `/robots.txt` and `/sitemap.xml` routes for search engines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688354bcea588327a5d4f48277365953