### PR TITLE
Improve weather icons

### DIFF
--- a/WT4Q/src/app/weather/page.tsx
+++ b/WT4Q/src/app/weather/page.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useState } from 'react';
+import { ReactElement, useState } from 'react';
 import WeatherIcon from '@/components/WeatherIcon';
+import WindIcon from '@/components/WindIcon';
 import styles from './weather.module.css';
 
 interface Weather {
@@ -17,6 +18,20 @@ interface ForecastEntry {
   temperature: number;
   windspeed: number | null;
   symbol: string | null;
+}
+
+function iconFromSymbol(symbol: string | null, className: string): ReactElement | null {
+  if (!symbol) return null;
+  const isDay = !symbol.includes('night');
+  if (symbol.includes('clearsky')) return <WeatherIcon code={0} isDay={isDay} className={className} />;
+  if (symbol.includes('partlycloudy'))
+    return <WeatherIcon code={1} isDay={isDay} className={className} />;
+  if (symbol.includes('cloudy')) return <WeatherIcon code={3} isDay={isDay} className={className} />;
+  if (symbol.includes('rain')) return <WeatherIcon code={61} isDay={isDay} className={className} />;
+  if (symbol.includes('snow')) return <WeatherIcon code={71} isDay={isDay} className={className} />;
+  if (symbol.includes('fog')) return <WeatherIcon code={45} isDay={isDay} className={className} />;
+  if (symbol.includes('thunder')) return <WeatherIcon code={95} isDay={isDay} className={className} />;
+  return <WeatherIcon code={3} isDay={isDay} className={className} />;
 }
 
 export default function WeatherPage() {
@@ -97,11 +112,16 @@ export default function WeatherPage() {
           {forecast.map((f) => (
             <div key={f.time} className={styles.forecastItem}>
               <span className={styles.time}>{new Date(f.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+              {iconFromSymbol(f.symbol, styles.icon)}
               <span>
                 {Math.round(unit === 'C' ? f.temperature : f.temperature * 1.8 + 32)}°{unit}
-                {f.windspeed != null && `, ${Math.round(f.windspeed)} km/h`}
-                {f.symbol && `, ${f.symbol}`}
               </span>
+              {f.windspeed != null && (
+                <span className={styles.wind}>
+                  <WindIcon className={styles.windIcon} />
+                  {Math.round(f.windspeed)} km/h
+                </span>
+              )}
             </div>
           ))}
         </div>

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -45,6 +45,18 @@
   height: 32px;
 }
 
+.windIcon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0.125rem;
+}
+
+.wind {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+}
+
 .subheading {
   font-size: 1.25rem;
   font-weight: bold;

--- a/WT4Q/src/components/WeatherIcon.tsx
+++ b/WT4Q/src/components/WeatherIcon.tsx
@@ -59,6 +59,27 @@ function Cloud({ className }: { className?: string }) {
   );
 }
 
+function PartlyCloudy({ isDay = true, className }: { isDay?: boolean; className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      {isDay ? (
+        <circle cx="8" cy="8" r="4" fill="#FFD54F" />
+      ) : (
+        <path d="M12 2a6 6 0 1 0 0 12c-2.5 0-4.5-2-4.5-4.5S9.5 5 12 5z" fill="#FFEB3B" />
+      )}
+      <path
+        fill="#90A4AE"
+        d="M19 18H8a4 4 0 0 1 0-8 6 6 0 0 1 10.7-1.6A4.5 4.5 0 0 1 19 18z"
+      />
+    </svg>
+  );
+}
+
 function Rain({ className }: { className?: string }) {
   return (
     <svg
@@ -141,7 +162,9 @@ function Storm({ className }: { className?: string }) {
 
 export default function WeatherIcon({ code, isDay = true, className }: Props) {
   if (code === 0) return isDay ? <Sun className={className} /> : <Moon className={className} />;
-  if (code >= 1 && code <= 3) return <Cloud className={className} />;
+  if (code === 1 || code === 2)
+    return <PartlyCloudy isDay={isDay} className={className} />;
+  if (code === 3) return <Cloud className={className} />;
   if (code >= 45 && code <= 48) return <Fog className={className} />;
   if (code >= 51 && code <= 67) return <Rain className={className} />;
   if (code >= 80 && code <= 82) return <Rain className={className} />;

--- a/WT4Q/src/components/WeatherWidget.module.css
+++ b/WT4Q/src/components/WeatherWidget.module.css
@@ -26,6 +26,12 @@
   color: currentColor;
 }
 
+.windIcon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0.125rem;
+}
+
 .location {
   font-size: 0.875rem;
 }

--- a/WT4Q/src/components/WeatherWidget.tsx
+++ b/WT4Q/src/components/WeatherWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import WeatherIcon from './WeatherIcon';
+import WindIcon from './WindIcon';
 import styles from './WeatherWidget.module.css';
 import { API_ROUTES } from '@/lib/api';
 
@@ -79,7 +80,10 @@ export default function WeatherWidget() {
         </button>
       </span>
       {weather.windspeed != null && (
-        <span className={styles.location}>{Math.round(weather.windspeed)} km/h</span>
+        <span className={styles.location}>
+          <WindIcon className={styles.windIcon} />
+          {Math.round(weather.windspeed)} km/h
+        </span>
       )}
       {location && (
         <span className={styles.location}>

--- a/WT4Q/src/components/WindIcon.tsx
+++ b/WT4Q/src/components/WindIcon.tsx
@@ -1,0 +1,24 @@
+export default function WindIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M3 12h10a3 3 0 1 0 0-6"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        d="M4 18h11a2 2 0 1 0 0-4"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <line x1="3" y1="6" x2="14" y2="6" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `WindIcon` component
- support partly cloudy conditions in `WeatherIcon`
- show wind SVG in widgets and forecast
- map forecast symbol codes to icons for clarity

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cbb99a3948327a169a1bdc7c18675