### PR TITLE
feat: add saved city weather with map

### DIFF
--- a/WT4Q/src/app/api/weather/by-city/route.ts
+++ b/WT4Q/src/app/api/weather/by-city/route.ts
@@ -48,6 +48,8 @@ export async function GET(request: Request) {
       JSON.stringify({
         city: name,
         country,
+        latitude,
+        longitude,
         temperature: current.temperature,
         weathercode: current.weathercode,
         isDay: current.is_day === 1,

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -45,6 +45,18 @@
   height: 32px;
 }
 
+.mapContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.map {
+  border: 0;
+  width: 100%;
+  height: 300px;
+}
+
 .windIcon {
   width: 16px;
   height: 16px;
@@ -76,4 +88,17 @@
 
 .time {
   width: 100px;
+}
+
+.saved {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.savedItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- return latitude and longitude from weather-by-city API
- save searched cities locally and display maps for results
- show and remove saved city weather entries

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e29988a3c8327b6d109fed395eab6