### PR TITLE
Notify on city save and extend forecast to seven days

### DIFF
--- a/WT4Q/src/app/api/weather/daily-forecast-by-city/route.ts
+++ b/WT4Q/src/app/api/weather/daily-forecast-by-city/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
     const { latitude, longitude } = geoData.results[0];
 
     const forecastRes = await fetch(
-      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&forecast_days=3&timezone=auto`
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&daily=weathercode,temperature_2m_max,temperature_2m_min&forecast_days=7&timezone=auto`
     );
     if (!forecastRes.ok) {
       return new Response(JSON.stringify({ message: 'Weather fetch failed' }), {

--- a/WT4Q/src/app/weather/head.tsx
+++ b/WT4Q/src/app/weather/head.tsx
@@ -4,7 +4,7 @@ export default function Head() {
       <title>Weather Search</title>
       <meta
         name="description"
-        content="Check current conditions and 3-day forecasts for your favorite cities."
+        content="Check current conditions and 7-day forecasts for your favorite cities."
       />
       <meta name="keywords" content="weather, forecast, city" />
     </>

--- a/WT4Q/src/app/weather/page.tsx
+++ b/WT4Q/src/app/weather/page.tsx
@@ -54,6 +54,7 @@ export default function WeatherPage() {
   const [error, setError] = useState('');
   const [unit, setUnit] = useState<'C' | 'F'>('C');
   const [saved, setSaved] = useState<SavedCity[]>([]);
+  const [notice, setNotice] = useState('');
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem('savedCities') || '[]') as string[];
@@ -92,6 +93,8 @@ export default function WeatherPage() {
       ...saved,
       { ...weather, forecast: Array.isArray(fData.forecast) ? fData.forecast : [] },
     ]);
+    setNotice('City saved');
+    setTimeout(() => setNotice(''), 3000);
   };
 
   const removeCity = (name: string) => {
@@ -156,6 +159,7 @@ export default function WeatherPage() {
         <button type="submit" className={styles.button}>Search</button>
       </form>
       {error && <p className={styles.error}>{error}</p>}
+      {notice && <p className={styles.notice}>{notice}</p>}
       {weather && (
         <>
           <div className={styles.result}>

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -34,6 +34,9 @@
 .error {
   color: red;
 }
+.notice {
+  color: green;
+}
 .result {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- show a "City saved" notice after saving a city
- request and describe seven-day forecasts instead of three

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e477a64f883279c1f14220da59cf8