### PR TITLE
fix: use client wrapper for MemeMaker

### DIFF
--- a/WT4Q/src/app/tools/mememaker/MemeMakerClient.tsx
+++ b/WT4Q/src/app/tools/mememaker/MemeMakerClient.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { JSX } from 'react';
+
+const MemeMaker = dynamic(() => import('@/components/services/MemeMaker'), {
+  ssr: false,
+});
+
+export default function MemeMakerClient(): JSX.Element {
+  return <MemeMaker />;
+}

--- a/WT4Q/src/app/tools/mememaker/page.tsx
+++ b/WT4Q/src/app/tools/mememaker/page.tsx
@@ -1,11 +1,6 @@
 import { Metadata } from "next";
-import dynamic from "next/dynamic";
 import type { JSX } from "react";
-
-const MemeMaker = dynamic(
-  () => import("@/components/services/MemeMaker"),
-  { ssr: false }
-);
+import MemeMakerClient from "./MemeMakerClient";
 
 export const metadata: Metadata = {
   title: "Meme Maker",
@@ -14,5 +9,5 @@ export const metadata: Metadata = {
 };
 
 export default function MemeMakerPage(): JSX.Element {
-  return <MemeMaker />;
+  return <MemeMakerClient />;
 }


### PR DESCRIPTION
## Summary
- move MemeMaker dynamic import into a dedicated client component
- reference client component from tools/mememaker page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: useSearchParams() should be wrapped in a suspense boundary at page "/contact")

------
https://chatgpt.com/codex/tasks/task_e_6897351dd2248327a7ac493c90f0559b