### PR TITLE
Fix like toggle logic across stack

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -146,19 +146,15 @@ namespace Northeast.Controllers
                 return BadRequest(new { message = "Sorry, no article found with this ID" });
             }
 
-            var Like = await articleUpload.GetLikeByUserAndArticle(article.Id);
+            var existingLike = await articleUpload.GetLikeByUserAndArticle(article.Id);
 
-
-
-            if (await articleUpload.hasLiked(Id) && like.Type == Like.Type)
+            if (existingLike != null && like.Type == existingLike.Type)
             {
-                await articleUpload.DeleteLike(Like.Id);
+                await articleUpload.DeleteLike(existingLike.Id);
                 return Ok(new { message = "unliked" });
             }
-            if (await articleUpload.hasLiked(Id) && like.Type != Like.Type)
+            if (existingLike != null && like.Type != existingLike.Type)
             {
-                Like.Type = like.Type;
-
                 await articleUpload.ModifyLike(Id, like);
                 return Ok(new { message = "Like changed" });
             }

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -209,7 +209,6 @@ namespace Northeast.Services
                 like.Id = new int();
                 like.Article = Article;
                 like.ArticleId = Article.Id;
-                like.Type = like.Type;
                 like.User = user;
                 like.UserId = userId;
 
@@ -235,10 +234,10 @@ namespace Northeast.Services
 
             if (await _likeRepository.UserAlreadyLiked(userId, Article.Id))
             {
-                var Like = await _likeRepository.GetLikeByUserAndArticle(userId, Article.Id);
+                var existingLike = await _likeRepository.GetLikeByUserAndArticle(userId, Article.Id);
 
-                Like.Type = like.Type;
-                await _likeRepository.Update(like);
+                existingLike.Type = like.Type;
+                await _likeRepository.Update(existingLike);
                 return;
             }
             return;

--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -38,14 +38,29 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
         return;
       }
       if (res.ok) {
-        if (type === 0) {
-          setLikes(likes + (status === 'like' ? -1 : 1));
-          if (status === 'dislike') setDislikes(dislikes - 1);
-          setStatus(status === 'like' ? null : 'like');
-        } else {
-          setDislikes(dislikes + (status === 'dislike' ? -1 : 1));
-          if (status === 'like') setLikes(likes - 1);
-          setStatus(status === 'dislike' ? null : 'dislike');
+        const data = await res.json();
+        if (data.message === 'unliked') {
+          if (type === 0) setLikes(likes - 1);
+          else setDislikes(dislikes - 1);
+          setStatus(null);
+        } else if (data.message === 'Like changed') {
+          if (type === 0) {
+            setLikes(likes + 1);
+            setDislikes(dislikes - 1);
+            setStatus('like');
+          } else {
+            setDislikes(dislikes + 1);
+            setLikes(likes - 1);
+            setStatus('dislike');
+          }
+        } else if (data.message === 'Liked') {
+          if (type === 0) {
+            setLikes(likes + 1);
+            setStatus('like');
+          } else {
+            setDislikes(dislikes + 1);
+            setStatus('dislike');
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## Summary
- handle existing likes correctly when updating or removing reactions
- clarify article like controller logic and avoid redundant checks
- update reaction button UI to reflect API responses

## Testing
- `dotnet test`
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c6a2637cc8327b9a64ed86babe9fb