### PR TITLE
Fix vendor-prefixed text clipping

### DIFF
--- a/WT4Q/src/app/globals.css
+++ b/WT4Q/src/app/globals.css
@@ -88,7 +88,9 @@ a {
 .shinyText {
   background: var(--metal-gradient);
   -webkit-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 button {


### PR DESCRIPTION
## Summary
- Add standard `background-clip` and transparent color to `.shinyText` for better browser compatibility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890d3d2a174832786709c3650a6e4b9