### PR TITLE
fix: elevate user menu and add immersive navbar

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -7,6 +7,8 @@
   background: var(--secondary);
   border-radius: 0 0 var(--radius) var(--radius);
   color: #ffffff;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  perspective: 500px;
 }
 
 @media (min-width: 1025px) {
@@ -23,12 +25,13 @@
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
   border: 2px solid transparent;
-  transition: background 0.2s, transform 0.2s;
+  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
 .link:hover {
   background: var(--primary);
-  transform: translateY(-2px);
+  transform: translateY(-2px) translateZ(5px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
 @media (max-width: 1024px) {

--- a/WT4Q/src/components/UserMenu.module.css
+++ b/WT4Q/src/components/UserMenu.module.css
@@ -1,5 +1,6 @@
 .wrapper {
   position: relative;
+  z-index: 1100;
 }
 
 .icon {
@@ -51,7 +52,7 @@
   border: 1px solid var(--secondary);
   border-radius: 8px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
-  z-index: 10;
+  z-index: 1101;
 }
 
 .item {


### PR DESCRIPTION
## Summary
- raise user menu z-index so dropdown stays above navbar and overlay
- add perspective, box-shadow, and 3D hover to category navbar for more immersive feel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f400448b08327a2a93164e26e8b52