### PR TITLE
Improve mobile header layout

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -9,6 +9,12 @@
   color: #ffffff;
 }
 
+@media (min-width: 769px) {
+  .nav {
+    justify-content: center;
+  }
+}
+
 .link {
   text-decoration: none;
   color: inherit;

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -38,6 +38,16 @@
   display: flex;
 }
 
+.weather {
+  display: flex;
+  align-items: center;
+}
+
+.userMenu {
+  display: flex;
+  align-items: center;
+}
+
 @media (max-width: 768px) {
   .inner {
     position: relative;
@@ -52,9 +62,17 @@
   .menuButton {
     order: -1;
   }
+  .weather {
+    margin-left: auto;
+    order: 1;
+  }
   .search {
     order: 2;
-    width: 100%;
+    flex: 1;
+    width: auto;
+  }
+  .userMenu {
+    order: 3;
   }
 }
 

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -35,13 +35,19 @@ export default function Header() {
         >
           <MenuIcon className={styles.menuIcon} />
         </button>
-        <Link href="/weather" aria-label="Weather details">
+        <Link
+          href="/weather"
+          aria-label="Weather details"
+          className={styles.weather}
+        >
           <WeatherWidget />
         </Link>
         <div className={styles.search}>
           <SearchBar />
         </div>
-        <UserMenu />
+        <div className={styles.userMenu}>
+          <UserMenu />
+        </div>
       </div>
       <div className={styles.categories}>
         <CategoryNavbar open={open} />


### PR DESCRIPTION
## Summary
- refine header layout with explicit classes for weather and user menu
- tweak mobile flex order so menu button stays left and widgets shift right
- center category navigation on wide screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d4fc7a3dc8327ae2704f49d48f02e