### PR TITLE
Handle unauthenticated requests in GetConnectedUser

### DIFF
--- a/Northeast/Utilities/GetConnectedUser.cs
+++ b/Northeast/Utilities/GetConnectedUser.cs
@@ -7,54 +7,63 @@ namespace Northeast.Utilities
 {
     public class GetConnectedUser
     {
-        public Guid Id { get; set; }
-        public string Id_String { get; set; }
-
         private readonly IHttpContextAccessor _httpContextAccessor;
 
         public GetConnectedUser(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
-            Id = GetUserid();
-            Id_String = GetUseridtoString();
         }
+
+        public Guid Id => GetUserid();
+
+        public string Id_String => Id.ToString();
+
         public Guid GetUserid()
         {
-            var user = _httpContextAccessor.HttpContext.User;
-            if (!user.Identity.IsAuthenticated)
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext == null)
             {
-                Console.WriteLine("User is not authenticated.");
                 return Guid.Empty;
             }
-            var userId = _httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
 
+            var user = httpContext.User;
+            if (user?.Identity?.IsAuthenticated != true)
+            {
+                return Guid.Empty;
+            }
+
+            var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
 
             if (string.IsNullOrEmpty(userId))
             {
                 return Guid.Empty;
-
             }
+
             if (!Guid.TryParse(userId, out var userGuid))
             {
-
                 return Guid.Empty;
             }
 
-
             return userGuid;
         }
+
         public string GetUseridtoString()
         {
-
             return GetUserid().ToString();
         }
-        public string GetUserIP()
+
+        public string? GetUserIP()
         {
-            var ipAddress = _httpContextAccessor.HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault() ??
-             _httpContextAccessor.HttpContext.Connection.RemoteIpAddress?.ToString();
+            var httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext == null)
+            {
+                return null;
+            }
+
+            var ipAddress = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault() ??
+                            httpContext.Connection.RemoteIpAddress?.ToString();
             return ipAddress;
         }
-
     }
 }
 


### PR DESCRIPTION
## Summary
- compute user identifiers lazily to avoid early authentication checks
- return empty GUID or null when HttpContext is missing instead of writing to console
- allow GetUserIP to fall back gracefully when no HTTP context is available

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*
- `dotnet build Northeast/Northeast.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6890c28498248327b2ac985a0e81e6e3