### PR TITLE
Add colored day/night weather icons

### DIFF
--- a/Northeast/Controllers/WeatherController.cs
+++ b/Northeast/Controllers/WeatherController.cs
@@ -46,6 +46,8 @@ namespace Northeast.Controllers
             {
                 temperature = current.GetProperty("temperature").GetDecimal(),
                 weathercode = current.GetProperty("weathercode").GetInt32(),
+                isDay = current.TryGetProperty("is_day", out var isDayProperty) &&
+                        isDayProperty.GetInt32() == 1,
                 windspeed = current.TryGetProperty("windspeed", out var speed)
                     ? speed.GetDecimal()
                     : (decimal)0

--- a/WT4Q/src/app/api/weather/by-city/route.ts
+++ b/WT4Q/src/app/api/weather/by-city/route.ts
@@ -50,6 +50,7 @@ export async function GET(request: Request) {
         country,
         temperature: current.temperature,
         weathercode: current.weathercode,
+        isDay: current.is_day === 1,
         windspeed: current.windspeed ?? null,
       }),
       {

--- a/WT4Q/src/app/weather/page.tsx
+++ b/WT4Q/src/app/weather/page.tsx
@@ -8,6 +8,7 @@ interface Weather {
   country: string;
   temperature: number;
   weathercode: number;
+  isDay: boolean;
   windspeed?: number | null;
 }
 
@@ -54,7 +55,11 @@ export default function WeatherPage() {
       {error && <p className={styles.error}>{error}</p>}
       {weather && (
         <div className={styles.result}>
-          <WeatherIcon code={weather.weathercode} className={styles.icon} />
+          <WeatherIcon
+            code={weather.weathercode}
+            isDay={weather.isDay}
+            className={styles.icon}
+          />
           <span>
             {Math.round(unit === 'C' ? weather.temperature : weather.temperature * 1.8 + 32)}
             &deg;{unit} - {weather.city}, {weather.country}

--- a/WT4Q/src/components/WeatherIcon.tsx
+++ b/WT4Q/src/components/WeatherIcon.tsx
@@ -1,5 +1,6 @@
 interface Props {
   code: number;
+  isDay?: boolean;
   className?: string;
 }
 
@@ -11,8 +12,8 @@ function Sun({ className }: { className?: string }) {
       className={className}
       aria-hidden="true"
     >
-      <circle cx="12" cy="12" r="5" fill="currentColor" />
-      <g stroke="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="5" fill="#FFD54F" />
+      <g stroke="#FFD54F" strokeWidth="2">
         <line x1="12" y1="1" x2="12" y2="3" />
         <line x1="12" y1="21" x2="12" y2="23" />
         <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
@@ -26,6 +27,22 @@ function Sun({ className }: { className?: string }) {
   );
 }
 
+function Moon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+        fill="#FFEB3B"
+      />
+    </svg>
+  );
+}
+
 function Cloud({ className }: { className?: string }) {
   return (
     <svg
@@ -35,7 +52,7 @@ function Cloud({ className }: { className?: string }) {
       aria-hidden="true"
     >
       <path
-        fill="currentColor"
+        fill="#90A4AE"
         d="M19 18H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 18z"
       />
     </svg>
@@ -51,12 +68,12 @@ function Rain({ className }: { className?: string }) {
       aria-hidden="true"
     >
       <path
-        fill="currentColor"
+        fill="#90A4AE"
         d="M19 17H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 17z"
       />
-      <line x1="8" y1="20" x2="8" y2="22" stroke="currentColor" strokeWidth="2" />
-      <line x1="12" y1="20" x2="12" y2="22" stroke="currentColor" strokeWidth="2" />
-      <line x1="16" y1="20" x2="16" y2="22" stroke="currentColor" strokeWidth="2" />
+      <line x1="8" y1="20" x2="8" y2="22" stroke="#2196F3" strokeWidth="2" />
+      <line x1="12" y1="20" x2="12" y2="22" stroke="#2196F3" strokeWidth="2" />
+      <line x1="16" y1="20" x2="16" y2="22" stroke="#2196F3" strokeWidth="2" />
     </svg>
   );
 }
@@ -70,14 +87,32 @@ function Snow({ className }: { className?: string }) {
       aria-hidden="true"
     >
       <path
-        fill="currentColor"
+        fill="#90A4AE"
         d="M19 16H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 16z"
       />
-      <g fill="currentColor">
+      <g fill="#BBDEFB">
         <circle cx="8" cy="20" r="1" />
         <circle cx="12" cy="20" r="1" />
         <circle cx="16" cy="20" r="1" />
       </g>
+    </svg>
+  );
+}
+
+function Fog({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fill="#90A4AE"
+        d="M19 16H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 16z"
+      />
+      <line x1="4" y1="18" x2="20" y2="18" stroke="#B0BEC5" strokeWidth="2" />
+      <line x1="6" y1="21" x2="18" y2="21" stroke="#B0BEC5" strokeWidth="2" />
     </svg>
   );
 }
@@ -91,12 +126,12 @@ function Storm({ className }: { className?: string }) {
       aria-hidden="true"
     >
       <path
-        fill="currentColor"
+        fill="#90A4AE"
         d="M19 16H6a4 4 0 0 1 0-8 6 6 0 0 1 11.7-1.6A4.5 4.5 0 0 1 19 16z"
       />
       <polyline
         points="13 16 11 22 15 22 13 28"
-        stroke="currentColor"
+        stroke="#FFC107"
         strokeWidth="2"
         fill="none"
       />
@@ -104,12 +139,13 @@ function Storm({ className }: { className?: string }) {
   );
 }
 
-export default function WeatherIcon({ code, className }: Props) {
-  if (code === 0) return <Sun className={className} />;
+export default function WeatherIcon({ code, isDay = true, className }: Props) {
+  if (code === 0) return isDay ? <Sun className={className} /> : <Moon className={className} />;
   if (code >= 1 && code <= 3) return <Cloud className={className} />;
-  if ((code >= 45 && code <= 48) || (code >= 51 && code <= 67))
-    return <Rain className={className} />;
-  if ((code >= 71 && code <= 86)) return <Snow className={className} />;
+  if (code >= 45 && code <= 48) return <Fog className={className} />;
+  if (code >= 51 && code <= 67) return <Rain className={className} />;
+  if (code >= 80 && code <= 82) return <Rain className={className} />;
+  if (code >= 71 && code <= 86) return <Snow className={className} />;
   if (code >= 95) return <Storm className={className} />;
   return <Cloud className={className} />;
 }

--- a/WT4Q/src/components/WeatherWidget.tsx
+++ b/WT4Q/src/components/WeatherWidget.tsx
@@ -7,6 +7,7 @@ import { API_ROUTES } from '@/lib/api';
 interface Weather {
   temperature: number;
   weathercode: number;
+  isDay: boolean;
   windspeed?: number | null;
 }
 
@@ -66,7 +67,11 @@ export default function WeatherWidget() {
 
   return (
     <div className={styles.weather} aria-label="Current weather">
-      <WeatherIcon code={weather.weathercode} className={styles.icon} />
+      <WeatherIcon
+        code={weather.weathercode}
+        isDay={weather.isDay}
+        className={styles.icon}
+      />
       <span className={styles.temp}>
         {Math.round(unit === 'C' ? weather.temperature : weather.temperature * 1.8 + 32)}&deg;{unit}
         <button className={styles.button} onClick={() => setUnit(unit === 'C' ? 'F' : 'C')} aria-label="Toggle units">


### PR DESCRIPTION
## Summary
- enrich weather icon component with colored SVGs
- show a moon icon when it's night
- expose `isDay` from backend and weather API route
- display icons using `isDay` in weather widget and weather page

## Testing
- `npm run lint`
- `dotnet build Northeast/Northeast.csproj` *(fails: merge conflict in UserLocController.cs)*

------
https://chatgpt.com/codex/tasks/task_e_6883eeb2b2508327be05bbd71e51baf8