### PR TITLE
Add hoverable arrow navigation to breaking news slider

### DIFF
--- a/WT4Q/src/components/BreakingNewsSlider.module.css
+++ b/WT4Q/src/components/BreakingNewsSlider.module.css
@@ -5,6 +5,7 @@
   margin: 1rem 0;
   border-radius: 4px;
   text-align: center;
+  position: relative;
 }
 
 .item {
@@ -63,4 +64,31 @@
 .readMore {
   color: var(--ink);
   text-decoration: underline;
+}
+
+.arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.3s;
+  padding: 0 0.25rem;
+  z-index: 1;
+}
+
+.slider:hover .arrow {
+  opacity: 1;
+}
+
+.left {
+  left: 0.25rem;
+}
+
+.right {
+  right: 0.25rem;
 }

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -22,12 +22,14 @@ export default function BreakingNewsSlider({
 }) {
   const [index, setIndex] = useState(0);
 
+  const next = () => setIndex((i) => (i + 1) % articles.length);
+  const prev = () => setIndex((i) => (i - 1 + articles.length) % articles.length);
+
   useEffect(() => {
     if (articles.length === 0) return;
-    const interval = setInterval(() => {
-      setIndex((i) => (i + 1) % articles.length);
-    }, 5000);
+    const interval = setInterval(next, 5000);
     return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [articles]);
 
   if (articles.length === 0) return null;
@@ -39,6 +41,20 @@ export default function BreakingNewsSlider({
 
   return (
     <div className={`${styles.slider} ${className ?? ''}`.trim()}>
+      <button
+        className={`${styles.arrow} ${styles.left}`}
+        onClick={prev}
+        aria-label="Previous article"
+      >
+        ‹
+      </button>
+      <button
+        className={`${styles.arrow} ${styles.right}`}
+        onClick={next}
+        aria-label="Next article"
+      >
+        ›
+      </button>
       {showDetails ? (
         <div className={styles.detail}>
           {imageSrc && (


### PR DESCRIPTION
## Summary
- add prev/next handlers for breaking news slider and hook to auto-advance
- display left/right arrow buttons that appear on hover for manual navigation
- style arrows for seamless appearance on the breaking news bar

## Testing
- `npm test`
- `npm run lint` *(fails: `'Link' is defined but never used`, `Unexpected any` and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b7a3f7af48327b7c339d17858d68b