### PR TITLE
feat: align online editor with newspaper theme

### DIFF
--- a/WT4Q/src/app/page.module.css
+++ b/WT4Q/src/app/page.module.css
@@ -18,7 +18,7 @@
   color: var(--ink);
   padding: 1.5rem clamp(1rem, 3vw, 1rem) 2rem;
   margin: 0 auto;
-  max-width: 1900px;
+  max-width: 2100px;
   box-shadow: 0 2px 6px rgba(0,0,0,.06);
   border: 1px solid #ddd;
   font-family: "Georgia", "Times New Roman", serif;
@@ -26,7 +26,6 @@
 
 /* Optional subtle paper texture */
 .newspaper::before {
-  max-width: 9;
   content: "";
   position: fixed;
   inset: 0;

--- a/WT4Q/src/app/tools/online-photoshop/styles/editor.module.css
+++ b/WT4Q/src/app/tools/online-photoshop/styles/editor.module.css
@@ -1,4 +1,17 @@
-.root { display: flex; flex-direction: column; height: 100vh; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
+.root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: #f7f5ef;
+  background-image: url('/images/paper_background.webp');
+  color: #111;
+  padding: 1.5rem clamp(1rem, 3vw, 1rem) 2rem;
+  margin: 0 auto;
+  max-width: 1900px;
+  box-shadow: 0 2px 6px rgba(0,0,0,.06);
+  border: 1px solid #ddd;
+  font-family: "Georgia", "Times New Roman", serif;
+}
 .header { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-bottom: 1px solid #e5e5e5; }
 .title { font-size: 16px; margin: 0; }
 .main { flex: 1; display: grid; grid-template-columns: 260px 1fr 260px; min-height: 0; }


### PR DESCRIPTION
## Summary
- style online Photoshop editor with newspaper look and serif fonts
- widen home page newspaper layout and ensure full page texture

## Testing
- `npm test`
- `npm run lint` *(fails: no-img-element, no-unused-vars, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b42e11d948327a242029ab20b382e