### PR TITLE
Support multiple article images with captions

### DIFF
--- a/Northeast/DTOs/ArticleDto.cs
+++ b/Northeast/DTOs/ArticleDto.cs
@@ -22,7 +22,7 @@ namespace Northeast.DTOs
 
         public bool IsBreakingNews { get; set; } = false;
 
-        public ArticleImageDto? Image { get; set; }
+        public List<ArticleImageDto>? Images { get; set; }
         public string? EmbededCode { get; set; }
 
         public string? CountryName { get; set; }

--- a/Northeast/DTOs/ArticleImageDto.cs
+++ b/Northeast/DTOs/ArticleImageDto.cs
@@ -2,7 +2,7 @@ namespace Northeast.DTOs
 {
     public class ArticleImageDto
     {
-        public List<byte[]>? Photo { get; set; }
+        public byte[]? Photo { get; set; }
         public string? PhotoLink { get; set; }
         public string? AltText { get; set; }
         public string? Caption { get; set; }

--- a/Northeast/Data/AppDbContext.cs
+++ b/Northeast/Data/AppDbContext.cs
@@ -40,12 +40,12 @@ namespace Northeast.Data
                 .HasForeignKey(a => a.AuthorId);
 
             modelBuilder.Entity<Article>()
-                .HasOne(a => a.Image)
+                .HasMany(a => a.Images)
                 .WithOne(i => i.Article)
-                .HasForeignKey<ArticleImage>(i => i.ArticleId);
+                .HasForeignKey(i => i.ArticleId);
 
             modelBuilder.Entity<Article>()
-                .Navigation(a => a.Image)
+                .Navigation(a => a.Images)
                 .AutoInclude();
 
             modelBuilder.Entity<Comment>()

--- a/Northeast/Models/Article.cs
+++ b/Northeast/Models/Article.cs
@@ -25,7 +25,7 @@ namespace Northeast.Models
         [DefaultValue(false)]
         public bool IsBreakingNews { get; set; } = false;
 
-        public ArticleImage? Image { get; set; }
+        public List<ArticleImage>? Images { get; set; } = new List<ArticleImage>();
         public string? EmbededCode { get; set; }
         public List<Comment>? Comments { get; set; } = new List<Comment>();
         public ICollection<LikeEntity>? Like { get; set; } = new List<LikeEntity>();

--- a/Northeast/Models/ArticleImage.cs
+++ b/Northeast/Models/ArticleImage.cs
@@ -8,7 +8,7 @@ namespace Northeast.Models
         [Key]
         public Guid Id { get; set; } = Guid.NewGuid();
 
-        public List<byte[]>? Photo { get; set; }
+        public byte[]? Photo { get; set; }
         public string? PhotoLink { get; set; }
         public string? AltText { get; set; }
         public string? Caption { get; set; }

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -52,13 +52,13 @@ namespace Northeast.Services
                 IsBreakingNews = articleDto.ArticleType == ArticleType.News && articleDto.IsBreakingNews,
                 EmbededCode = articleDto.EmbededCode,
                 Keywords = articleDto.Keyword ?? null,
-                Image = articleDto.Image != null ? new ArticleImage
+                Images = articleDto.Images?.Select(img => new ArticleImage
                 {
-                    Photo = articleDto.Image.Photo,
-                    PhotoLink = articleDto.Image.PhotoLink,
-                    AltText = articleDto.Image.AltText,
-                    Caption = articleDto.Image.Caption
-                } : null,
+                    Photo = img.PhotoLink == null ? img.Photo : null,
+                    PhotoLink = img.PhotoLink,
+                    AltText = img.AltText,
+                    Caption = img.Caption
+                }).ToList(),
             };
             if (articleDto.ArticleType == 0)
             {
@@ -140,17 +140,20 @@ namespace Northeast.Services
             article.EmbededCode = articleDto.EmbededCode;
             article.Keywords = articleDto.Keyword ?? null;
 
-            if (articleDto.Image != null)
+            if (articleDto.Images != null && articleDto.Images.Any())
             {
-                article.Image ??= new ArticleImage { ArticleId = article.Id };
-                article.Image.Photo = articleDto.Image.Photo;
-                article.Image.PhotoLink = articleDto.Image.PhotoLink;
-                article.Image.AltText = articleDto.Image.AltText;
-                article.Image.Caption = articleDto.Image.Caption;
+                article.Images = articleDto.Images.Select(img => new ArticleImage
+                {
+                    ArticleId = article.Id,
+                    Photo = img.PhotoLink == null ? img.Photo : null,
+                    PhotoLink = img.PhotoLink,
+                    AltText = img.AltText,
+                    Caption = img.Caption
+                }).ToList();
             }
             else
             {
-                article.Image = null;
+                article.Images = new List<ArticleImage>();
             }
 
             if (articleDto.ArticleType == 0)

--- a/WT4Q/lib/models.ts
+++ b/WT4Q/lib/models.ts
@@ -1,5 +1,5 @@
 export interface ArticleImage {
-  photo?: string[];
+  photo?: string;
   photoLink?: string;
   altText?: string;
   caption?: string;

--- a/WT4Q/src/app/admin/dashboard/dashboard.module.css
+++ b/WT4Q/src/app/admin/dashboard/dashboard.module.css
@@ -144,3 +144,9 @@
   align-items: center;
   gap: 0.5rem;
 }
+
+.imageGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
@@ -15,7 +15,7 @@ interface ArticleDetails {
   createdDate: string;
   articleType: number;
   category: number;
-  image?: ArticleImage;
+  images?: ArticleImage[];
   embededCode?: string;
   countryName?: string;
   countryCode?: string;
@@ -30,11 +30,10 @@ export default function EditArticleClient({ id }: { id: string }) {
   const [category, setCategory] = useState('');
   const [keywords, setKeywords] = useState('');
   const [createdDate, setCreatedDate] = useState('');
-  const [photos, setPhotos] = useState<FileList | null>(null);
-  const [photoLink, setPhotoLink] = useState('');
+  const [images, setImages] = useState<{ file?: File; link: string; altText: string; caption: string; existing?: string; }[]>([
+    { link: '', altText: '', caption: '' }
+  ]);
   const [embededCode, setEmbededCode] = useState('');
-  const [altText, setAltText] = useState('');
-  const [caption, setCaption] = useState('');
   const [countryName, setCountryName] = useState('');
   const [countryCode, setCountryCode] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -53,11 +52,17 @@ export default function EditArticleClient({ id }: { id: string }) {
         setType(ARTICLE_TYPES[data.articleType] ?? '');
         setCategory(CATEGORIES[data.category - 1] ?? '');
         setCreatedDate(data.createdDate.slice(0, 16));
-        const img = data.image;
-        setPhotoLink(img?.photoLink || '');
         setEmbededCode(data.embededCode || '');
-        setAltText(img?.altText || '');
-        setCaption(img?.caption || '');
+        setImages(
+          data.images && data.images.length
+            ? data.images.map((img) => ({
+                link: img.photoLink || '',
+                altText: img.altText || '',
+                caption: img.caption || '',
+                existing: img.photo ? `data:image/jpeg;base64,${img.photo}` : undefined,
+              }))
+            : [{ link: '', altText: '', caption: '' }]
+        );
         setCountryName(data.countryName || '');
         setCountryCode(data.countryCode || '');
         setKeywords(data.keywords ? data.keywords.join(', ') : '');
@@ -73,44 +78,62 @@ export default function EditArticleClient({ id }: { id: string }) {
     setError(null);
     startTransition(async () => {
       try {
-        const photosBase64 = photos
-          ? await Promise.all(
-              Array.from(photos).map(
-                (file) =>
-                  new Promise<string>((resolve, reject) => {
-                    const reader = new FileReader();
-                    reader.onload = () => {
-                      const result = reader.result as string;
-                      const base64 = result.split(',')[1];
-                      resolve(base64);
-                    };
-                    reader.onerror = () => reject(reader.error);
-                    reader.readAsDataURL(file);
-                  })
-              )
-            )
-          : undefined;
+        const imagesPayload = (
+          await Promise.all(
+            images.map(async (img) => {
+              if (img.file && img.link) {
+                throw new Error('Provide either a file or a link for each image');
+              }
+              if (img.file) {
+                const base64 = await new Promise<string>((resolve, reject) => {
+                  const reader = new FileReader();
+                  reader.onload = () => {
+                    const result = reader.result as string;
+                    resolve(result.split(',')[1]);
+                  };
+                  reader.onerror = () => reject(reader.error);
+                  reader.readAsDataURL(img.file!);
+                });
+                return {
+                  photo: base64,
+                  altText: img.altText || undefined,
+                  caption: img.caption || undefined,
+                };
+              }
+              if (img.link) {
+                return {
+                  photoLink: img.link,
+                  altText: img.altText || undefined,
+                  caption: img.caption || undefined,
+                };
+              }
+              if (img.existing) {
+                return {
+                  photo: img.existing.split(',')[1],
+                  altText: img.altText || undefined,
+                  caption: img.caption || undefined,
+                };
+              }
+              return null;
+            })
+          )
+        ).filter(Boolean);
 
-          const body = {
-            title,
-            category: category ? CATEGORIES.indexOf(category) + 1 : 0,
-            articleType: type ? ARTICLE_TYPES.indexOf(type) : 0,
-            createdDate: new Date(createdDate).toISOString(),
-            content,
-            image: {
-              photo: photosBase64,
-              photoLink: photoLink || undefined,
-              altText: altText || undefined,
-              caption: caption || undefined,
-            },
-            embededCode: embededCode || undefined,
-            countryName: countryName || undefined,
-            countryCode: countryCode || undefined,
-            keyword: keywords
-              .split(',')
-              .map((k) => k.trim())
-              .filter((k) => k.length > 0),
-          } as Record<string, unknown>;
+        const body = {
+          title,
+          category: category ? CATEGORIES.indexOf(category) + 1 : 0,
+          articleType: type ? ARTICLE_TYPES.indexOf(type) : 0,
+          createdDate: new Date(createdDate).toISOString(),
+          content,
+          images: imagesPayload,
+          embededCode: embededCode || undefined,
+          countryName: countryName || undefined,
+          countryCode: countryCode || undefined,
+          keyword: keywords
+            .split(',')
+            .map((k) => k.trim())
+            .filter((k) => k.length > 0),
+        } as Record<string, unknown>;
 
           const res = await fetch(`${API_ROUTES.ARTICLE.UPDATE}?Id=${id}`, {
             method: 'PUT',
@@ -157,34 +180,71 @@ export default function EditArticleClient({ id }: { id: string }) {
           className={styles.textarea}
           required
         />
-        <input
-          type="file"
-          multiple
-          accept="image/*"
-          onChange={(e) => setPhotos(e.target.files)}
-          className={styles.input}
-        />
-        <input
-          type="text"
-          placeholder="Alt text"
-          value={altText}
-          onChange={(e) => setAltText(e.target.value)}
-          className={styles.input}
-        />
-        <input
-          type="text"
-          placeholder="Caption"
-          value={caption}
-          onChange={(e) => setCaption(e.target.value)}
-          className={styles.input}
-        />
-        <input
-          type="text"
-          placeholder="Link to photo"
-          value={photoLink}
-          onChange={(e) => setPhotoLink(e.target.value)}
-          className={styles.input}
-        />
+        {images.map((img, idx) => (
+          <div key={idx} className={styles.imageGroup}>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                setImages((prev) => {
+                  const copy = [...prev];
+                  copy[idx].file = file || undefined;
+                  return copy;
+                });
+              }}
+              className={styles.input}
+            />
+            <input
+              type="text"
+              placeholder="Link to photo"
+              value={img.link}
+              onChange={(e) =>
+                setImages((prev) => {
+                  const copy = [...prev];
+                  copy[idx].link = e.target.value;
+                  return copy;
+                })
+              }
+              className={styles.input}
+            />
+            <input
+              type="text"
+              placeholder="Alt text"
+              value={img.altText}
+              onChange={(e) =>
+                setImages((prev) => {
+                  const copy = [...prev];
+                  copy[idx].altText = e.target.value;
+                  return copy;
+                })
+              }
+              className={styles.input}
+            />
+            <input
+              type="text"
+              placeholder="Caption"
+              value={img.caption}
+              onChange={(e) =>
+                setImages((prev) => {
+                  const copy = [...prev];
+                  copy[idx].caption = e.target.value;
+                  return copy;
+                })
+              }
+              className={styles.input}
+            />
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() =>
+            setImages((prev) => [...prev, { link: '', altText: '', caption: '' }])
+          }
+          className={styles.button}
+        >
+          Add Image
+        </button>
         <textarea
           placeholder="Embedded code"
           value={embededCode}

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -62,6 +62,12 @@
   margin: 1rem 0;
 }
 
+.gallery {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
 .caption {
   font-size: 0.875rem;
   color: #555;

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -38,7 +38,7 @@ async function fetchBreakingNews(): Promise<BreakingArticle[]> {
       id: a.id,
       title: a.title,
       content: a.content,
-      image: a.image as ArticleImage,
+      images: a.images as ArticleImage[],
     }));
   } catch {
     return [];

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -8,7 +8,7 @@ export interface BreakingArticle {
   id: string;
   title: string;
   content?: string;
-  image?: ArticleImage;
+  images?: ArticleImage[];
 }
 
 export default function BreakingNewsSlider({
@@ -33,10 +33,9 @@ export default function BreakingNewsSlider({
   if (articles.length === 0) return null;
 
   const current = articles[index];
-  const base64 = current?.image?.photo?.[0]
-    ? `data:image/jpeg;base64,${current.image.photo[0]}`
-    : undefined;
-  const imageSrc = current?.image?.photoLink || base64;
+  const first = current.images?.[0];
+  const base64 = first?.photo ? `data:image/jpeg;base64,${first.photo}` : undefined;
+  const imageSrc = first?.photoLink || base64;
 
   return (
     <div className={`${styles.slider} ${className ?? ''}`.trim()}>
@@ -46,11 +45,11 @@ export default function BreakingNewsSlider({
             <figure className={styles.detailFigure}>
               <img
                 src={imageSrc}
-                alt={current.image?.altText || current.title}
+                alt={first?.altText || current.title}
                 className={styles.detailImage}
               />
-              {current.image?.caption && (
-                <figcaption className={styles.detailCaption}>{current.image.caption}</figcaption>
+              {first?.caption && (
+                <figcaption className={styles.detailCaption}>{first.caption}</figcaption>
               )}
             </figure>
           )}


### PR DESCRIPTION
## Summary
- Allow articles to hold multiple images, each with their own caption and alt text
- Update admin upload/edit UI and article page to handle image galleries or links
- Enforce per-image choice between uploaded data or external link

## Testing
- `dotnet build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a59da0bf0832780dbc8a476675d48