### PR TITLE
Add weather search page and dynamic widget update

### DIFF
--- a/WT4Q/src/app/api/weather/by-city/route.ts
+++ b/WT4Q/src/app/api/weather/by-city/route.ts
@@ -1,0 +1,65 @@
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const city = searchParams.get('city');
+  if (!city) {
+    return new Response(JSON.stringify({ message: 'City is required' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  try {
+    const geoRes = await fetch(
+      `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1`
+    );
+    if (!geoRes.ok) {
+      return new Response(JSON.stringify({ message: 'Geocoding failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const geoData = await geoRes.json();
+    if (!geoData.results || geoData.results.length === 0) {
+      return new Response(JSON.stringify({ message: 'City not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const { latitude, longitude, name, country } = geoData.results[0];
+
+    const weatherRes = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true`
+    );
+    if (!weatherRes.ok) {
+      return new Response(JSON.stringify({ message: 'Weather fetch failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const weatherData = await weatherRes.json();
+    const current = weatherData.current_weather;
+    if (!current) {
+      return new Response(JSON.stringify({ message: 'Weather data unavailable' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        city: name,
+        country,
+        temperature: current.temperature,
+        weathercode: current.weathercode,
+      }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }
+    );
+  } catch {
+    return new Response(JSON.stringify({ message: 'Request failed' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/WT4Q/src/app/weather/page.tsx
+++ b/WT4Q/src/app/weather/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useState } from 'react';
+import WeatherIcon from '@/components/WeatherIcon';
+import styles from './weather.module.css';
+
+interface Weather {
+  city: string;
+  country: string;
+  temperature: number;
+  weathercode: number;
+}
+
+export default function WeatherPage() {
+  const [city, setCity] = useState('');
+  const [weather, setWeather] = useState<Weather | null>(null);
+  const [error, setError] = useState('');
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = city.trim();
+    if (!trimmed) return;
+    try {
+      setError('');
+      const res = await fetch(`/api/weather/by-city?city=${encodeURIComponent(trimmed)}`);
+      if (res.ok) {
+        const data: Weather = await res.json();
+        setWeather(data);
+      } else {
+        const data = await res.json().catch(() => null);
+        setError(data?.message || 'Unable to fetch weather');
+        setWeather(null);
+      }
+    } catch {
+      setError('Unable to fetch weather');
+      setWeather(null);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>Weather Search</h1>
+      <form onSubmit={handleSearch} className={styles.form}>
+        <input
+          type="text"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          placeholder="Enter city name"
+          className={styles.input}
+        />
+        <button type="submit" className={styles.button}>Search</button>
+      </form>
+      {error && <p className={styles.error}>{error}</p>}
+      {weather && (
+        <div className={styles.result}>
+          <WeatherIcon code={weather.weathercode} className={styles.icon} />
+          <span>
+            {Math.round(weather.temperature)}&deg;C - {weather.city}, {weather.country}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -1,0 +1,41 @@
+.container {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.heading {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+.form {
+  display: flex;
+  gap: 0.5rem;
+}
+.input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.button {
+  padding: 0.5rem 1rem;
+  background: #0070f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.error {
+  color: red;
+}
+.result {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+}
+.icon {
+  width: 32px;
+  height: 32px;
+}

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -24,7 +24,9 @@ export default function Header() {
         <div className={styles.search}>
           <SearchBar />
         </div>
-        <WeatherWidget />
+        <Link href="/weather" aria-label="Weather details">
+          <WeatherWidget />
+        </Link>
         <UserMenu />
       </div>
       <div className={styles.categories}>

--- a/WT4Q/src/components/WeatherWidget.tsx
+++ b/WT4Q/src/components/WeatherWidget.tsx
@@ -19,21 +19,27 @@ export default function WeatherWidget() {
   const [location, setLocation] = useState<Location | null>(null);
 
   useEffect(() => {
-    fetch(API_ROUTES.WEATHER.CURRENT)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) setWeather(data);
-      })
-      .catch(() => {});
+    const fetchData = () => {
+      fetch(API_ROUTES.WEATHER.CURRENT)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (data) setWeather(data);
+        })
+        .catch(() => {});
 
-    fetch(API_ROUTES.USER_LOCATION.GET)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data && data.city && data.country) {
-          setLocation({ city: data.city, country: data.country });
-        }
-      })
-      .catch(() => {});
+      fetch(API_ROUTES.USER_LOCATION.GET)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (data && data.city && data.country) {
+            setLocation({ city: data.city, country: data.country });
+          }
+        })
+        .catch(() => {});
+    };
+
+    fetchData();
+    const id = setInterval(fetchData, 10 * 60 * 1000);
+    return () => clearInterval(id);
   }, []);
 
   if (!weather) return null;


### PR DESCRIPTION
## Summary
- refresh weather widget periodically
- make weather widget open `/weather` when clicked
- add API route to fetch weather data by city
- create new Weather page with search

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883df996a948327978e699d7537e1f1