### PR TITLE
Revert header to pre-PR state

### DIFF
--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -13,8 +13,6 @@ import styles from './Header.module.css';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  // Start hidden to match the server-rendered markup and avoid hydration mismatches.
-  // The header visibility is then adjusted on the client based on the scroll position.
   const [hidden, setHidden] = useState(true);
 
   useEffect(() => {
@@ -22,7 +20,7 @@ export default function Header() {
     const onScroll = () => {
       const y = window.scrollY;
       if (y < 50) {
-        setHidden(false);
+        setHidden(true);
       } else if (y < lastY) {
         setHidden(false);
       } else if (y > lastY) {
@@ -30,9 +28,6 @@ export default function Header() {
       }
       lastY = y;
     };
-
-    // Run once on mount to ensure the initial visibility matches the scroll position.
-    onScroll();
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
   }, []);


### PR DESCRIPTION
## Summary
- revert header visibility logic to match pre-PR behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in `src/app/tools/mememaker/page.tsx` and related files)*

------
https://chatgpt.com/codex/tasks/task_e_6899f33f4e24832797ae8b147aa05ed8