### PR TITLE
Fix dynamic import causing server component error

### DIFF
--- a/WT4Q/src/app/tools/online-photoshop/page.tsx
+++ b/WT4Q/src/app/tools/online-photoshop/page.tsx
@@ -1,12 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import type { Metadata } from 'next';
-import dynamic from 'next/dynamic';
-
-const EditorShell = dynamic(
-  () => import('@/app/tools/online-photoshop/components/EditorShell'),
-  { ssr: false }
-);
+import EditorShell from '@/app/tools/online-photoshop/components/EditorShell';
 
 export const metadata: Metadata = {
   title: 'Free Online Photoshop',


### PR DESCRIPTION
## Summary
- load `EditorShell` directly instead of using `next/dynamic` with `ssr:false`

## Testing
- `npm test`
- `npm run lint` *(fails: 'Link' is defined but never used and numerous `any` type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b3930ec948327a9716db4a802adec