### PR TITLE
Fix CategoryNavbar JSX structure

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -10,18 +10,23 @@ interface Props {
 
 export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
   return (
-
+    <nav className={`${styles.nav} ${open ? styles.open : ''}`}>
       <Link href="/" className={styles.link} onClick={onNavigate}>
-        Home
-
+        <HomeIcon className={styles.homeIcon} />
+        <span className={styles.homeText}>Home</span>
       </Link>
       {CATEGORIES.map((c) => (
-        <Link key={c} href={`/category/${c}`} className={styles.link} onClick={onNavigate}>
+        <Link
+          key={c}
+          href={`/category/${c}`}
+          className={styles.link}
+          onClick={onNavigate}
+        >
           {c}
         </Link>
       ))}
       <Link href="/weather" className={styles.link} onClick={onNavigate}>
-       Weather
+        Weather
       </Link>
       <Link href="/bar" className={styles.link} onClick={onNavigate}>
         Bar


### PR DESCRIPTION
## Summary
- wrap category links in a `<nav>` element and restore home icon and label

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f523c466083278cc0c75c28078b0d