### PR TITLE
Fix header alignment

### DIFF
--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -9,8 +9,7 @@
 }
 
 .inner {
-  max-width: 960px;
-  margin: 0 auto;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -31,14 +30,12 @@
 
 
 .categories {
-  max-width: 960px;
-  margin: 0 auto;
+  width: 100%;
 }
 
 .search {
   flex: 1;
   display: flex;
-  justify-content: flex-end;
 }
 
 @keyframes slideIn {

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -10,6 +10,13 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <div className={styles.inner}>
+        <UserMenu />
+        <div className={styles.search}>
+          <SearchBar />
+        </div>
+        <Link href="/weather" aria-label="Weather details">
+          <WeatherWidget />
+        </Link>
         <Link href="/" className={styles.logo}>
           <Image
             src="/images/wt4q-logo.png"
@@ -21,13 +28,6 @@ export default function Header() {
             priority
           />
         </Link>
-        <div className={styles.search}>
-          <SearchBar />
-        </div>
-        <Link href="/weather" aria-label="Weather details">
-          <WeatherWidget />
-        </Link>
-        <UserMenu />
       </div>
       <div className={styles.categories}>
         <CategoryNavbar />


### PR DESCRIPTION
## Summary
- flip order of header items so the user menu is on the left and the logo on the right
- allow header containers to span the full width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d1277d30483278b8e93c40bff727f