### PR TITLE
Add 3‑day forecast boxes for saved cities

### DIFF
--- a/WT4Q/src/app/api/weather/daily-forecast-by-city/route.ts
+++ b/WT4Q/src/app/api/weather/daily-forecast-by-city/route.ts
@@ -1,0 +1,63 @@
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const city = searchParams.get('city');
+  if (!city) {
+    return new Response(JSON.stringify({ message: 'City is required' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  try {
+    const geoRes = await fetch(
+      `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1`
+    );
+    if (!geoRes.ok) {
+      return new Response(JSON.stringify({ message: 'Geocoding failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const geoData = await geoRes.json();
+    if (!geoData.results || geoData.results.length === 0) {
+      return new Response(JSON.stringify({ message: 'City not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const { latitude, longitude } = geoData.results[0];
+
+    const forecastRes = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&forecast_days=3&timezone=auto`
+    );
+    if (!forecastRes.ok) {
+      return new Response(JSON.stringify({ message: 'Weather fetch failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const forecastData = await forecastRes.json();
+    const daily = forecastData.daily;
+    if (!daily || !Array.isArray(daily.time)) {
+      return new Response(JSON.stringify({ message: 'Forecast unavailable' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const forecast = daily.time.map((t: string, i: number) => ({
+      date: t,
+      weathercode: daily.weathercode[i],
+      max: daily.temperature_2m_max[i],
+      min: daily.temperature_2m_min[i],
+    }));
+    return new Response(JSON.stringify({ forecast }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch {
+    return new Response(JSON.stringify({ message: 'Request failed' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/WT4Q/src/app/weather/head.tsx
+++ b/WT4Q/src/app/weather/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <title>Weather Search</title>
+      <meta
+        name="description"
+        content="Check current conditions and 3-day forecasts for your favorite cities."
+      />
+      <meta name="keywords" content="weather, forecast, city" />
+    </>
+  );
+}

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -99,6 +99,37 @@
 
 .savedItem {
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.savedHeader {
+  display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.savedForecast {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.savedForecastDay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.875rem;
+}
+
+.smallIcon {
+  width: 24px;
+  height: 24px;
+}
+
+.day {
+  font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- show saved cities in boxed layout with 3-day forecasts and clickable detail view
- add API route for 3-day daily forecasts
- include basic SEO meta tags for weather page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e375a615c8327983d94ec12243423