### PR TITLE
feat: add world clock tool

### DIFF
--- a/WT4Q/lib/worldCities.ts
+++ b/WT4Q/lib/worldCities.ts
@@ -1,0 +1,804 @@
+export interface WorldCity { name: string; lat: number; lon: number; country: string; timezone: string; population: number;}
+
+export const WORLD_CITIES: WorldCity[] = [
+  {
+    "name": "Shanghai",
+    "lat": 31.22222,
+    "lon": 121.45806,
+    "country": "CN",
+    "population": 24874500,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Beijing",
+    "lat": 39.9075,
+    "lon": 116.39723,
+    "country": "CN",
+    "population": 18960744,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Shenzhen",
+    "lat": 22.54554,
+    "lon": 114.0683,
+    "country": "CN",
+    "population": 17494398,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Guangzhou",
+    "lat": 23.11667,
+    "lon": 113.25,
+    "country": "CN",
+    "population": 16096724,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Kinshasa",
+    "lat": -4.32758,
+    "lon": 15.31357,
+    "country": "CD",
+    "population": 16000000,
+    "timezone": "Africa/Kinshasa"
+  },
+  {
+    "name": "Istanbul",
+    "lat": 41.01384,
+    "lon": 28.94966,
+    "country": "TR",
+    "population": 15701602,
+    "timezone": "Europe/Istanbul"
+  },
+  {
+    "name": "Lagos",
+    "lat": 6.45407,
+    "lon": 3.39467,
+    "country": "NG",
+    "population": 15388000,
+    "timezone": "Africa/Lagos"
+  },
+  {
+    "name": "Ho Chi Minh City",
+    "lat": 10.82302,
+    "lon": 106.62965,
+    "country": "VN",
+    "population": 14002598,
+    "timezone": "Asia/Ho_Chi_Minh"
+  },
+  {
+    "name": "Chengdu",
+    "lat": 30.66667,
+    "lon": 104.06667,
+    "country": "CN",
+    "population": 13568357,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Lahore",
+    "lat": 31.558,
+    "lon": 74.35071,
+    "country": "PK",
+    "population": 13004135,
+    "timezone": "Asia/Karachi"
+  },
+  {
+    "name": "Mumbai",
+    "lat": 19.07283,
+    "lon": 72.88261,
+    "country": "IN",
+    "population": 12691836,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "São Paulo",
+    "lat": -23.5475,
+    "lon": -46.63611,
+    "country": "BR",
+    "population": 12400232,
+    "timezone": "America/Sao_Paulo"
+  },
+  {
+    "name": "Mexico City",
+    "lat": 19.42847,
+    "lon": -99.12766,
+    "country": "MX",
+    "population": 12294193,
+    "timezone": "America/Mexico_City"
+  },
+  {
+    "name": "Karachi",
+    "lat": 24.8608,
+    "lon": 67.0104,
+    "country": "PK",
+    "population": 11624219,
+    "timezone": "Asia/Karachi"
+  },
+  {
+    "name": "Tianjin",
+    "lat": 39.14222,
+    "lon": 117.17667,
+    "country": "CN",
+    "population": 11090314,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Delhi",
+    "lat": 28.65195,
+    "lon": 77.23149,
+    "country": "IN",
+    "population": 11034555,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Wuhan",
+    "lat": 30.58333,
+    "lon": 114.26667,
+    "country": "CN",
+    "population": 10392693,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Moscow",
+    "lat": 55.75222,
+    "lon": 37.61556,
+    "country": "RU",
+    "population": 10381222,
+    "timezone": "Europe/Moscow"
+  },
+  {
+    "name": "Dhaka",
+    "lat": 23.7104,
+    "lon": 90.40744,
+    "country": "BD",
+    "population": 10356500,
+    "timezone": "Asia/Dhaka"
+  },
+  {
+    "name": "Seoul",
+    "lat": 37.566,
+    "lon": 126.9784,
+    "country": "KR",
+    "population": 10349312,
+    "timezone": "Asia/Seoul"
+  },
+  {
+    "name": "Tokyo",
+    "lat": 35.6895,
+    "lon": 139.69171,
+    "country": "JP",
+    "population": 9733276,
+    "timezone": "Asia/Tokyo"
+  },
+  {
+    "name": "Dongguan",
+    "lat": 23.01797,
+    "lon": 113.74866,
+    "country": "CN",
+    "population": 9644871,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Cairo",
+    "lat": 30.06263,
+    "lon": 31.24967,
+    "country": "EG",
+    "population": 9606916,
+    "timezone": "Africa/Cairo"
+  },
+  {
+    "name": "Xi’an",
+    "lat": 34.25833,
+    "lon": 108.92861,
+    "country": "CN",
+    "population": 9600000,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Johannesburg",
+    "lat": -26.20227,
+    "lon": 28.04363,
+    "country": "ZA",
+    "population": 9418183,
+    "timezone": "Africa/Johannesburg"
+  },
+  {
+    "name": "Nanjing",
+    "lat": 32.06167,
+    "lon": 118.77778,
+    "country": "CN",
+    "population": 9314685,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Hangzhou",
+    "lat": 30.29365,
+    "lon": 120.16142,
+    "country": "CN",
+    "population": 9236032,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Foshan",
+    "lat": 23.02677,
+    "lon": 113.13148,
+    "country": "CN",
+    "population": 9042509,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "London",
+    "lat": 51.50853,
+    "lon": -0.12574,
+    "country": "GB",
+    "population": 8961989,
+    "timezone": "Europe/London"
+  },
+  {
+    "name": "New York City",
+    "lat": 40.71427,
+    "lon": -74.00597,
+    "country": "US",
+    "population": 8804190,
+    "timezone": "America/New_York"
+  },
+  {
+    "name": "Jakarta",
+    "lat": -6.21462,
+    "lon": 106.84513,
+    "country": "ID",
+    "population": 8540121,
+    "timezone": "Asia/Jakarta"
+  },
+  {
+    "name": "Bengaluru",
+    "lat": 12.97194,
+    "lon": 77.59369,
+    "country": "IN",
+    "population": 8495492,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Hanoi",
+    "lat": 21.0245,
+    "lon": 105.84117,
+    "country": "VN",
+    "population": 8053663,
+    "timezone": "Asia/Bangkok"
+  },
+  {
+    "name": "Taipei",
+    "lat": 25.05306,
+    "lon": 121.52639,
+    "country": "TW",
+    "population": 7871900,
+    "timezone": "Asia/Taipei"
+  },
+  {
+    "name": "Lima",
+    "lat": -12.04318,
+    "lon": -77.02824,
+    "country": "PE",
+    "population": 7737002,
+    "timezone": "America/Lima"
+  },
+  {
+    "name": "Bogotá",
+    "lat": 4.60971,
+    "lon": -74.08175,
+    "country": "CO",
+    "population": 7674366,
+    "timezone": "America/Bogota"
+  },
+  {
+    "name": "Chongqing",
+    "lat": 29.56026,
+    "lon": 106.55771,
+    "country": "CN",
+    "population": 7457599,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Hong Kong",
+    "lat": 22.27832,
+    "lon": 114.17469,
+    "country": "HK",
+    "population": 7396076,
+    "timezone": "Asia/Hong_Kong"
+  },
+  {
+    "name": "Baghdad",
+    "lat": 33.34058,
+    "lon": 44.40088,
+    "country": "IQ",
+    "population": 7216000,
+    "timezone": "Asia/Baghdad"
+  },
+  {
+    "name": "Qingdao",
+    "lat": 36.06488,
+    "lon": 120.38042,
+    "country": "CN",
+    "population": 7172451,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Tehran",
+    "lat": 35.69439,
+    "lon": 51.42151,
+    "country": "IR",
+    "population": 7153309,
+    "timezone": "Asia/Tehran"
+  },
+  {
+    "name": "Shenyang",
+    "lat": 41.79222,
+    "lon": 123.43278,
+    "country": "CN",
+    "population": 7050000,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Hyderābād",
+    "lat": 17.38405,
+    "lon": 78.45636,
+    "country": "IN",
+    "population": 6809970,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Rio de Janeiro",
+    "lat": -22.90642,
+    "lon": -43.18223,
+    "country": "BR",
+    "population": 6747815,
+    "timezone": "America/Sao_Paulo"
+  },
+  {
+    "name": "Suzhou",
+    "lat": 31.30408,
+    "lon": 120.59538,
+    "country": "CN",
+    "population": 6715559,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Ahmedabad",
+    "lat": 23.02579,
+    "lon": 72.58727,
+    "country": "IN",
+    "population": 6357693,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Abidjan",
+    "lat": 5.35444,
+    "lon": -4.00167,
+    "country": "CI",
+    "population": 6321017,
+    "timezone": "Africa/Abidjan"
+  },
+  {
+    "name": "Singapore",
+    "lat": 1.28967,
+    "lon": 103.85007,
+    "country": "SG",
+    "population": 5638700,
+    "timezone": "Asia/Singapore"
+  },
+  {
+    "name": "Sydney",
+    "lat": -33.86785,
+    "lon": 151.20732,
+    "country": "AU",
+    "population": 5557233,
+    "timezone": "Australia/Sydney"
+  },
+  {
+    "name": "Dar es Salaam",
+    "lat": -6.82349,
+    "lon": 39.26951,
+    "country": "TZ",
+    "population": 5383728,
+    "timezone": "Africa/Dar_es_Salaam"
+  },
+  {
+    "name": "Saint Petersburg",
+    "lat": 59.93863,
+    "lon": 30.31413,
+    "country": "RU",
+    "population": 5351935,
+    "timezone": "Europe/Moscow"
+  },
+  {
+    "name": "Melbourne",
+    "lat": -37.814,
+    "lon": 144.96332,
+    "country": "AU",
+    "population": 5350705,
+    "timezone": "Australia/Melbourne"
+  },
+  {
+    "name": "Alexandria",
+    "lat": 31.20176,
+    "lon": 29.91582,
+    "country": "EG",
+    "population": 5263542,
+    "timezone": "Africa/Cairo"
+  },
+  {
+    "name": "Harbin",
+    "lat": 45.75,
+    "lon": 126.65,
+    "country": "CN",
+    "population": 5242897,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Bangkok",
+    "lat": 13.75398,
+    "lon": 100.50144,
+    "country": "TH",
+    "population": 5104476,
+    "timezone": "Asia/Bangkok"
+  },
+  {
+    "name": "Hefei",
+    "lat": 31.86389,
+    "lon": 117.28083,
+    "country": "CN",
+    "population": 5050000,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Dalian",
+    "lat": 38.91222,
+    "lon": 121.60222,
+    "country": "CN",
+    "population": 4913879,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Kano",
+    "lat": 12.00012,
+    "lon": 8.51672,
+    "country": "NG",
+    "population": 4910000,
+    "timezone": "Africa/Lagos"
+  },
+  {
+    "name": "Santiago",
+    "lat": -33.45694,
+    "lon": -70.64827,
+    "country": "CL",
+    "population": 4837295,
+    "timezone": "America/Santiago"
+  },
+  {
+    "name": "Cape Town",
+    "lat": -33.92584,
+    "lon": 18.42322,
+    "country": "ZA",
+    "population": 4772846,
+    "timezone": "Africa/Johannesburg"
+  },
+  {
+    "name": "Peshawar",
+    "lat": 34.008,
+    "lon": 71.57849,
+    "country": "PK",
+    "population": 4758762,
+    "timezone": "Asia/Karachi"
+  },
+  {
+    "name": "Changchun",
+    "lat": 43.88,
+    "lon": 125.32278,
+    "country": "CN",
+    "population": 4714996,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Jeddah",
+    "lat": 21.49012,
+    "lon": 39.18624,
+    "country": "SA",
+    "population": 4697000,
+    "timezone": "Asia/Riyadh"
+  },
+  {
+    "name": "Chennai",
+    "lat": 13.08784,
+    "lon": 80.27847,
+    "country": "IN",
+    "population": 4681087,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Kolkata",
+    "lat": 22.56263,
+    "lon": 88.36304,
+    "country": "IN",
+    "population": 4631392,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Xiamen",
+    "lat": 24.47979,
+    "lon": 118.08187,
+    "country": "CN",
+    "population": 4617251,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Surat",
+    "lat": 21.19594,
+    "lon": 72.83023,
+    "country": "IN",
+    "population": 4591246,
+    "timezone": "Asia/Kolkata"
+  },
+  {
+    "name": "Yangon",
+    "lat": 16.80528,
+    "lon": 96.15611,
+    "country": "MM",
+    "population": 4477638,
+    "timezone": "Asia/Yangon"
+  },
+  {
+    "name": "Bao'an",
+    "lat": 22.55213,
+    "lon": 113.88288,
+    "country": "CN",
+    "population": 4476554,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Kabul",
+    "lat": 34.52813,
+    "lon": 69.17233,
+    "country": "AF",
+    "population": 4434550,
+    "timezone": "Asia/Kabul"
+  },
+  {
+    "name": "Nairobi",
+    "lat": -1.28333,
+    "lon": 36.81667,
+    "country": "KE",
+    "population": 4397073,
+    "timezone": "Africa/Nairobi"
+  },
+  {
+    "name": "Wuxi",
+    "lat": 31.56887,
+    "lon": 120.28857,
+    "country": "CN",
+    "population": 4396835,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Giza",
+    "lat": 30.00944,
+    "lon": 31.20861,
+    "country": "EG",
+    "population": 4367343,
+    "timezone": "Africa/Cairo"
+  },
+  {
+    "name": "Jinan",
+    "lat": 36.66833,
+    "lon": 116.99722,
+    "country": "CN",
+    "population": 4335989,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Taiyuan",
+    "lat": 37.86944,
+    "lon": 112.56028,
+    "country": "CN",
+    "population": 4303673,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Zhengzhou",
+    "lat": 34.75778,
+    "lon": 113.64861,
+    "country": "CN",
+    "population": 4253913,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Bamako",
+    "lat": 12.60915,
+    "lon": -7.97522,
+    "country": "ML",
+    "population": 4227569,
+    "timezone": "Africa/Bamako"
+  },
+  {
+    "name": "Riyadh",
+    "lat": 24.68773,
+    "lon": 46.72185,
+    "country": "SA",
+    "population": 4205961,
+    "timezone": "Asia/Riyadh"
+  },
+  {
+    "name": "New Taipei City",
+    "lat": 25.06199,
+    "lon": 121.45703,
+    "country": "TW",
+    "population": 4004367,
+    "timezone": "Asia/Taipei"
+  },
+  {
+    "name": "New Territories",
+    "lat": 22.42441,
+    "lon": 114.11095,
+    "country": "HK",
+    "population": 3984077,
+    "timezone": "Asia/Hong_Kong"
+  },
+  {
+    "name": "Shijiazhuang",
+    "lat": 38.04139,
+    "lon": 114.47861,
+    "country": "CN",
+    "population": 3938513,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Chattogram",
+    "lat": 22.3384,
+    "lon": 91.83168,
+    "country": "BD",
+    "population": 3920222,
+    "timezone": "Asia/Dhaka"
+  },
+  {
+    "name": "Addis Ababa",
+    "lat": 9.02497,
+    "lon": 38.74689,
+    "country": "ET",
+    "population": 3860000,
+    "timezone": "Africa/Addis_Ababa"
+  },
+  {
+    "name": "Kunming",
+    "lat": 25.03889,
+    "lon": 102.71833,
+    "country": "CN",
+    "population": 3855346,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Zhongshan",
+    "lat": 22.52306,
+    "lon": 113.37912,
+    "country": "CN",
+    "population": 3841873,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Nanning",
+    "lat": 22.81667,
+    "lon": 108.31667,
+    "country": "CN",
+    "population": 3839800,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Shantou",
+    "lat": 23.35489,
+    "lon": 116.67876,
+    "country": "CN",
+    "population": 3838900,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Los Angeles",
+    "lat": 34.05223,
+    "lon": -118.24368,
+    "country": "US",
+    "population": 3820914,
+    "timezone": "America/Los_Angeles"
+  },
+  {
+    "name": "Faisalabad",
+    "lat": 31.41554,
+    "lon": 73.08969,
+    "country": "PK",
+    "population": 3800193,
+    "timezone": "Asia/Karachi"
+  },
+  {
+    "name": "Dubai",
+    "lat": 25.07725,
+    "lon": 55.30927,
+    "country": "AE",
+    "population": 3790000,
+    "timezone": "Asia/Dubai"
+  },
+  {
+    "name": "Yokohama",
+    "lat": 35.43333,
+    "lon": 139.65,
+    "country": "JP",
+    "population": 3777491,
+    "timezone": "Asia/Tokyo"
+  },
+  {
+    "name": "Fuzhou",
+    "lat": 26.06139,
+    "lon": 119.30611,
+    "country": "CN",
+    "population": 3740000,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Ningbo",
+    "lat": 29.87819,
+    "lon": 121.54945,
+    "country": "CN",
+    "population": 3731203,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Casablanca",
+    "lat": 33.58831,
+    "lon": -7.61138,
+    "country": "MA",
+    "population": 3665954,
+    "timezone": "Africa/Casablanca"
+  },
+  {
+    "name": "Ibadan",
+    "lat": 7.37756,
+    "lon": 3.90591,
+    "country": "NG",
+    "population": 3649000,
+    "timezone": "Africa/Lagos"
+  },
+  {
+    "name": "Puyang",
+    "lat": 29.45679,
+    "lon": 119.88872,
+    "country": "CN",
+    "population": 3590000,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Ankara",
+    "lat": 39.91987,
+    "lon": 32.85427,
+    "country": "TR",
+    "population": 3517182,
+    "timezone": "Europe/Istanbul"
+  },
+  {
+    "name": "Shiyan",
+    "lat": 32.6475,
+    "lon": 110.77806,
+    "country": "CN",
+    "population": 3460000,
+    "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Berlin",
+    "lat": 52.52437,
+    "lon": 13.41053,
+    "country": "DE",
+    "population": 3426354,
+    "timezone": "Europe/Berlin"
+  },
+  {
+    "name": "Tangshan",
+    "lat": 39.64381,
+    "lon": 118.18319,
+    "country": "CN",
+    "population": 3372102,
+    "timezone": "Asia/Shanghai"
+  }
+] as const;

