### PR TITLE
Add breaking news section with API and UI integration

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -47,6 +47,17 @@ namespace Northeast.Controllers
 
         }
 
+        [HttpGet("breaking")]
+        public async Task<IActionResult> GetBreakingNews()
+        {
+            var articles = await articleUpload.GetBreakingNews();
+            if (!articles.Any())
+            {
+                return NotFound(new { message = "No breaking news available" });
+            }
+            return Ok(articles);
+        }
+
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(Guid id)
         {

--- a/Northeast/DTOs/ArticleDto.cs
+++ b/Northeast/DTOs/ArticleDto.cs
@@ -20,6 +20,8 @@ namespace Northeast.DTOs
         [Required]
         public string Description { get; set; }
 
+        public bool IsBreakingNews { get; set; } = false;
+
         public List<byte[]>? Photo { get; set; }
         public string? PhotoLink { get; set; }
         public string? EmbededCode { get; set; }

--- a/Northeast/Models/Article.cs
+++ b/Northeast/Models/Article.cs
@@ -23,7 +23,10 @@ namespace Northeast.Models
         public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
         [Required]
         public string Description { get; set; }
-       
+
+        [DefaultValue(false)]
+        public bool IsBreakingNews { get; set; } = false;
+
         public List<byte[]>? Photo { get; set; }
         public string? PhotoLink { get; set; }
         public string? EmbededCode { get; set; }

--- a/Northeast/Repository/ArticleRepository.cs
+++ b/Northeast/Repository/ArticleRepository.cs
@@ -177,6 +177,15 @@ namespace Northeast.Repository
             return scored;
         }
 
+        public async Task<IEnumerable<Article>> GetBreakingNews()
+        {
+            var cutoff = DateTime.UtcNow.AddDays(-3);
+            return await _context.Articles.AsNoTracking()
+                .Where(a => a.ArticleType == ArticleType.News && a.IsBreakingNews && a.CreatedDate >= cutoff)
+                .OrderByDescending(a => a.CreatedDate)
+                .ToListAsync();
+        }
+
         private static double CalculateSimilarity(Article a, Article b)
         {
             double score = 0;

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -41,6 +41,7 @@ namespace Northeast.Services
                 CreatedDate = DateTime.UtcNow,
                 ArticleType= articleDto.ArticleType,
                 Description= articleDto.Description,
+                IsBreakingNews = articleDto.ArticleType == ArticleType.News && articleDto.IsBreakingNews,
                 Photo = articleDto.Photo ?? null,
                 PhotoLink = articleDto.PhotoLink,
                 EmbededCode = articleDto.EmbededCode,
@@ -96,6 +97,10 @@ namespace Northeast.Services
         {
             return await _articleRepository.GetRecommendedArticles(articleId, count);
         }
+        public async Task<IEnumerable<Article>> GetBreakingNews()
+        {
+            return await _articleRepository.GetBreakingNews();
+        }
         public async Task<LikeEntity> GetLikeByUserAndArticle(Guid ArticleId)
         {
            var UserId = _connectedUser.Id;
@@ -120,6 +125,7 @@ namespace Northeast.Services
             article.Category = articleDto.Category;
             article.ArticleType = articleDto.ArticleType;
             article.Description = articleDto.Description;
+            article.IsBreakingNews = articleDto.ArticleType == ArticleType.News && articleDto.IsBreakingNews;
             article.Photo = articleDto.Photo;
             article.PhotoLink = articleDto.PhotoLink;
             article.EmbededCode = articleDto.EmbededCode;

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -39,6 +39,7 @@ export const API_ROUTES = {
     COMMENT: `${API_BASE_URL}/api/Article/Comment`,
     MODIFY_COMMENT: `${API_BASE_URL}/api/Article/ModifyComment`,
     SEARCH_BY_AUTHOR: (id: string) => `${API_BASE_URL}/api/ArticleSearch/by-author/${id}`,
+    BREAKING: `${API_BASE_URL}/api/Article/breaking`,
   },
 
   COCKTAIL: {

--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -11,6 +11,7 @@ interface ArticleDetails {
   title: string;
   description: string;
   createdDate: string;
+  isBreakingNews?: boolean;
   countryName?: string;
   photo?: string[];
   photoLink?: string;
@@ -75,9 +76,16 @@ export default async function ArticlePage({
   if (!article) {
     return <div className={styles.container}>Article not found.</div>;
   }
+  const isBreakingActive =
+    article.isBreakingNews &&
+    new Date(article.createdDate) >=
+      new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
   const related = await fetchRelated(id);
   return (
     <div className={styles.container}>
+      {isBreakingActive && (
+        <div className={styles.breaking}>Breaking News</div>
+      )}
       <h1 className={styles.title}>{article.title}</h1>
       <p className={styles.meta}>
         {new Date(article.createdDate).toLocaleDateString(undefined, {

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -45,6 +45,15 @@
   gap: 1rem;
 }
 
+.breaking {
+  background: red;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-weight: bold;
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 700px) {
   .grid {
     grid-template-columns: 1fr;

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -1,5 +1,6 @@
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import Hero from '@/components/Hero';
+import BreakingNewsSlider from '@/components/BreakingNewsSlider';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
 import type { Metadata } from 'next';
@@ -28,6 +29,16 @@ async function fetchArticlesByCategory(cat: string): Promise<Article[]> {
   }
 }
 
+async function fetchBreakingNews(): Promise<{ id: string; title: string }[]> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.BREAKING, { cache: 'no-store' });
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
 export default async function Home() {
   const categoriesWithArticles = await Promise.all(
     CATEGORIES.map(async (c) => ({
@@ -35,9 +46,11 @@ export default async function Home() {
       articles: await fetchArticlesByCategory(c),
     }))
   );
+  const breaking = await fetchBreakingNews();
   return (
     <div className={styles.newspaper}>
       <Hero />
+      <BreakingNewsSlider articles={breaking} />
       {categoriesWithArticles.map(({ category, articles }) => (
         <section key={category} className={styles.section}>
           <h2 className={styles.heading}>{category}</h2>

--- a/WT4Q/src/components/BreakingNewsSlider.module.css
+++ b/WT4Q/src/components/BreakingNewsSlider.module.css
@@ -1,0 +1,33 @@
+.slider {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  margin: 1rem 0;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.item {
+  display: block;
+  font-weight: bold;
+}
+
+.dots {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
+  gap: 0.25rem;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  border: none;
+  cursor: pointer;
+}
+
+.active {
+  background: #fff;
+}

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import styles from './BreakingNewsSlider.module.css';
+
+export interface BreakingArticle {
+  id: string;
+  title: string;
+}
+
+export default function BreakingNewsSlider({
+  articles,
+}: {
+  articles: BreakingArticle[];
+}) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (articles.length === 0) return;
+    const interval = setInterval(() => {
+      setIndex((i) => (i + 1) % articles.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [articles]);
+
+  if (articles.length === 0) return null;
+
+  return (
+    <div className={styles.slider}>
+      <Link href={`/articles/${articles[index].id}`} className={styles.item}>
+        {articles[index].title}
+      </Link>
+      <div className={styles.dots}>
+        {articles.map((_, i) => (
+          <button
+            key={i}
+            className={`${styles.dot} ${i === index ? styles.active : ''}`}
+            onClick={() => setIndex(i)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `IsBreakingNews` flag to articles with service, repository and controller support
- Expose `/api/Article/breaking` and integrate on frontend with a rotating Breaking News slider
- Highlight active breaking news on article pages

## Testing
- `dotnet build`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f559109d48327910a64366a62e385