### PR TITLE
Add user activity feed

### DIFF
--- a/Northeast/Controllers/UserController.cs
+++ b/Northeast/Controllers/UserController.cs
@@ -116,6 +116,44 @@ namespace Northeast.Controllers
             return Ok(new { message = "Account deleted" });
         }
 
+        [Authorize]
+        [HttpGet("activity")]
+        public async Task<IActionResult> GetActivity()
+        {
+            var userId = _connectedUser.Id;
+            if (userId == Guid.Empty)
+            {
+                return Unauthorized(new { message = "Not logged in" });
+            }
+
+            var comments = await _appDbContext.Set<Comment>()
+                .Include(c => c.Article)
+                .Where(c => c.Writer.Id == userId)
+                .Select(c => new
+                {
+                    id = c.Id,
+                    articleId = c.ArticleId,
+                    articleTitle = c.Article.Title,
+                    content = c.Content,
+                    createdAt = c.CreatedAt
+                })
+                .ToListAsync();
+
+            var likes = await _appDbContext.Set<LikeEntity>()
+                .Include(l => l.Article)
+                .Where(l => l.UserId == userId)
+                .Select(l => new
+                {
+                    id = l.Id,
+                    articleId = l.ArticleId,
+                    articleTitle = l.Article.Title,
+                    type = l.Type
+                })
+                .ToListAsync();
+
+            return Ok(new { comments, likes });
+        }
+
         
 
     }

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -20,6 +20,7 @@ export const API_ROUTES = {
     ME: `${API_BASE_URL}/User/me`,
     UPDATE: `${API_BASE_URL}/User`,
     DELETE: `${API_BASE_URL}/User`,
+    ACTIVITY: `${API_BASE_URL}/User/activity`,
   },
 
   ARTICLE: {

--- a/WT4Q/src/app/profile/Profile.module.css
+++ b/WT4Q/src/app/profile/Profile.module.css
@@ -58,3 +58,13 @@
   text-align: center;
   margin-top: 2rem;
 }
+
+.activitySection {
+  max-width: 500px;
+  margin: 2rem auto;
+}
+
+.activityList {
+  margin-left: 1.25rem;
+  list-style: disc;
+}

--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -10,9 +10,23 @@ interface User {
   dob?: string;
 }
 
+interface Activity {
+  comments: {
+    id: string;
+    articleTitle: string;
+    content: string;
+  }[];
+  likes: {
+    id: number;
+    articleTitle: string;
+    type: number;
+  }[];
+}
+
 export default function Profile() {
   const [user, setUser] = useState<User | null>(null);
   const [password, setPassword] = useState('');
+  const [activity, setActivity] = useState<Activity | null>(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -20,6 +34,11 @@ export default function Profile() {
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setUser(data))
       .catch(() => setUser(null));
+
+    fetch(API_ROUTES.USERS.ACTIVITY, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setActivity(data))
+      .catch(() => setActivity(null));
   }, []);
 
   const handleSubmit = async (e: FormEvent) => {
@@ -53,6 +72,7 @@ export default function Profile() {
   if (!user) return <p className={styles.message}>Please log in</p>;
 
   return (
+    <>
     <form onSubmit={handleSubmit} className={styles.form}>
       <h1 className={styles.title}>Profile</h1>
       <label className={styles.label}>
@@ -98,5 +118,33 @@ export default function Profile() {
         </button>
       </div>
     </form>
+    {activity && (
+      <section className={styles.activitySection}>
+        <h2 className={styles.title}>Recent Activity</h2>
+        <h3>Comments</h3>
+        {activity.comments.length === 0 ? (
+          <p>No comments yet.</p>
+        ) : (
+          <ul className={styles.activityList}>
+            {activity.comments.map((c) => (
+              <li key={c.id}>
+                Commented on {c.articleTitle}: {c.content}
+              </li>
+            ))}
+          </ul>
+        )}
+        <h3>Likes</h3>
+        {activity.likes.length === 0 ? (
+          <p>No likes yet.</p>
+        ) : (
+          <ul className={styles.activityList}>
+            {activity.likes.map((l) => (
+              <li key={l.id}>Liked {l.articleTitle}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- expose user activity API to list comments and likes
- display recent activity on profile page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688355100738832789d0bedcc6359250