### PR TITLE
feat: adjust header layout for responsive design

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -9,7 +9,7 @@
   color: #ffffff;
 }
 
-@media (min-width: 769px) {
+@media (min-width: 1025px) {
   .nav {
     justify-content: center;
   }
@@ -31,7 +31,7 @@
   transform: translateY(-2px);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .nav {
     flex-direction: column;
     position: fixed;

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -10,31 +10,18 @@
 
 .inner {
   width: 100%;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 1rem;
-}
-
-.left,
-.right {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
-}
-
-.left {
-  justify-content: flex-start;
-}
-
-.right {
-  justify-content: flex-end;
 }
 
 .logo {
   display: flex;
   align-items: center;
-  justify-self: center;
+  width: 100%;
+  justify-content: center;
+  order: 0;
 }
 
 .logoImage {
@@ -43,19 +30,18 @@
   border-radius: 50%;
 }
 
-
-.categories {
-  width: 100%;
-}
-
-.search {
-  flex: 1;
-  display: flex;
-}
-
 .weather {
   display: flex;
   align-items: center;
+  order: 1;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-left: auto;
+  order: 2;
 }
 
 .userMenu {
@@ -63,28 +49,15 @@
   align-items: center;
 }
 
-@media (max-width: 768px) {
-  .inner {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-  }
-  .logo {
-    order: -1;
-    width: 100%;
-    justify-content: center;
-  }
-  .left,
-  .right {
-    width: 50%;
-  }
-  .left {
-    justify-content: flex-start;
-  }
-  .right {
-    justify-content: flex-end;
-  }
+.search {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  order: 3;
+}
+
+.categories {
+  width: 100%;
 }
 
 .menuButton {
@@ -106,7 +79,28 @@
   z-index: 900;
 }
 
-@media (min-width: 769px) {
+@media (min-width: 1025px) {
+  .inner {
+    flex-wrap: nowrap;
+  }
+  .logo {
+    width: auto;
+    justify-content: flex-start;
+    order: 0;
+  }
+  .weather {
+    order: 1;
+  }
+  .search {
+    width: auto;
+    justify-content: flex-start;
+    margin-left: auto;
+    order: 2;
+  }
+  .actions {
+    order: 3;
+    margin-left: 1rem;
+  }
   .menuButton {
     display: none;
   }
@@ -120,3 +114,4 @@
     transform: translateY(0);
   }
 }
+

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -17,18 +17,6 @@ export default function Header() {
     <header className={styles.header}>
       {open && <div className={styles.overlay} onClick={() => setOpen(false)} />}
       <div className={styles.inner}>
-        <div className={styles.left}>
-          <Link
-            href="/weather"
-            aria-label="Weather details"
-            className={styles.weather}
-          >
-            <WeatherWidget />
-          </Link>
-          <div className={styles.search}>
-            <SearchBar />
-          </div>
-        </div>
         <Link href="/" className={styles.logo}>
           <Image
             src="/images/wt4q-logo.png"
@@ -40,7 +28,14 @@ export default function Header() {
             priority
           />
         </Link>
-        <div className={styles.right}>
+        <Link
+          href="/weather"
+          aria-label="Weather details"
+          className={styles.weather}
+        >
+          <WeatherWidget />
+        </Link>
+        <div className={styles.actions}>
           <button
             className={styles.menuButton}
             onClick={() => setOpen(true)}
@@ -51,6 +46,9 @@ export default function Header() {
           <div className={styles.userMenu}>
             <UserMenu />
           </div>
+        </div>
+        <div className={styles.search}>
+          <SearchBar />
         </div>
       </div>
       <div className={styles.categories}>


### PR DESCRIPTION
## Summary
- reposition logo and weather to left on large screens
- center logo and search bar on small/medium layouts
- convert category navigation to sidebar on screens up to 1024px

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e1e5d928c83279cb4d75d858cf9a2