### PR TITLE
Improve responsive header layout

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -24,3 +24,24 @@
   background: var(--primary);
   transform: translateY(-2px);
 }
+
+@media (max-width: 768px) {
+  .nav {
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 16rem;
+    height: 100%;
+    overflow-y: auto;
+    padding-top: 4rem;
+    border-radius: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+  }
+
+  .open {
+    transform: translateX(0);
+  }
+}

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -2,9 +2,12 @@ import Link from 'next/link';
 import { CATEGORIES } from '@/lib/categories';
 import styles from './CategoryNavbar.module.css';
 
-export default function CategoryNavbar() {
+interface Props {
+  open?: boolean;
+}
+export default function CategoryNavbar({ open }: Props = {}) {
   return (
-    <nav className={styles.nav} aria-label="categories">
+    <nav className={`${styles.nav} ${open ? styles.open : ''}`} aria-label="categories">
       <Link href="/" className={styles.link}>
         Home
       </Link>

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -38,6 +38,27 @@
   display: flex;
 }
 
+.menuButton {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 900;
+}
+
+@media (min-width: 769px) {
+  .menuButton {
+    display: none;
+  }
+}
+
 @keyframes slideIn {
   from {
     transform: translateY(-100%);

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import CategoryNavbar from './CategoryNavbar';
@@ -7,16 +10,12 @@ import WeatherWidget from './WeatherWidget';
 import styles from './Header.module.css';
 
 export default function Header() {
+  const [open, setOpen] = useState(false);
+
   return (
     <header className={styles.header}>
+      {open && <div className={styles.overlay} onClick={() => setOpen(false)} />}
       <div className={styles.inner}>
-        <UserMenu />
-        <div className={styles.search}>
-          <SearchBar />
-        </div>
-        <Link href="/weather" aria-label="Weather details">
-          <WeatherWidget />
-        </Link>
         <Link href="/" className={styles.logo}>
           <Image
             src="/images/wt4q-logo.png"
@@ -28,9 +27,23 @@ export default function Header() {
             priority
           />
         </Link>
+        <button
+          className={styles.menuButton}
+          onClick={() => setOpen(true)}
+          aria-label="Open categories"
+        >
+          ☰
+        </button>
+        <div className={styles.search}>
+          <SearchBar />
+        </div>
+        <Link href="/weather" aria-label="Weather details">
+          <WeatherWidget />
+        </Link>
+        <UserMenu />
       </div>
       <div className={styles.categories}>
-        <CategoryNavbar />
+        <CategoryNavbar open={open} />
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- move logo to the left side of the header
- add menu button and overlay for category sidebar
- show user menu at the right
- turn category navbar into a slide‑in sidebar on small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d1a9e87588327a7214315ad7d2f7d