### PR TITLE
fix: mark CategoryNavbar as client component

### DIFF
--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import PrefetchLink from './PrefetchLink';
 import { CATEGORIES } from '@/lib/categories';
 import HomeIcon from './HomeIcon';


### PR DESCRIPTION
## Summary
- fix hydration mismatch by marking `CategoryNavbar` as a client component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any type and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a4b0464508327aaa0aa3460a76a98