### PR TITLE
fix: correct article like query parameter

### DIFF
--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -25,7 +25,7 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
   const send = async (type: 0 | 2) => {
     try {
       const res = await fetch(
-        `${API_ROUTES.ARTICLE.LIKE}?Id=${articleId}`,
+        `${API_ROUTES.ARTICLE.LIKE}?ArticleId=${articleId}`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- send the article ID using `ArticleId` in ReactionButtons

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run lint` *(fails: `Link` is defined but never used... among other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c61965df883279d7b963a6642698d