### PR TITLE
feat: add city search to world clock

### DIFF
--- a/WT4Q/src/app/tools/world-clock/WorldClock.module.css
+++ b/WT4Q/src/app/tools/world-clock/WorldClock.module.css
@@ -2,6 +2,14 @@
   padding: 1rem;
 }
 
+.search {
+  display: block;
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto 1rem;
+  padding: 0.5rem;
+}
+
 .grid {
   display: grid;
   gap: 1rem;

--- a/WT4Q/src/app/tools/world-clock/WorldClockClient.tsx
+++ b/WT4Q/src/app/tools/world-clock/WorldClockClient.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import WeatherIcon from '@/components/WeatherIcon';
+import styles from './WorldClock.module.css';
+import type { CityWeather } from './page';
+
+interface Props {
+  cities: CityWeather[];
+}
+
+export default function WorldClockClient({ cities }: Props) {
+  const [search, setSearch] = useState('');
+  const [debounced, setDebounced] = useState(search);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(search), 300);
+    return () => clearTimeout(handler);
+  }, [search]);
+
+  const filtered = useMemo(() => {
+    const lower = debounced.toLowerCase();
+    return cities.filter((c) => c.name.toLowerCase().includes(lower));
+  }, [cities, debounced]);
+
+  return (
+    <main className={styles.container}>
+      <h1>World Clock</h1>
+      <input
+        type="text"
+        placeholder="Search cities"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className={styles.search}
+      />
+      <div className={styles.grid}>
+        {filtered.map((c) => (
+          <div key={c.name} className={styles.card}>
+            <h2 className={styles.city}>{c.name}</h2>
+            <div className={styles.time}>{c.time}</div>
+            <div className={styles.weather}>
+              <WeatherIcon code={c.weathercode} isDay={c.is_day === 1} className={styles.icon} />
+              <span>{Math.round(c.temperature)}°C</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+

--- a/WT4Q/src/app/tools/world-clock/page.tsx
+++ b/WT4Q/src/app/tools/world-clock/page.tsx
@@ -1,8 +1,7 @@
 // Data courtesy of Open-Meteo (https://open-meteo.com/)
-import WeatherIcon from '@/components/WeatherIcon';
 import { WORLD_CITIES, WorldCity } from '@/lib/worldCities';
-import styles from './WorldClock.module.css';
 import { Metadata } from 'next';
+import WorldClockClient from './WorldClockClient';
 
 export const metadata: Metadata = {
   title: 'World Clock – Global Time & Weather',
@@ -10,7 +9,7 @@ export const metadata: Metadata = {
   keywords: ['world clock', 'global time', 'weather', 'cities', 'tools'],
 };
 
-interface CityWeather extends WorldCity {
+export interface CityWeather extends WorldCity {
   time: string;
   temperature: number;
   weathercode: number;
@@ -38,21 +37,5 @@ async function fetchCity(city: WorldCity): Promise<CityWeather> {
 
 export default async function WorldClockPage() {
   const cities = await Promise.all(WORLD_CITIES.map(fetchCity));
-  return (
-    <main className={styles.container}>
-      <h1>World Clock</h1>
-      <div className={styles.grid}>
-        {cities.map((c) => (
-          <div key={c.name} className={styles.card}>
-            <h2 className={styles.city}>{c.name}</h2>
-            <div className={styles.time}>{c.time}</div>
-            <div className={styles.weather}>
-              <WeatherIcon code={c.weathercode} isDay={c.is_day === 1} className={styles.icon} />
-              <span>{Math.round(c.temperature)}&deg;C</span>
-            </div>
-          </div>
-        ))}
-      </div>
-    </main>
-  );
+  return <WorldClockClient cities={cities} />;
 }


### PR DESCRIPTION
## Summary
- add debounced city search input for world clock
- filter displayed cities by search query

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68920812455883278a27858d5425468c