### PR TITLE
feat: improve header layout responsiveness

### DIFF
--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -10,16 +10,31 @@
 
 .inner {
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
 }
 
+.left,
+.right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.left {
+  justify-content: flex-start;
+}
+
+.right {
+  justify-content: flex-end;
+}
 
 .logo {
   display: flex;
   align-items: center;
+  justify-self: center;
 }
 
 .logoImage {
@@ -50,29 +65,25 @@
 
 @media (max-width: 768px) {
   .inner {
-    position: relative;
+    display: flex;
     flex-wrap: wrap;
-    min-height: 3rem;
+    align-items: center;
+    justify-content: space-between;
   }
   .logo {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-  .menuButton {
     order: -1;
+    width: 100%;
+    justify-content: center;
   }
-  .weather {
-    margin-left: auto;
-    order: 1;
+  .left,
+  .right {
+    width: 50%;
   }
-  .search {
-    order: 2;
-    flex: 1;
-    width: auto;
+  .left {
+    justify-content: flex-start;
   }
-  .userMenu {
-    order: 3;
+  .right {
+    justify-content: flex-end;
   }
 }
 

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -17,6 +17,18 @@ export default function Header() {
     <header className={styles.header}>
       {open && <div className={styles.overlay} onClick={() => setOpen(false)} />}
       <div className={styles.inner}>
+        <div className={styles.left}>
+          <Link
+            href="/weather"
+            aria-label="Weather details"
+            className={styles.weather}
+          >
+            <WeatherWidget />
+          </Link>
+          <div className={styles.search}>
+            <SearchBar />
+          </div>
+        </div>
         <Link href="/" className={styles.logo}>
           <Image
             src="/images/wt4q-logo.png"
@@ -28,25 +40,17 @@ export default function Header() {
             priority
           />
         </Link>
-        <button
-          className={styles.menuButton}
-          onClick={() => setOpen(true)}
-          aria-label="Open categories"
-        >
-          <MenuIcon className={styles.menuIcon} />
-        </button>
-        <Link
-          href="/weather"
-          aria-label="Weather details"
-          className={styles.weather}
-        >
-          <WeatherWidget />
-        </Link>
-        <div className={styles.search}>
-          <SearchBar />
-        </div>
-        <div className={styles.userMenu}>
-          <UserMenu />
+        <div className={styles.right}>
+          <button
+            className={styles.menuButton}
+            onClick={() => setOpen(true)}
+            aria-label="Open categories"
+          >
+            <MenuIcon className={styles.menuIcon} />
+          </button>
+          <div className={styles.userMenu}>
+            <UserMenu />
+          </div>
         </div>
       </div>
       <div className={styles.categories}>


### PR DESCRIPTION
## Summary
- center the logo on small screens and move other controls below
- keep weather widget and search bar on the left across breakpoints
- redesign header layout with CSS grid and mobile flex wrapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e0e3ea4cc83278938bdb1e666a02a