### PR TITLE
Use home icon and button-style links for responsive navbar

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -42,6 +42,14 @@
   transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
+.homeIcon {
+  display: none;
+}
+
+.homeText {
+  display: inline;
+}
+
 .link:hover {
   background: var(--primary);
   transform: translateY(-2px) translateZ(5px);
@@ -66,5 +74,38 @@
 
   .open {
     transform: translateX(0);
+  }
+
+  .link {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    margin: 0 1rem 0.5rem;
+    border-radius: 14px;
+    background: linear-gradient(145deg, var(--primary), var(--secondary));
+    color: #fff;
+    box-shadow:
+      inset 3px 3px 6px var(--metal-shadow),
+      inset -3px -3px 6px var(--metal-reflect),
+      0 6px 15px rgba(0, 0, 0, 0.4);
+    transition: transform 0.1s, box-shadow 0.2s;
+  }
+
+  .link:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      inset 3px 3px 6px var(--metal-shadow),
+      inset -3px -3px 6px var(--metal-reflect),
+      0 12px 25px rgba(0, 0, 0, 0.45);
+  }
+
+  .homeText {
+    display: none;
+  }
+
+  .homeIcon {
+    display: block;
+    width: 1.25rem;
+    height: 1.25rem;
   }
 }

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { CATEGORIES } from '@/lib/categories';
+import HomeIcon from './HomeIcon';
 import styles from './CategoryNavbar.module.css';
 
 interface Props {
@@ -9,7 +10,8 @@ export default function CategoryNavbar({ open }: Props = {}) {
   return (
     <nav className={`${styles.nav} ${open ? styles.open : ''}`} aria-label="categories">
       <Link href="/" className={styles.link}>
-        Home
+        <span className={styles.homeText}>Home</span>
+        <HomeIcon className={styles.homeIcon} />
       </Link>
       {CATEGORIES.map((c) => (
         <Link key={c} href={`/category/${c}`} className={styles.link}>

--- a/WT4Q/src/components/HomeIcon.tsx
+++ b/WT4Q/src/components/HomeIcon.tsx
@@ -1,0 +1,20 @@
+export default function HomeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2v-5H9v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9z"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add reusable `HomeIcon` SVG component
- Replace "Home" text with icon and show button-style links on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f4e9b317c832787df37ae9191c61e