### PR TITLE
feat: add sports category and paper background

### DIFF
--- a/Northeast/Models/Category.cs
+++ b/Northeast/Models/Category.cs
@@ -9,7 +9,8 @@
         Enetrtainment,
         Business,
         Technology,
-        Adult
+        Adult,
+        Sports
 
     }
 }

--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -8,4 +8,5 @@ export const CATEGORIES = [
   'Business',
   'Technology',
   'Adult',
+  'Sports',
 ];

--- a/WT4Q/src/app/globals.css
+++ b/WT4Q/src/app/globals.css
@@ -24,7 +24,12 @@ body {
 
 body {
   color: var(--foreground);
-  background: var(--background);
+  background-color: var(--background);
+  background-image: url('/images/paper_background.webp');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
   font-family: 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/WT4Q/src/app/page.module.css
+++ b/WT4Q/src/app/page.module.css
@@ -1,14 +1,25 @@
+.newspaper {
+  background-color: rgba(255, 255, 255, 0.85);
+  padding: 2rem;
+  margin: 0 auto;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
 .section {
-  font-family: 'Inter', sans-serif;
-  padding: 2rem 1rem;
+  font-family: 'Times New Roman', serif;
+  padding: 2rem 0;
+  border-bottom: 1px solid #ccc;
 }
 
 .heading {
-  text-transform: capitalize;
+  font-family: 'Times New Roman', serif;
+  text-transform: uppercase;
   margin-bottom: 1rem;
-  font-size: 1.75rem;
+  font-size: 2rem;
   font-weight: bold;
   color: var(--primary);
+  border-bottom: 2px solid #333;
 }
 
 .grid {

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -36,7 +36,7 @@ export default async function Home() {
     }))
   );
   return (
-    <>
+    <div className={styles.newspaper}>
       <Hero />
       {categoriesWithArticles.map(({ category, articles }) => (
         <section key={category} className={styles.section}>
@@ -48,6 +48,6 @@ export default async function Home() {
           </div>
         </section>
       ))}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- style homepage with serif headings and a paper-textured background for a newspaper feel
- add Sports to category navigation and backend enum

## Testing
- `npm run lint`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688e70f654b88327a29ed4ffe265606d