### PR TITLE
Add Kathmandu to world cities list

### DIFF
--- a/WT4Q/lib/worldCities.ts
+++ b/WT4Q/lib/worldCities.ts
@@ -800,5 +800,13 @@ export const WORLD_CITIES: WorldCity[] = [
     "country": "CN",
     "population": 3372102,
     "timezone": "Asia/Shanghai"
+  },
+  {
+    "name": "Kathmandu",
+    "lat": 27.70832,
+    "lon": 85.32058,
+    "country": "NP",
+    "population": 845767,
+    "timezone": "Asia/Kathmandu"
   }
 ] as const;


### PR DESCRIPTION
## Summary
- add Kathmandu data to worldCities dataset

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689207faaef88327ad0d187251fe7612