### PR TITLE
feat: add sidebar for related articles

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -84,56 +84,56 @@ export default async function ArticlePage({
       new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
   const related = await fetchRelated(id);
   return (
-    <div className={styles.container}>
-      {isBreakingActive && (
-        <div className={styles.breaking}>Breaking News</div>
-      )}
-      <h1 className={styles.title}>{article.title}</h1>
-      <p className={styles.meta}>
-        {new Date(article.createdDate).toLocaleDateString(undefined, {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })}
-        {article.countryName ? ` | ${article.countryName}` : ''}
-        {article.author?.adminName ? ` – ${article.author.adminName}` : ''}
-      </p>
-      {(() => {
-        const imageSrc =
-          article.photoLink ||
-          (article.photo?.[0]
-            ? `data:image/jpeg;base64,${article.photo[0]}`
-            : undefined);
-        if (!imageSrc) return null;
-        return (
-          <Image
-            src={imageSrc}
-            alt={article.altText || article.title}
-            className={styles.image}
-            width={700}
-            height={400}
-            unoptimized={imageSrc.startsWith('data:')}
+    <div className={styles.newspaper}>
+      <article className={styles.main}>
+        {isBreakingActive && (
+          <div className={styles.breaking}>Breaking News</div>
+        )}
+        <h1 className={styles.title}>{article.title}</h1>
+        <p className={styles.meta}>
+          {new Date(article.createdDate).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+          {article.countryName ? ` | ${article.countryName}` : ''}
+          {article.author?.adminName ? ` – ${article.author.adminName}` : ''}
+        </p>
+        {(() => {
+          const imageSrc =
+            article.photoLink ||
+            (article.photo?.[0]
+              ? `data:image/jpeg;base64,${article.photo[0]}`
+              : undefined);
+          if (!imageSrc) return null;
+          return (
+            <Image
+              src={imageSrc}
+              alt={article.altText || article.title}
+              className={styles.image}
+              width={700}
+              height={400}
+              unoptimized={imageSrc.startsWith('data:')}
+            />
+          );
+        })()}
+        {article.embededCode && (
+          <div
+            className={styles.embed}
+            dangerouslySetInnerHTML={{ __html: article.embededCode }}
           />
-        );
-      })()}
-      {article.embededCode && (
-        <div
-          className={styles.embed}
-          dangerouslySetInnerHTML={{ __html: article.embededCode }}
-        />
-      )}
-      <p className={styles.content}>{article.description}</p>
-      <LikeButton articleId={id} initialCount={article.like?.length || 0} />
-      <CommentsSection articleId={id} initialComments={article.comments || []} />
+        )}
+        <p className={styles.content}>{article.description}</p>
+        <LikeButton articleId={id} initialCount={article.like?.length || 0} />
+        <CommentsSection articleId={id} initialComments={article.comments || []} />
+      </article>
       {related.length > 0 && (
-        <section>
+        <aside className={styles.sidebar}>
           <h2 className={styles.relatedHeading}>Related Articles</h2>
-          <div className={styles.grid}>
-            {related.map((a) => (
-              <ArticleCard key={a.id} article={a} />
-            ))}
-          </div>
-        </section>
+          {related.map((a) => (
+            <ArticleCard key={a.id} article={a} />
+          ))}
+        </aside>
       )}
     </div>
   );

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -1,3 +1,28 @@
+
+/* Container for the article page with a newspaper-like layout */
+.newspaper {
+  color: var(--ink);
+  padding: 1.5rem clamp(1rem, 3vw, 1rem) 2rem;
+  margin: 0 auto;
+  max-width: 1900px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, .06);
+  border: 1px solid #ddd;
+  font-family: "Georgia", "Times New Roman", serif;
+  display: flex;
+  gap: 2rem;
+}
+
+.main {
+  flex: 1;
+}
+
+.sidebar {
+  width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .container {
   font-family: 'Inter', sans-serif;
   padding: 1rem;
@@ -39,12 +64,6 @@
   color: var(--primary);
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1rem;
-}
-
 .breaking {
   background: red;
   color: #fff;
@@ -55,7 +74,10 @@
 }
 
 @media (max-width: 700px) {
-  .grid {
-    grid-template-columns: 1fr;
+  .newspaper {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- style article pages with a newspaper-like container
- show related articles in a sidebar beside the main article

## Testing
- `npm run lint` *(fails: Hero is defined but never used, and several no-explicit-any warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6899de6b78508327aea6cc1e78479957