### PR TITLE
Add met.no forecast support

### DIFF
--- a/Northeast/Controllers/WeatherController.cs
+++ b/Northeast/Controllers/WeatherController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Northeast.Services;
 using System.Text.Json;
+using System.Collections.Generic;
 
 namespace Northeast.Controllers
 {
@@ -54,6 +55,64 @@ namespace Northeast.Controllers
             };
 
             return Ok(result);
+        }
+
+        [HttpGet("forecast")]
+        public async Task<IActionResult> GetForecast()
+        {
+            var visitor = await _siteVisitorServices.VisitorLog();
+            if (visitor == null || string.IsNullOrEmpty(visitor.Location))
+            {
+                return BadRequest(new { message = "Unable to determine location." });
+            }
+
+            var parts = visitor.Location.Split(',');
+            if (parts.Length != 2 ||
+                !double.TryParse(parts[0], out var lat) ||
+                !double.TryParse(parts[1], out var lon))
+            {
+                return BadRequest(new { message = "Invalid location." });
+            }
+
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"https://api.met.no/weatherapi/locationforecast/2.0/compact?lat={lat}&lon={lon}");
+            request.Headers.Add("User-Agent", "WT4Q/1.0 https://example.com");
+
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return BadRequest(new { message = "Forecast data unavailable" });
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("properties", out var properties) ||
+                !properties.TryGetProperty("timeseries", out var series))
+            {
+                return BadRequest(new { message = "Forecast data unavailable" });
+            }
+
+            var list = new List<object>();
+            int count = 0;
+            foreach (var entry in series.EnumerateArray())
+            {
+                if (count >= 24) break;
+                var time = entry.GetProperty("time").GetString();
+                var details = entry.GetProperty("data").GetProperty("instant").GetProperty("details");
+                var temp = details.GetProperty("air_temperature").GetDecimal();
+                decimal wind = details.TryGetProperty("wind_speed", out var windProp) ? windProp.GetDecimal() : 0;
+                string symbol = "";
+                if (entry.GetProperty("data").TryGetProperty("next_1_hours", out var hour) &&
+                    hour.TryGetProperty("summary", out var summary) &&
+                    summary.TryGetProperty("symbol_code", out var codeProp))
+                {
+                    symbol = codeProp.GetString() ?? "";
+                }
+                list.Add(new { time, temperature = temp, windspeed = wind, symbol });
+                count++;
+            }
+
+            return Ok(new { forecast = list });
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ dotnet ef database update
 from the `Northeast` directory.
 
 This repository contains a Next.js app in the `WT4Q` directory and a .NET API in the `Northeast` directory.
+
+### Weather Forecast
+
+Current weather data comes from Open‑Meteo. For a more detailed 24‑hour forecast the application now queries the Norwegian Meteorological Institute API (`api.met.no`). If you use this service commercially, follow their terms of service and include a `User-Agent` header identifying your application.

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -72,5 +72,6 @@ export const API_ROUTES = {
 
   WEATHER: {
     CURRENT: `${API_BASE_URL}/api/Weather/current`,
+    FORECAST: `${API_BASE_URL}/api/Weather/forecast`,
   },
 };

--- a/WT4Q/src/app/api/weather/forecast-by-city/route.ts
+++ b/WT4Q/src/app/api/weather/forecast-by-city/route.ts
@@ -1,0 +1,82 @@
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const city = searchParams.get('city');
+  if (!city) {
+    return new Response(JSON.stringify({ message: 'City is required' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  try {
+    const geoRes = await fetch(
+      `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1`
+    );
+    if (!geoRes.ok) {
+      return new Response(JSON.stringify({ message: 'Geocoding failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const geoData = await geoRes.json();
+    if (!geoData.results || geoData.results.length === 0) {
+      return new Response(JSON.stringify({ message: 'City not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const { latitude, longitude } = geoData.results[0];
+
+    const metRes = await fetch(
+      `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=${latitude}&lon=${longitude}`,
+      {
+        headers: { 'User-Agent': 'WT4Q/1.0 https://example.com' },
+      }
+    );
+    if (!metRes.ok) {
+      return new Response(JSON.stringify({ message: 'Weather fetch failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const metData = await metRes.json();
+    const series = metData.properties?.timeseries;
+    if (!Array.isArray(series)) {
+      return new Response(JSON.stringify({ message: 'Forecast unavailable' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    interface MetEntry {
+      time: string;
+      data: {
+        instant: {
+          details: {
+            air_temperature: number;
+            wind_speed?: number;
+          };
+        };
+        next_1_hours?: {
+          summary?: {
+            symbol_code?: string;
+          };
+        };
+      };
+    }
+    const forecast = (series as MetEntry[]).slice(0, 24).map((entry) => ({
+      time: entry.time,
+      temperature: entry.data.instant.details.air_temperature,
+      windspeed: entry.data.instant.details.wind_speed ?? null,
+      symbol: entry.data.next_1_hours?.summary?.symbol_code ?? null,
+    }));
+    return new Response(JSON.stringify({ forecast }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch {
+    return new Response(JSON.stringify({ message: 'Request failed' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -44,3 +44,24 @@
   width: 32px;
   height: 32px;
 }
+
+.subheading {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-top: 1rem;
+}
+
+.forecast {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.forecastItem {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.time {
+  width: 100px;
+}


### PR DESCRIPTION
## Summary
- update .NET weather controller to fetch forecast from api.met.no
- expose forecast API from Next.js for searching by city
- fetch forecast data on weather page and show 24 hour forecast
- add CSS styles for new forecast display
- document new forecast feature in README

## Testing
- `dotnet build` *(fails: merge conflict in UserLocController.cs)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883f4a7d61883278b16fe868d983577