### PR TITLE
fix: allow navbar dropdown to display

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.module.css
+++ b/WT4Q/src/components/CategoryNavbar.module.css
@@ -2,7 +2,7 @@
   position: relative;
   display: flex;
   gap: 1rem;
-  overflow-x: auto;
+  overflow: visible;
   padding: 0.5rem 1rem;
   font-family: 'Inter', sans-serif;
   border-radius: 0 0 var(--radius) var(--radius);


### PR DESCRIPTION
## Summary
- ensure navbar dropdown is visible by preventing parent overflow clipping

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890e2ff3a288327b3bd6743a038f749