### PR TITLE
Improve header responsiveness

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -30,13 +30,13 @@
     flex-direction: column;
     position: fixed;
     top: 0;
-    left: 0;
+    right: 0;
     width: 16rem;
     height: 100%;
     overflow-y: auto;
     padding-top: 4rem;
     border-radius: 0;
-    transform: translateX(-100%);
+    transform: translateX(100%);
     transition: transform 0.3s ease;
     z-index: 1000;
   }

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -38,6 +38,16 @@
   display: flex;
 }
 
+@media (max-width: 768px) {
+  .inner {
+    flex-wrap: wrap;
+  }
+  .search {
+    order: 2;
+    width: 100%;
+  }
+}
+
 .menuButton {
   background: none;
   border: none;

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -34,12 +34,12 @@ export default function Header() {
         >
           ☰
         </button>
-        <div className={styles.search}>
-          <SearchBar />
-        </div>
         <Link href="/weather" aria-label="Weather details">
           <WeatherWidget />
         </Link>
+        <div className={styles.search}>
+          <SearchBar />
+        </div>
         <UserMenu />
       </div>
       <div className={styles.categories}>

--- a/WT4Q/src/components/SearchBar.module.css
+++ b/WT4Q/src/components/SearchBar.module.css
@@ -28,3 +28,9 @@
   background: var(--secondary);
   transform: translateY(-1px);
 }
+
+@media (max-width: 768px) {
+  .form {
+    width: 100%;
+  }
+}

--- a/WT4Q/src/components/UserMenu.module.css
+++ b/WT4Q/src/components/UserMenu.module.css
@@ -27,6 +27,22 @@
   color: #fff;
 }
 
+.loginIcon {
+  width: 20px;
+  height: 20px;
+}
+
+@media (max-width: 768px) {
+  .loginLink {
+    flex-direction: column;
+    padding: 0.25rem;
+  }
+  .loginText {
+    font-size: 0.75rem;
+    line-height: 1;
+  }
+}
+
 .dropdown {
   position: absolute;
   top: 110%;

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -47,8 +47,7 @@ export default function UserMenu() {
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
-          width="20"
-          height="20"
+          className={styles.loginIcon}
           aria-hidden="true"
           focusable="false"
         >
@@ -57,7 +56,7 @@ export default function UserMenu() {
             d="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"
           />
         </svg>
-        <span>Sign In</span>
+        <span className={styles.loginText}>Sign In</span>
       </Link>
     );
   }


### PR DESCRIPTION
## Summary
- adjust sign-in link layout and make it responsive
- move WeatherWidget before the SearchBar
- wrap header items on narrow screens
- slide the mobile category sidebar in from the right
- allow the search bar to stretch across small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d30d3cd3c832787b1b26a6580d385