### PR TITLE
Add banner prompt for Online Photoshop login and expose tool links

### DIFF
--- a/WT4Q/src/app/login/Login.module.css
+++ b/WT4Q/src/app/login/Login.module.css
@@ -71,6 +71,16 @@
   box-shadow: 0 4px 10px rgba(0,0,0,0.3);
 }
 
+.banner {
+  background: var(--wt4q-blue);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+}
+
 .form {
   display: flex;
   flex-direction: column;

--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -14,7 +14,11 @@ interface LoginRequest {
 
 const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/;
 
-const LoginClient: FC = () => {
+interface Props {
+  from?: string;
+}
+
+const LoginClient: FC<Props> = ({ from }) => {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -71,12 +75,19 @@ const LoginClient: FC = () => {
     window.location.href = `${API_ROUTES.GOOGLE_SIGN_IN.AUTH}?returnUrl=${encodeURIComponent(returnUrl)}`;
   };
 
+  const fromPhotoshop = from === 'online-photoshop';
+
   return (
     <main className={styles.container}>
       <section className={styles.card} aria-labelledby="user-login-title">
         <h1 id="user-login-title" className={styles.title}>
           User Login
         </h1>
+        {fromPhotoshop && (
+          <div role="alert" className={styles.banner}>
+            Login to use free online Photoshop
+          </div>
+        )}
         {error && (
           <div role="alert" className={styles.error}>
             {error}

--- a/WT4Q/src/app/login/page.tsx
+++ b/WT4Q/src/app/login/page.tsx
@@ -7,10 +7,14 @@ export const metadata = {
   description: 'Sign in to your WT4Q account',
 };
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams?: { from?: string };
+}) {
   const cookieStore = await cookies();
   if (cookieStore.get('JwtToken')) {
     redirect('/');
   }
-  return <LoginClient />;
+  return <LoginClient from={searchParams?.from} />;
 }

--- a/WT4Q/src/app/tools/online-photoshop/page.tsx
+++ b/WT4Q/src/app/tools/online-photoshop/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default async function OnlinePhotoshopPage() {
   const cookieStore = await cookies();
   if (!cookieStore.get('JwtToken')) {
-    redirect('/login');
+    redirect('/login?from=online-photoshop');
   }
   return <EditorShell />;
 }

--- a/WT4Q/src/app/tools/page.tsx
+++ b/WT4Q/src/app/tools/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from 'next';
 import PrefetchLink from '@/components/PrefetchLink';
-import { cookies } from 'next/headers';
 
 export const metadata: Metadata = {
   title: 'Tools',
@@ -8,10 +7,7 @@ export const metadata: Metadata = {
     'Handy utilities including a free online Photoshop-like editor and a world clock.',
 };
 
-export default async function ToolsPage() {
-  const cookieStore = await cookies();
-  const loggedIn = Boolean(cookieStore.get('JwtToken'));
-
+export default function ToolsPage() {
   return (
     <main style={{ padding: '1rem' }}>
       <h1>Tools</h1>
@@ -22,13 +18,11 @@ export default async function ToolsPage() {
         <li>
           <PrefetchLink href="/tools/mememaker">Mememaker</PrefetchLink>
         </li>
-        {loggedIn && (
-          <li>
-            <PrefetchLink href="/tools/online-photoshop">
-              Free Online Photoshop
-            </PrefetchLink>
-          </li>
-        )}
+        <li>
+          <PrefetchLink href="/tools/online-photoshop">
+            Free Online Photoshop
+          </PrefetchLink>
+        </li>
       </ul>
     </main>
   );

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -37,12 +37,19 @@ export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
           >
             World Clock
           </PrefetchLink>
-                    <PrefetchLink
+          <PrefetchLink
             href="/tools/mememaker"
             className={styles.link}
             onClick={onNavigate}
           >
             Mememaker
+          </PrefetchLink>
+          <PrefetchLink
+            href="/tools/online-photoshop"
+            className={styles.link}
+            onClick={onNavigate}
+          >
+            Free Online Photoshop
           </PrefetchLink>
 
         </div>


### PR DESCRIPTION
## Summary
- Display a banner on the login page when users are redirected from Online Photoshop
- Add Free Online Photoshop links to the Tools dropdown and Tools page
- Redirect unauthenticated visitors with query param so login knows to show the banner

## Testing
- `npm test`
- `npm run lint` *(fails: Link is defined but never used, Unexpected any, missing deps, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b3c1d0fa08327bad173e05d158e36