### PR TITLE
Display article summary on article page

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -14,6 +14,7 @@ import type { ArticleImage } from '@/lib/models';
 interface ArticleDetails {
   id: string;
   title: string;
+  summary?: string;
   content: string;
   createdDate: string;
   isBreakingNews?: boolean;
@@ -88,7 +89,8 @@ export async function generateMetadata(
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
   const url = new URL(`/articles/${id}`, siteUrl).toString();
 
-  const description = (article.content || '').slice(0, 160);
+  const description =
+    article.summary || (article.content || '').slice(0, 160);
 
   // Prefer a proper, reachable URL for OG (many scrapers ignore data:)
   let ogImage: string | undefined = undefined;
@@ -137,6 +139,9 @@ export default async function ArticlePage(
           <div className={styles.breaking}>Breaking News</div>
         )}
         <h1 className={styles.title}>{article.title}</h1>
+        {article.summary && (
+          <p className={styles.summary}>{article.summary}</p>
+        )}
         <p className={styles.meta}>
           {new Date(article.createdDate).toLocaleDateString(undefined, {
             year: 'numeric',

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -45,6 +45,13 @@
   font-size: 0.875rem;
 }
 
+.summary {
+  font-size: 1.125rem;
+  font-style: italic;
+  margin-bottom: 1rem;
+  color: var(--muted);
+}
+
 .content {
   line-height: 1.6;
   margin-bottom: 2rem;


### PR DESCRIPTION
## Summary
- show article summaries on individual article page
- prefer summary for metadata description
- add styling for summary text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Link unused and `any` types in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a5f3a41cc83278ef66bfd2eaf2017