### PR TITLE
Revert header to initial implementation

### DIFF
--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -1,32 +1,23 @@
 
 .header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 100;
-  transition: transform 0.3s ease;
-  transform: translateY(0);
+  position: relative;
   color: #ffffff;
   padding: 0.25rem 0.5rem;
   font-family: 'Inter', sans-serif;
   box-shadow: 0 0.1rem 0.2rem rgba(0, 0, 0, 0.1);
   border-bottom: 0.2rem solid var(--secondary);
+  animation: slideIn 0.6s ease-out;
   background-image: url('/images/paper_background.webp');
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
 }
 
-.hidden {
-  transform: translateY(-100%);
-}
-
 .header::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: rgba(0, 34, 128, 0.245);
+  background: rgba(0, 0, 128, 0.5);
   z-index: 0;
 }
 
@@ -52,7 +43,7 @@
 .logoImage {
   width: clamp(4rem, 10vw, 6rem);
   height: auto;
-  border-radius: 10%;
+  border-radius: 50%;
 }
 
 .weather {

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import PrefetchLink from './PrefetchLink';
 import Image from 'next/image';
 import CategoryNavbar from './CategoryNavbar';
@@ -13,36 +13,13 @@ import styles from './Header.module.css';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  // Start hidden to match the server-rendered markup and avoid hydration mismatches.
-  // The header visibility is then adjusted on the client based on the scroll position.
-  const [hidden, setHidden] = useState(true);
-
-  useEffect(() => {
-    let lastY = window.scrollY;
-    const onScroll = () => {
-      const y = window.scrollY;
-      if (y < 50) {
-        setHidden(false);
-      } else if (y < lastY) {
-        setHidden(false);
-      } else if (y > lastY) {
-        setHidden(true);
-      }
-      lastY = y;
-    };
-
-    // Run once on mount to ensure the initial visibility matches the scroll position.
-    onScroll();
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
 
   const handleNavigate = () => {
     if (window.innerWidth <= 1024) setOpen(false);
   };
 
   return (
-    <header className={`${styles.header} ${hidden ? styles.hidden : ''}`}>
+    <header className={styles.header}>
       {open && <div className={styles.overlay} onClick={() => setOpen(false)} />}
       <div className={styles.inner}>
         <PrefetchLink href="/" className={styles.logo}>


### PR DESCRIPTION
## Summary
- restore original Header component without scroll-based hiding
- revert header CSS to its early layout and slide-in animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in `src/app/tools/mememaker/page.tsx` and related files)*

------
https://chatgpt.com/codex/tasks/task_e_6899f33f4e24832797ae8b147aa05ed8