### PR TITLE
Add last login map widget

### DIFF
--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './Profile.module.css';
 import { API_ROUTES } from '@/lib/api';
+import VisitorMap from '@/components/VisitorMap';
 
 interface User {
   userName: string;
@@ -143,6 +144,8 @@ export default function Profile() {
           </button>
         </div>
       )}
+    </section>
+    <VisitorMap />
 
     {activity && (
       <section className={styles.activitySection}>

--- a/WT4Q/src/components/VisitorMap.module.css
+++ b/WT4Q/src/components/VisitorMap.module.css
@@ -1,0 +1,25 @@
+.container {
+  max-width: 220px;
+  margin: 1rem auto;
+  text-align: center;
+  font-family: 'Inter', sans-serif;
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.map {
+  width: 200px;
+  height: 200px;
+  border: 1px solid var(--secondary);
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.info {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}

--- a/WT4Q/src/components/VisitorMap.tsx
+++ b/WT4Q/src/components/VisitorMap.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { API_ROUTES } from '@/lib/api';
+import styles from './VisitorMap.module.css';
+
+interface VisitorInfo {
+  location?: string;
+  city?: string;
+  country?: string;
+  visitTime?: string;
+}
+
+export default function VisitorMap() {
+  const [info, setInfo] = useState<VisitorInfo | null>(null);
+
+  useEffect(() => {
+    fetch(API_ROUTES.USER_LOCATION.GET, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setInfo(data))
+      .catch(() => {});
+  }, []);
+
+  if (!info) return null;
+
+  const [lat, lon] = info.location?.split(',') ?? [];
+  const mapSrc = lat && lon
+    ? `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lon}&zoom=10&size=200x200&markers=${lat},${lon},red-pushpin`
+    : undefined;
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>Last Login</h2>
+      {mapSrc && (
+        <img
+          src={mapSrc}
+          alt="Map showing your last location"
+          className={styles.map}
+        />
+      )}
+      {info.visitTime && (
+        <p className={styles.info}>
+          {new Date(info.visitTime).toLocaleString(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+          })}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `VisitorMap` component to show last login details with OpenStreetMap
- style the visitor map
- display the map and last login info on the profile page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883a52bd64083278c5db838eac05583