### PR TITLE
Add like/dislike counts to article view

### DIFF
--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -73,8 +73,12 @@ namespace Northeast.Services
         }
 
         public async Task<Article> GetArticleByID(Guid Id) {
-            var Article = await _articleRepository.GetByGUId(Id);
-            return Article;
+            var article = await _appDbContext.Articles
+                .AsNoTracking()
+                .Include(a => a.Like)
+                .Include(a => a.Comments)
+                .FirstOrDefaultAsync(a => a.Id == Id);
+            return article;
         }
 
         public async Task<IEnumerable<Article>> Search(string query)

--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -23,8 +23,7 @@ interface ArticleDetails {
   embededCode?: string;
   author?: { adminName?: string };
   comments?: Comment[];
-  like?: { id: number }[];
-  dislike?: { id: number }[];
+  like?: { id: number; type: number }[];
 }
 
 interface RelatedArticle {
@@ -138,6 +137,9 @@ export default async function ArticlePage(
 
   const related = await fetchRelated(id);
 
+  const likeCount = article.like?.filter((l) => l.type === 0).length ?? 0;
+  const dislikeCount = article.like?.filter((l) => l.type === 2).length ?? 0;
+
   return (
     <div className={styles.newspaper}>
       <article className={styles.main}>
@@ -216,8 +218,8 @@ export default async function ArticlePage(
         <p className={styles.content}>{article.content}</p>
         <ReactionButtons
           articleId={id}
-          initialLikes={article.like?.length ?? 0}
-          initialDislikes={article.dislike?.length ?? 0}
+          initialLikes={likeCount}
+          initialDislikes={dislikeCount}
         />
         <CommentsSection
           articleId={id}


### PR DESCRIPTION
## Summary
- include article likes and comments when fetching article details
- count like and dislike reactions on article page and pass to ReactionButtons

## Testing
- `dotnet build`
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c65a1f0ac8327a7fef191cfcfbd78