### PR TITLE
fix JSX namespace in MemeMaker page

### DIFF
--- a/WT4Q/src/app/tools/mememaker/page.tsx
+++ b/WT4Q/src/app/tools/mememaker/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import MemeMaker from "@/components/services/MemeMaker";
+import type { JSX } from "react";
 
 export const metadata: Metadata = {
   title: "Meme Maker",
@@ -7,6 +8,6 @@ export const metadata: Metadata = {
   keywords: ["meme", "meme maker", "image editor", "tools"],
 };
 
-export default function MemeMakerPage() {
+export default function MemeMakerPage(): JSX.Element {
   return <MemeMaker />;
 }


### PR DESCRIPTION
## Summary
- import `JSX` type from React and use as explicit return type on the Meme Maker page to resolve `JSX` namespace errors

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68966571430c8327a419299726465ddf