### PR TITLE
Fix like request path

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -130,9 +130,8 @@ namespace Northeast.Controllers
             return Ok(new { message = "The article has been deleted" });
         }
         [Authorize]
-        [HttpPut("Like")]
-
-        public async Task<IActionResult> Like(Guid Id, LikeEntity like)
+        [HttpPut("{Id}/Like")]
+        public async Task<IActionResult> Like([FromRoute] Guid Id, [FromBody] LikeEntity like)
         {
             if (Id == Guid.Empty)
             {

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -36,7 +36,7 @@ export const API_ROUTES = {
     FILTER: `${API_BASE_URL}/api/ArticleFilter`,
     UPDATE: `${API_BASE_URL}/api/Article`,
     DELETE: `${API_BASE_URL}/api/Article`,
-    LIKE: `${API_BASE_URL}/api/Article/Like`,
+    LIKE: (id: string) => `${API_BASE_URL}/api/Article/${id}/Like`,
     COMMENT: `${API_BASE_URL}/api/Article/Comment`,
     MODIFY_COMMENT: `${API_BASE_URL}/api/Article/ModifyComment`,
     REPORT_COMMENT: `${API_BASE_URL}/api/Article/ReportComment`,

--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -25,7 +25,7 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
   const send = async (type: 0 | 2) => {
     try {
       const res = await fetch(
-        `${API_ROUTES.ARTICLE.LIKE}?Id=${articleId}`,
+        API_ROUTES.ARTICLE.LIKE(articleId),
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- route like endpoint as /api/Article/{id}/Like in backend
- update frontend API helper and reaction component to call new route

## Testing
- `npm test` *(fails: No test files found)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c70e6e9648327991bc94bf508e654