### PR TITLE
Add advanced search link to search page

### DIFF
--- a/WT4Q/src/app/search/page.tsx
+++ b/WT4Q/src/app/search/page.tsx
@@ -4,6 +4,7 @@ export const dynamic = 'force-dynamic';
 
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import { API_ROUTES } from '@/lib/api';
 import styles from './search.module.css';
@@ -62,6 +63,9 @@ function SearchContent() {
           Search
         </button>
       </form>
+      <Link href="/search/advanced" className={styles.advancedLink}>
+        Advanced search
+      </Link>
       <div className={styles.results}>
         {results.map((a) => (
           <ArticleCard key={a.id} article={a} />

--- a/WT4Q/src/app/search/search.module.css
+++ b/WT4Q/src/app/search/search.module.css
@@ -32,6 +32,18 @@
   transform: translateY(-2px);
 }
 
+.advancedLink {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: var(--primary);
+  text-decoration: underline;
+  transition: color 0.2s;
+}
+
+.advancedLink:hover {
+  color: var(--secondary);
+}
+
 .results {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));


### PR DESCRIPTION
## Summary
- expose advanced search link on standard search page
- style link for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e25035a1483278bd2e869361ae30b