### PR TITLE
Add About page and footer link

### DIFF
--- a/WT4Q/src/app/about/page.module.css
+++ b/WT4Q/src/app/about/page.module.css
@@ -1,0 +1,19 @@
+.container {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+  font-family: 'Inter', sans-serif;
+  line-height: 1.6;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: var(--primary);
+}
+
+.heading {
+  margin-top: 1.5rem;
+  font-size: 1.5rem;
+  color: var(--primary);
+}

--- a/WT4Q/src/app/about/page.tsx
+++ b/WT4Q/src/app/about/page.tsx
@@ -1,0 +1,26 @@
+import styles from './page.module.css';
+
+export const metadata = {
+  title: 'About WT4Q',
+};
+
+export default function AboutPage() {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>About WT4Q</h1>
+      <p>
+        WT4Q is your source for local and global news, providing timely updates
+        and in-depth stories that matter to our community.
+      </p>
+      <p>
+        Our team is dedicated to accurate reporting and thoughtful commentary.
+        We strive to highlight diverse voices and perspectives from around the
+        region.
+      </p>
+      <p>
+        Have feedback or story ideas? We&apos;d love to hear from you. Reach out via
+        our contact page and help us make WT4Q even better.
+      </p>
+    </div>
+  );
+}

--- a/WT4Q/src/components/Footer.tsx
+++ b/WT4Q/src/components/Footer.tsx
@@ -9,6 +9,8 @@ export default function Footer() {
         <span aria-hidden="true">|</span>{' '}
         <Link href="/terms">Terms &amp; Cookies</Link>{' '}
         <span aria-hidden="true">|</span>{' '}
+        <Link href="/about">About</Link>{' '}
+        <span aria-hidden="true">|</span>{' '}
         <Link href="/contact?type=problem">Report a Problem</Link>{' '}
         <span aria-hidden="true">|</span>{' '}
         <Link href="/contact">Contact Us</Link>


### PR DESCRIPTION
## Summary
- add descriptive About page
- link to the About page from the site footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7b489eac8327a9d6706251734c12