--- a/WT4Q/src/app/tools/page.tsx
+++ b/WT4Q/src/app/tools/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Tools',
+  description: 'Handy utilities including a world clock with weather data.',
+};
+
+export default function ToolsPage() {
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Tools</h1>
+      <ul>
+        <li>
+          <Link href="/tools/world-clock">World Clock</Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/WT4Q/src/app/tools/world-clock/WorldClock.module.css
+++ b/WT4Q/src/app/tools/world-clock/WorldClock.module.css
@@ -1,0 +1,40 @@
+.container {
+  padding: 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.city {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.time {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.weather {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.icon {
+  width: 1.5rem;
+  height: 1.5rem;
+}

--- a/WT4Q/src/app/tools/world-clock/page.tsx
+++ b/WT4Q/src/app/tools/world-clock/page.tsx
@@ -1,0 +1,58 @@
+// Data courtesy of Open-Meteo (https://open-meteo.com/)
+import WeatherIcon from '@/components/WeatherIcon';
+import { WORLD_CITIES, WorldCity } from '@/lib/worldCities';
+import styles from './WorldClock.module.css';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'World Clock – Global Time & Weather',
+  description: 'Current local time and weather for 100 major cities around the world.',
+  keywords: ['world clock', 'global time', 'weather', 'cities', 'tools'],
+};
+
+interface CityWeather extends WorldCity {
+  time: string;
+  temperature: number;
+  weathercode: number;
+  is_day: number;
+}
+
+async function fetchCity(city: WorldCity): Promise<CityWeather> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&current_weather=true&timezone=${encodeURIComponent(city.timezone)}`;
+  const res = await fetch(url, { next: { revalidate: 300 } });
+  const data = await res.json();
+  const now = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: city.timezone,
+  }).format(new Date());
+  return {
+    ...city,
+    time: now,
+    temperature: data.current_weather?.temperature ?? 0,
+    weathercode: data.current_weather?.weathercode ?? 0,
+    is_day: data.current_weather?.is_day ?? 1,
+  };
+}
+
+export default async function WorldClockPage() {
+  const cities = await Promise.all(WORLD_CITIES.map(fetchCity));
+  return (
+    <main className={styles.container}>
+      <h1>World Clock</h1>
+      <div className={styles.grid}>
+        {cities.map((c) => (
+          <div key={c.name} className={styles.card}>
+            <h2 className={styles.city}>{c.name}</h2>
+            <div className={styles.time}>{c.time}</div>
+            <div className={styles.weather}>
+              <WeatherIcon code={c.weathercode} isDay={c.is_day === 1} className={styles.icon} />
+              <span>{Math.round(c.temperature)}&deg;C</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -43,6 +43,31 @@
   transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 
+.dropdown {
+  position: relative;
+}
+
+.dropdownMenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--background, #fff);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  flex-direction: column;
+  padding: 0.5rem 0;
+  z-index: 10;
+}
+
+.dropdownMenu .link {
+  display: block;
+}
+
+.dropdown:hover .dropdownMenu {
+  display: flex;
+}
+
 .homeIcon {
   display: none;
 }
@@ -101,5 +126,12 @@
     display: block;
     width: 1.25rem;
     height: 1.25rem;
+  }
+
+  .dropdownMenu {
+    position: static;
+    box-shadow: none;
+    display: block;
+    padding-left: 1rem;
   }
 }

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -25,6 +25,20 @@ export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
           {c}
         </Link>
       ))}
+      <div className={styles.dropdown}>
+        <Link href="/tools" className={styles.link} onClick={onNavigate}>
+          Tools
+        </Link>
+        <div className={styles.dropdownMenu}>
+          <Link
+            href="/tools/world-clock"
+            className={styles.link}
+            onClick={onNavigate}
+          >
+            World Clock
+          </Link>
+        </div>
+      </div>
       <Link href="/weather" className={styles.link} onClick={onNavigate}>
         Weather
       </Link>


### PR DESCRIPTION
## Summary
- add Tools section with a world clock showing time and weather for 100 cities
- populate world clock using Open-Meteo data and basic styling
- expose Tools dropdown in navbar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e06499f48327936eefda19486653