### PR TITLE
fix: adjust navbar layering and styling

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -1,14 +1,28 @@
 .nav {
+  position: relative;
   display: flex;
   gap: 1rem;
   overflow-x: auto;
   padding: 0.5rem 1rem;
   font-family: 'Inter', sans-serif;
-  background: var(--secondary);
   border-radius: 0 0 var(--radius) var(--radius);
   color: #ffffff;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   perspective: 500px;
+  z-index: 0;
+  background-image: url('/images/paper_background.webp');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.nav::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 128, 0.5);
+  z-index: -1;
+  border-radius: inherit;
 }
 
 @media (min-width: 1025px) {

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -124,12 +124,18 @@
   .actions {
     order: 3;
     margin-left: 1rem;
-    z-index: 1;
+    z-index: 5;
   }
   .menuButton {
     display: none;
   }
 
+}
+
+@media (max-width: 1024px) {
+  .categories {
+    z-index: 40;
+  }
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
## Summary
- ensure user menu appears above category navbar on large screens
- lift mobile categories above weather/search elements
- style category navbar with paper background to match header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f4b94b4bc832784e63dbb04560f3f