### PR TITLE
Align category names with backend enum

### DIFF
--- a/Northeast/Models/Category.cs
+++ b/Northeast/Models/Category.cs
@@ -4,7 +4,7 @@
     {
         Politics,
         Crime,
-        Enetrtainment,
+        Entertainment,
         Business,
         Technology,
         Sports

--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -1,21 +1,17 @@
 export const UPLOADCATEGORIES = [
-
   'Politics',
   'Crime',
   'Entertainment',
   'Business',
-  'Science and Tech',
+  'Technology',
   'Sports',
 ];
 
 export const CATEGORIES = [
-
   'Politics',
   'Crime',
   'Entertainment',
   'Business',
+  'Technology',
   'Sports',
-  'Health',
-  'Science and Tech',
-  'Lifestyle',
 ];


### PR DESCRIPTION
## Summary
- Correct typo in backend `Category` enum so `Entertainment` is recognized
- Sync frontend category lists with backend enum values to ensure articles load for each category

## Testing
- `npm run lint` *(fails: 'Link' is defined but never used, many `any` type errors)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a71607e8483278a141b6176d2f627