### PR TITLE
feat: add global error boundary

### DIFF
--- a/WT4Q/src/app/error.tsx
+++ b/WT4Q/src/app/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h2 style={{ marginBottom: '1rem' }}>Something went wrong</h2>
+      <p style={{ marginBottom: '1rem' }}>
+        An unexpected error has occurred. Please try again or contact support if the problem
+        persists.
+      </p>
+      <button
+        onClick={() => reset()}
+        style={{
+          padding: '0.5rem 1rem',
+          border: '1px solid var(--muted)',
+          borderRadius: '0.25rem',
+          background: 'var(--background)',
+          color: 'var(--foreground)',
+          cursor: 'pointer'
+        }}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/WT4Q/src/app/global-error.tsx
+++ b/WT4Q/src/app/global-error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body style={{ padding: '2rem', textAlign: 'center' }}>
+        <h2 style={{ marginBottom: '1rem' }}>Something went wrong</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          An unexpected error has occurred. Please try again or contact support if the problem
+          persists.
+        </p>
+        <button
+          onClick={() => reset()}
+          style={{
+            padding: '0.5rem 1rem',
+            border: '1px solid var(--muted)',
+            borderRadius: '0.25rem',
+            background: 'var(--background)',
+            color: 'var(--foreground)',
+            cursor: 'pointer'
+          }}
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add global error component for user friendly handling
- log and allow retry on unexpected failures

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e266b25b48327a13f5de1f825102f