### PR TITLE
feat: unify button styling across auth pages

### DIFF
--- a/WT4Q/src/app/admin-login/AdminLogin.module.css
+++ b/WT4Q/src/app/admin-login/AdminLogin.module.css
@@ -156,44 +156,6 @@
   color: var(--wt4q-blue);
 }
 
-.button {
-  padding: 0.9rem;
-  font-size: 1rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  border: none;
-  border-radius: 14px;
-  cursor: pointer;
-  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
-  color: #fff;
-  box-shadow:
-    inset 3px 3px 6px var(--metal-shadow),
-    inset -3px -3px 6px var(--metal-reflect),
-    0 6px 15px rgba(0,0,0,0.4);
-  transition: transform 0.1s, box-shadow 0.2s;
-}
-
-.button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow:
-    inset 3px 3px 6px var(--metal-shadow),
-    inset -3px -3px 6px var(--metal-reflect),
-    0 12px 25px rgba(0,0,0,0.45);
-}
-
-.button:active:not(:disabled) {
-  transform: translateY(1px);
-  box-shadow:
-    inset 2px 2px 4px var(--metal-shadow),
-    inset -2px -2px 4px var(--metal-reflect),
-    0 4px 8px rgba(0,0,0,0.3);
-}
-
-.button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 .spinner {
   display: inline-block;

--- a/WT4Q/src/app/admin-login/AdminLoginClient.tsx
+++ b/WT4Q/src/app/admin-login/AdminLoginClient.tsx
@@ -3,6 +3,7 @@
 import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './AdminLogin.module.css';
+import Button from '@/components/Button';
 import { API_ROUTES } from '@/lib/api';
 
 interface LoginRequest {
@@ -125,17 +126,13 @@ const AdminLoginClient: FC = () => {
             </div>
           </div>
 
-          <button
-            type="submit"
-            disabled={isLoading}
-            className={styles.button}
-          >
+          <Button type="submit" disabled={isLoading}>
             {isLoading ? (
               <span className={styles.spinner} aria-hidden="true" />
             ) : (
               'Sign In'
             )}
-          </button>
+          </Button>
         </form>
       </section>
     </main>

--- a/WT4Q/src/app/login/Login.module.css
+++ b/WT4Q/src/app/login/Login.module.css
@@ -156,44 +156,6 @@
   color: var(--wt4q-blue);
 }
 
-.button {
-  padding: 0.9rem;
-  font-size: 1rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  border: none;
-  border-radius: 14px;
-  cursor: pointer;
-  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
-  color: #fff;
-  box-shadow:
-    inset 3px 3px 6px var(--metal-shadow),
-    inset -3px -3px 6px var(--metal-reflect),
-    0 6px 15px rgba(0,0,0,0.4);
-  transition: transform 0.1s, box-shadow 0.2s;
-}
-
-.button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow:
-    inset 3px 3px 6px var(--metal-shadow),
-    inset -3px -3px 6px var(--metal-reflect),
-    0 12px 25px rgba(0,0,0,0.45);
-}
-
-.button:active:not(:disabled) {
-  transform: translateY(1px);
-  box-shadow:
-    inset 2px 2px 4px var(--metal-shadow),
-    inset -2px -2px 4px var(--metal-reflect),
-    0 4px 8px rgba(0,0,0,0.3);
-}
-
-.button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 .spinner {
   display: inline-block;

--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -3,6 +3,7 @@ import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import styles from './Login.module.css';
+import Button from '@/components/Button';
 import { API_ROUTES } from '@/lib/api';
 
 interface LoginRequest {
@@ -129,17 +130,15 @@ const LoginClient: FC = () => {
             </div>
           </div>
 
-          <button type="submit" disabled={isLoading} className={styles.button}>
+          <Button type="submit" disabled={isLoading}>
             {isLoading ? (
               <span className={styles.spinner} aria-hidden="true" />
             ) : (
               'Sign In'
             )}
-          </button>
+          </Button>
         </form>
-        <button onClick={handleGoogleSignIn} className={styles.button}>
-          Sign in with Google
-        </button>
+        <Button onClick={handleGoogleSignIn}>Sign in with Google</Button>
         <p className={styles.switch}>
           Don&apos;t have an account?{' '}
           <Link href="/register" className={styles.switchLink}>

--- a/WT4Q/src/app/register/Register.module.css
+++ b/WT4Q/src/app/register/Register.module.css
@@ -156,44 +156,6 @@
   color: var(--wt4q-blue);
 }
 
-.button {
-  padding: 0.9rem;
-  font-size: 1rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  border: none;
-  border-radius: 14px;
-  cursor: pointer;
-  background: linear-gradient(145deg, var(--wt4q-blue), var(--wt4q-green));
-  color: #fff;
-  box-shadow:
-    inset 3px 3px 6px var(--metal-shadow),
-    inset -3px -3px 6px var(--metal-reflect),
-    0 6px 15px rgba(0,0,0,0.4);
-  transition: transform 0.1s, box-shadow 0.2s;
-}
-
-.button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow:
-    inset 3px 3px 6px var(--metal-shadow),
-    inset -3px -3px 6px var(--metal-reflect),
-    0 12px 25px rgba(0,0,0,0.45);
-}
-
-.button:active:not(:disabled) {
-  transform: translateY(1px);
-  box-shadow:
-    inset 2px 2px 4px var(--metal-shadow),
-    inset -2px -2px 4px var(--metal-reflect),
-    0 4px 8px rgba(0,0,0,0.3);
-}
-
-.button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 .spinner {
   display: inline-block;

--- a/WT4Q/src/app/register/page.tsx
+++ b/WT4Q/src/app/register/page.tsx
@@ -3,6 +3,7 @@ import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import styles from './Register.module.css';
+import Button from '@/components/Button';
 import { API_ROUTES } from '@/lib/api';
 
 interface RegisterRequest {
@@ -191,17 +192,15 @@ const Register: FC = () => {
               className={styles.input}
             />
           </div>
-          <button type="submit" disabled={isLoading} className={styles.button}>
+          <Button type="submit" disabled={isLoading}>
             {isLoading ? (
               <span className={styles.spinner} aria-hidden="true" />
             ) : (
               'Register'
             )}
-          </button>
+          </Button>
         </form>
-        <button onClick={handleGoogleSignIn} className={styles.button}>
-          Sign in with Google
-        </button>
+        <Button onClick={handleGoogleSignIn}>Sign in with Google</Button>
         <p className={styles.switch}>
           Already have an account?{' '}
           <Link href="/login" className={styles.switchLink}>

--- a/WT4Q/src/components/Button.module.css
+++ b/WT4Q/src/components/Button.module.css
@@ -1,0 +1,38 @@
+.button {
+  padding: 0.9rem;
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  background: linear-gradient(145deg, var(--primary), var(--secondary));
+  color: #fff;
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 6px 15px rgba(0,0,0,0.4);
+  transition: transform 0.1s, box-shadow 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 3px 3px 6px var(--metal-shadow),
+    inset -3px -3px 6px var(--metal-reflect),
+    0 12px 25px rgba(0,0,0,0.45);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(1px);
+  box-shadow:
+    inset 2px 2px 4px var(--metal-shadow),
+    inset -2px -2px 4px var(--metal-reflect),
+    0 4px 8px rgba(0,0,0,0.3);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/WT4Q/src/components/Button.tsx
+++ b/WT4Q/src/components/Button.tsx
@@ -1,0 +1,11 @@
+import { ButtonHTMLAttributes, FC } from 'react';
+import styles from './Button.module.css';
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement>;
+
+const Button: FC<Props> = ({ className = '', ...props }) => {
+  return <button className={`${styles.button} ${className}`.trim()} {...props} />;
+};
+
+export default Button;
+


### PR DESCRIPTION
## Summary
- add shared Button component using site-wide color variables
- switch login, admin login, and registration pages to use the shared Button
- drop duplicated page-specific button styles for consistent look

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e617a3aec83279eb847994637d93d