### PR TITLE
Fix article like API query parameter

### DIFF
--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -25,7 +25,7 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
   const send = async (type: 0 | 2) => {
     try {
       const res = await fetch(
-        `${API_ROUTES.ARTICLE.LIKE}?ArticleId=${articleId}`,
+        `${API_ROUTES.ARTICLE.LIKE}?Id=${articleId}`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- fix Article like endpoint query parameter to use `Id`

## Testing
- `npm test` *(fails: No test files found)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689c62dbba0083279658ef7141f79c24