### PR TITLE
feat: add newspaper article border and layout

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -155,60 +155,6 @@ export default async function ArticlePage(
   })();
 
   return (
-<<<<<<< HEAD
-    <div className={styles.container}>
-      {isBreakingActive && <div className={styles.breaking}>Breaking News</div>}
-
-      <h1 className={styles.title}>{article.title}</h1>
-
-      <p className={styles.meta}>
-        {new Date(article.createdDate).toLocaleDateString(undefined, {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })}
-        {article.countryName ? ` | ${article.countryName}` : ''}
-        {article.author?.adminName ? ` – ${article.author.adminName}` : ''}
-      </p>
-
-      {imageSrc && (shouldUseNextImage ? (
-        <Image
-          src={imageSrc}
-          alt={article.altText || article.title}
-          className={styles.image}
-          width={700}
-          height={400}
-          unoptimized={imageSrc.startsWith('data:')}
-          // priority // uncomment if you want LCP boost
-        />
-      ) : (
-        // Plain <img> as a never-crash fallback for any unforeseen hosts
-        <img
-          src={imageSrc}
-          alt={article.altText || article.title}
-          className={styles.image}
-          width={700}
-          height={400}
-        />
-      ))}
-
-      {article.embededCode && (
-        <div
-          className={styles.embed}
-          dangerouslySetInnerHTML={{ __html: article.embededCode }}
-        />
-      )}
-
-      <p className={styles.content}>{article.description}</p>
-
-      <LikeButton articleId={id} initialCount={article.like?.length ?? 0} />
-
-      <CommentsSection
-        articleId={id}
-        initialComments={article.comments ?? []}
-      />
-
-=======
     <div className={styles.newspaper}>
       <article className={styles.main}>
         {isBreakingActive && (
@@ -224,24 +170,24 @@ export default async function ArticlePage(
           {article.countryName ? ` | ${article.countryName}` : ''}
           {article.author?.adminName ? ` – ${article.author.adminName}` : ''}
         </p>
-        {(() => {
-          const imageSrc =
-            article.photoLink ||
-            (article.photo?.[0]
-              ? `data:image/jpeg;base64,${article.photo[0]}`
-              : undefined);
-          if (!imageSrc) return null;
-          return (
-            <Image
-              src={imageSrc}
-              alt={article.altText || article.title}
-              className={styles.image}
-              width={700}
-              height={400}
-              unoptimized={imageSrc.startsWith('data:')}
-            />
-          );
-        })()}
+        {imageSrc && (shouldUseNextImage ? (
+          <Image
+            src={imageSrc}
+            alt={article.altText || article.title}
+            className={styles.image}
+            width={700}
+            height={400}
+            unoptimized={imageSrc.startsWith('data:')}
+          />
+        ) : (
+          <img
+            src={imageSrc}
+            alt={article.altText || article.title}
+            className={styles.image}
+            width={700}
+            height={400}
+          />
+        ))}
         {article.embededCode && (
           <div
             className={styles.embed}
@@ -249,13 +195,16 @@ export default async function ArticlePage(
           />
         )}
         <p className={styles.content}>{article.description}</p>
-        <LikeButton articleId={id} initialCount={article.like?.length || 0} />
-        <CommentsSection articleId={id} initialComments={article.comments || []} />
+        <LikeButton articleId={id} initialCount={article.like?.length ?? 0} />
+        <CommentsSection
+          articleId={id}
+          initialComments={article.comments ?? []}
+        />
       </article>
->>>>>>> 28fe6193bc7c305d72ede65af682fbbd85f57b7b
+
       {related.length > 0 && (
         <aside className={styles.sidebar}>
-          <h2 className={styles.relatedHeading}>Related Articles</h2>
+          <h2 className={styles.relatedHeading}>Recommended Articles</h2>
           {related.map((a) => (
             <ArticleCard key={a.id} article={a} />
           ))}

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -1,7 +1,9 @@
 
 /* Container for the article page with a newspaper-like layout */
 .newspaper {
-  color: var(--ink);
+  background: #f7f5ef;
+  background-image: url('/images/paper_background.webp');
+  color: #111;
   padding: 1.5rem clamp(1rem, 3vw, 1rem) 2rem;
   margin: 0 auto;
   max-width: 1900px;
@@ -21,6 +23,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding-left: 1rem;
+  border-left: 1px solid #b6b6b6;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- style article page with newspaper-like background and layout
- add left border to separate recommended articles

## Testing
- `npm test --prefix WT4Q` *(fails: Missing script "test")*
- `npm run lint --prefix WT4Q` *(fails: Unexpected any & other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6899e16293b88327aed78e9832e6fe87