### PR TITLE
style: center login prompts in bordered boxes

### DIFF
--- a/WT4Q/src/components/CommentsSection.module.css
+++ b/WT4Q/src/components/CommentsSection.module.css
@@ -106,3 +106,11 @@
 .error {
   color: var(--error-red);
 }
+
+.loginPrompt {
+  border: 3px double var(--primary);
+  padding: 0.75rem 1.5rem;
+  width: fit-content;
+  margin: 1rem auto;
+  text-align: center;
+}

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -154,7 +154,7 @@ export default function CommentsSection({
           {error && <p className={styles.error}>{error}</p>}
         </form>
       ) : (
-        <p>
+        <p className={styles.loginPrompt}>
           <Link href={loginHref}>Log in to comment</Link>
         </p>
       )}

--- a/WT4Q/src/components/LikeButton.module.css
+++ b/WT4Q/src/components/LikeButton.module.css
@@ -31,7 +31,8 @@
 
 .prompt {
   background: #fff;
-  padding: 1rem 2rem;
+  padding: 0.75rem 1.5rem;
   border-radius: 4px;
   text-align: center;
+  border: 3px double var(--primary);
 }


### PR DESCRIPTION
## Summary
- center comment login prompt in a double-bordered box
- add double border styling to like button login dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b71d6f0488327bce52d1fbd98d690