### PR TITLE
Center logo on mobile and open categories from left

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -30,13 +30,13 @@
     flex-direction: column;
     position: fixed;
     top: 0;
-    right: 0;
+    left: 0;
     width: 16rem;
     height: 100%;
     overflow-y: auto;
     padding-top: 4rem;
     border-radius: 0;
-    transform: translateX(100%);
+    transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 1000;
   }

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -40,7 +40,17 @@
 
 @media (max-width: 768px) {
   .inner {
+    position: relative;
     flex-wrap: wrap;
+    min-height: 3rem;
+  }
+  .logo {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .menuButton {
+    order: -1;
   }
   .search {
     order: 2;
@@ -52,8 +62,12 @@
   background: none;
   border: none;
   color: inherit;
-  font-size: 1.5rem;
   cursor: pointer;
+}
+
+.menuIcon {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .overlay {

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -7,6 +7,7 @@ import CategoryNavbar from './CategoryNavbar';
 import SearchBar from './SearchBar';
 import UserMenu from './UserMenu';
 import WeatherWidget from './WeatherWidget';
+import MenuIcon from './MenuIcon';
 import styles from './Header.module.css';
 
 export default function Header() {
@@ -32,7 +33,7 @@ export default function Header() {
           onClick={() => setOpen(true)}
           aria-label="Open categories"
         >
-          ☰
+          <MenuIcon className={styles.menuIcon} />
         </button>
         <Link href="/weather" aria-label="Weather details">
           <WeatherWidget />

--- a/WT4Q/src/components/MenuIcon.tsx
+++ b/WT4Q/src/components/MenuIcon.tsx
@@ -1,0 +1,14 @@
+export default function MenuIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <line x1="3" y1="6" x2="21" y2="6" stroke="currentColor" strokeWidth="2" />
+      <line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" strokeWidth="2" />
+      <line x1="3" y1="18" x2="21" y2="18" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add `MenuIcon` SVG for hamburger button
- center logo on small screens
- open the category navigation from the left
- use the new SVG icon for the menu button

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d392fbc348327ac750544bde9a5e5