### PR TITLE
Ensure header visible on homepage load

### DIFF
--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -13,14 +13,14 @@ import styles from './Header.module.css';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  const [hidden, setHidden] = useState(true);
+  const [hidden, setHidden] = useState(false);
 
   useEffect(() => {
     let lastY = window.scrollY;
     const onScroll = () => {
       const y = window.scrollY;
       if (y < 50) {
-        setHidden(true);
+        setHidden(false);
       } else if (y < lastY) {
         setHidden(false);
       } else if (y > lastY) {


### PR DESCRIPTION
## Summary
- Keep site header visible when the page first loads
- Show header when at top of page and hide only when scrolling down

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and no-img-element warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6899eebaaf388327ad54da6c8071e7aa