### PR TITLE
feat: add global breaking news ticker

### DIFF
--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import CookieBanner from "@/components/CookieBanner";
 import PageVisitReporter from "@/components/PageVisitReporter";
+import BreakingNewsBar from "@/components/BreakingNewsBar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -51,6 +52,7 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <PageVisitReporter />
         <Header />
+        <BreakingNewsBar />
         <main>{children}</main>
         <Footer />
         <CookieBanner />

--- a/WT4Q/src/components/BreakingNewsBar.module.css
+++ b/WT4Q/src/components/BreakingNewsBar.module.css
@@ -1,0 +1,4 @@
+.bar {
+  margin: 0;
+  border-radius: 0;
+}

--- a/WT4Q/src/components/BreakingNewsBar.tsx
+++ b/WT4Q/src/components/BreakingNewsBar.tsx
@@ -1,0 +1,15 @@
+import BreakingNewsSlider, { BreakingArticle } from './BreakingNewsSlider';
+import { API_ROUTES } from '@/lib/api';
+import styles from './BreakingNewsBar.module.css';
+
+export default async function BreakingNewsBar() {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.BREAKING, { cache: 'no-store' });
+    if (!res.ok) return null;
+    const articles: BreakingArticle[] = await res.json();
+    if (!Array.isArray(articles) || articles.length === 0) return null;
+    return <BreakingNewsSlider articles={articles} className={styles.bar} />;
+  } catch {
+    return null;
+  }
+}

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -10,8 +10,10 @@ export interface BreakingArticle {
 
 export default function BreakingNewsSlider({
   articles,
+  className,
 }: {
   articles: BreakingArticle[];
+  className?: string;
 }) {
   const [index, setIndex] = useState(0);
 
@@ -26,7 +28,7 @@ export default function BreakingNewsSlider({
   if (articles.length === 0) return null;
 
   return (
-    <div className={styles.slider}>
+    <div className={`${styles.slider} ${className ?? ''}`.trim()}>
       <Link href={`/articles/${articles[index].id}`} className={styles.item}>
         {articles[index].title}
       </Link>


### PR DESCRIPTION
## Summary
- show breaking news across site with new BreakingNewsBar
- allow BreakingNewsSlider styling override with className
- expose ticker below header in layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: useSearchParams should be wrapped in suspense boundary at /contact)*

------
https://chatgpt.com/codex/tasks/task_e_688f72797b208327a98a8fb3566e9435