### PR TITLE
feat: refresh world clock times client-side

### DIFF
--- a/WT4Q/src/app/tools/world-clock/page.tsx
+++ b/WT4Q/src/app/tools/world-clock/page.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 // Data courtesy of Open-Meteo (https://open-meteo.com/)
+import { useEffect, useState } from 'react';
 import WeatherIcon from '@/components/WeatherIcon';
 import { WORLD_CITIES, WorldCity } from '@/lib/worldCities';
 import styles from './WorldClock.module.css';
@@ -19,7 +22,7 @@ interface CityWeather extends WorldCity {
 
 async function fetchCity(city: WorldCity): Promise<CityWeather> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&current_weather=true&timezone=${encodeURIComponent(city.timezone)}`;
-  const res = await fetch(url, { next: { revalidate: 300 } });
+  const res = await fetch(url);
   const data = await res.json();
   const now = new Intl.DateTimeFormat('en-GB', {
     hour: '2-digit',
@@ -36,8 +39,36 @@ async function fetchCity(city: WorldCity): Promise<CityWeather> {
   };
 }
 
-export default async function WorldClockPage() {
-  const cities = await Promise.all(WORLD_CITIES.map(fetchCity));
+export default function WorldClockPage() {
+  const [cities, setCities] = useState<CityWeather[]>([]);
+
+  useEffect(() => {
+    async function loadCities() {
+      const cityData = await Promise.all(WORLD_CITIES.map(fetchCity));
+      setCities(cityData);
+    }
+    loadCities();
+  }, []);
+
+  useEffect(() => {
+    const updateTimes = () => {
+      setCities((prev) =>
+        prev.map((c) => ({
+          ...c,
+          time: new Intl.DateTimeFormat('en-GB', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZone: c.timezone,
+          }).format(new Date()),
+        }))
+      );
+    };
+    const interval = setInterval(updateTimes, 60000);
+    updateTimes();
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <main className={styles.container}>
       <h1>World Clock</h1>


### PR DESCRIPTION
## Summary
- convert world clock page into a client component
- fetch weather data on mount and refresh displayed times every minute

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892081427e083278f0e6fe7cf07a25c