### PR TITLE
Revamp comment section with newspaper styling

### DIFF
--- a/WT4Q/src/components/CommentsSection.module.css
+++ b/WT4Q/src/components/CommentsSection.module.css
@@ -1,69 +1,108 @@
 .section {
   margin-top: 2rem;
+  background: #f7f5ef;
+  background-image: url('/images/paper_background.webp');
+  padding: 1rem;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  font-family: "Georgia", "Times New Roman", serif;
 }
+
 .heading {
   font-weight: bold;
   margin-bottom: 0.5rem;
-  color: var(--primary);
+  color: var(--ink);
 }
+
 .commentList {
   list-style: none;
   padding: 0;
   margin-bottom: 1rem;
 }
+
 .comment {
-  padding: 0.5rem;
-  margin-bottom: 0.5rem;
-  background: var(--secondary);
-  color: #fff;
-  border-radius: 0.5rem;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  background: #f7f5ef;
+  background-image: url('/images/paper_background.webp');
+  border: 1px solid #ddd;
+  color: var(--ink);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
 }
+
 .commentAuthor {
   font-weight: bold;
-  margin-right: 0.25rem;
+  display: block;
+  margin-bottom: 0.25rem;
 }
+
+.commentContent {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.commentActions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
 .replyButton {
   background: none;
   border: none;
-  color: inherit;
-  margin-left: 0.5rem;
+  color: var(--primary);
   cursor: pointer;
   text-decoration: underline;
   font-size: 0.875rem;
 }
+
 .reportButton {
   background: none;
   border: none;
-  margin-left: 0.5rem;
   cursor: pointer;
   padding: 0;
   display: inline-flex;
   align-items: center;
+  color: var(--primary);
 }
+
 .reportButton img {
   width: 16px;
   height: 16px;
 }
+
 .reportCount {
   margin-left: 0.25rem;
   font-size: 0.75rem;
 }
+
 .replying {
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
-  color: var(--secondary);
+  color: var(--primary);
 }
+
 .form {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
+
 .textarea {
   resize: vertical;
+  padding: 0.5rem;
+  font-family: "Georgia", "Times New Roman", serif;
+  background: #f7f5ef;
+  background-image: url('/images/paper_background.webp');
+  border: 1px solid #ddd;
+  color: var(--ink);
+  line-height: 1.4;
 }
+
 .button {
   align-self: flex-start;
 }
+
 .error {
   color: var(--error-red);
 }

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -95,26 +95,28 @@ export default function CommentsSection({
           {comments.map((c) => (
             <li key={c.id} className={styles.comment}>
               <span className={styles.commentAuthor}>{c.writer?.userName || 'Anonymous'}:</span>
-              {c.content}
-              <button
-                type="button"
-                className={styles.reportButton}
-                onClick={() => handleReport(c.id)}
-                disabled={reported[c.id]}
-                aria-label="Report comment"
-              >
-                <img src="/report.svg" alt="Report" />
-                {c.reportCount ? (
-                  <span className={styles.reportCount}>{c.reportCount}</span>
-                ) : null}
-              </button>
-              <button
-                type="button"
-                className={styles.replyButton}
-                onClick={() => setReplyTo(c.id)}
-              >
-                Reply
-              </button>
+              <p className={styles.commentContent}>{c.content}</p>
+              <div className={styles.commentActions}>
+                <button
+                  type="button"
+                  className={styles.replyButton}
+                  onClick={() => setReplyTo(c.id)}
+                >
+                  Reply
+                </button>
+                <button
+                  type="button"
+                  className={styles.reportButton}
+                  onClick={() => handleReport(c.id)}
+                  disabled={reported[c.id]}
+                  aria-label="Report comment"
+                >
+                  <img src="/report.svg" alt="Report" />
+                  {c.reportCount ? (
+                    <span className={styles.reportCount}>{c.reportCount}</span>
+                  ) : null}
+                </button>
+              </div>
             </li>
           ))}
         </ul>
@@ -129,6 +131,7 @@ export default function CommentsSection({
           rows={3}
           required
           className={styles.textarea}
+          placeholder="Share your thoughts..."
         />
         <button type="submit" disabled={submitting} className={styles.button}>
           Post Comment


### PR DESCRIPTION
## Summary
- Restyle the comment section with a paper-texture background and serif typography for a newspaper feel
- Introduce clearer comment markup with separated content and actions
- Add a placeholder and newspaper-like appearance to the comment textarea

## Testing
- `npm test`
- `npm run lint` *(fails: various pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b6a267af883279374516a4895ea22