### PR TITLE
feat: require login for article interactions

### DIFF
--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -92,6 +92,16 @@
   color: var(--ink);
 }
 
+.relatedBar {
+  margin: 1rem 0;
+  font-size: 0.875rem;
+}
+
+.separator {
+  margin: 0 0.5rem;
+  color: #b6b6b6;
+}
+
 .breaking {
   background: rgb(8, 0, 255);
   color: #fff;

--- a/WT4Q/src/components/LikeButton.module.css
+++ b/WT4Q/src/components/LikeButton.module.css
@@ -15,3 +15,23 @@
 .button:hover {
   color: var(--accent);
 }
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.prompt {
+  background: #fff;
+  padding: 1rem 2rem;
+  border-radius: 4px;
+  text-align: center;
+}

--- a/WT4Q/src/components/LikeButton.tsx
+++ b/WT4Q/src/components/LikeButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { API_ROUTES } from '@/lib/api';
 import styles from './LikeButton.module.css';
 
@@ -13,14 +14,30 @@ export default function LikeButton({
 }) {
   const [count, setCount] = useState(initialCount);
   const [liked, setLiked] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
+  const [loginHref, setLoginHref] = useState('/login');
+
+  useEffect(() => {
+    setLoginHref(
+      `/login?returnUrl=${encodeURIComponent(window.location.href + '#like')}`
+    );
+  }, []);
+
   const toggle = async () => {
     try {
-      const res = await fetch(`${API_ROUTES.ARTICLE.LIKE}?Id=${articleId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ type: 0 }),
-      });
+      const res = await fetch(
+        `${API_ROUTES.ARTICLE.LIKE}?ArticleId=${articleId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ type: 0 }),
+        }
+      );
+      if (res.status === 401) {
+        setShowLogin(true);
+        return;
+      }
       if (res.ok) {
         setLiked(!liked);
         setCount(count + (liked ? -1 : 1));
@@ -30,8 +47,23 @@ export default function LikeButton({
     }
   };
   return (
-    <button onClick={toggle} className={styles.button} aria-pressed={liked}>
-      👍 <span className={styles.count}>{count}</span>
-    </button>
+    <>
+      <button
+        id="like"
+        onClick={toggle}
+        className={styles.button}
+        aria-pressed={liked}
+      >
+        👍 <span className={styles.count}>{count}</span>
+      </button>
+      {showLogin && (
+        <div className={styles.overlay} onClick={() => setShowLogin(false)}>
+          <div className={styles.prompt} onClick={(e) => e.stopPropagation()}>
+            <p>Login to like</p>
+            <Link href={loginHref}>Go to login</Link>
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- inline recommended article links beside article separated by vertical bars
- require login before commenting
- show login overlay when unauthenticated users try to like an article

## Testing
- `npm run lint` *(fails: Link is defined but never used, Unexpected any)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6f1e5ebc83279b9ea2f5d1dcc7c6