### PR TITLE
fix: prevent mememaker hydration mismatch

### DIFF
--- a/WT4Q/src/app/tools/mememaker/page.tsx
+++ b/WT4Q/src/app/tools/mememaker/page.tsx
@@ -1,6 +1,11 @@
 import { Metadata } from "next";
-import MemeMaker from "@/components/services/MemeMaker";
+import dynamic from "next/dynamic";
 import type { JSX } from "react";
+
+const MemeMaker = dynamic(
+  () => import("@/components/services/MemeMaker"),
+  { ssr: false }
+);
 
 export const metadata: Metadata = {
   title: "Meme Maker",


### PR DESCRIPTION
## Summary
- fix MemeMaker page hydration by disabling server-side rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689733aceff88327b8cdb15ae6db42c1