### PR TITLE
Ensure EF Core migrations run automatically at startup

### DIFF
--- a/Northeast/Data/MigrationExtensions.cs
+++ b/Northeast/Data/MigrationExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Northeast.Data;
+
+public static class MigrationExtensions
+{
+    public static async Task ApplyMigrationsAsync(this IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await context.Database.MigrateAsync();
+    }
+}

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -134,12 +134,13 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 
 var app = builder.Build();
 
-// Apply any pending migrations at startup
+// Ensure database is up to date on startup
+await app.Services.ApplyMigrationsAsync();
+
+// Seed a SuperAdmin user if credentials are provided
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    await context.Database.MigrateAsync();
-
     var email = builder.Configuration["SuperAdmin:Email"];
     var password = builder.Configuration["SuperAdmin:Password"];
     if (!string.IsNullOrEmpty(email) && !string.IsNullOrEmpty(password))


### PR DESCRIPTION
## Summary
- Add `MigrationExtensions` to apply EF Core migrations
- Invoke migration helper in `Program.cs` before seeding

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a43bd8ca4832794be52a1b8e63b77