### PR TITLE
Refactor article like endpoint and frontend handling

### DIFF
--- a/Northeast/DTOs/LikeRequest.cs
+++ b/Northeast/DTOs/LikeRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Northeast.DTOs
+{
+    public sealed class LikeRequest
+    {
+        [Required]
+        public int Type { get; set; }
+    }
+}

--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -37,30 +37,32 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
         setShowLogin(true);
         return;
       }
-      if (res.ok) {
-        const data = await res.json();
-        if (data.message === 'unliked') {
-          if (type === 0) setLikes(likes - 1);
-          else setDislikes(dislikes - 1);
-          setStatus(null);
-        } else if (data.message === 'Like changed') {
-          if (type === 0) {
-            setLikes(likes + 1);
-            setDislikes(dislikes - 1);
-            setStatus('like');
-          } else {
-            setDislikes(dislikes + 1);
-            setLikes(likes - 1);
-            setStatus('dislike');
-          }
-        } else if (data.message === 'Liked') {
-          if (type === 0) {
-            setLikes(likes + 1);
-            setStatus('like');
-          } else {
-            setDislikes(dislikes + 1);
-            setStatus('dislike');
-          }
+      if (!res.ok) {
+        const msg = await res.json().catch(() => ({}));
+        throw new Error(msg?.message || `Failed: ${res.status}`);
+      }
+      const data = await res.json();
+      if (data.message === 'unliked') {
+        if (type === 0) setLikes(likes - 1);
+        else setDislikes(dislikes - 1);
+        setStatus(null);
+      } else if (data.message === 'Like changed') {
+        if (type === 0) {
+          setLikes(likes + 1);
+          setDislikes(dislikes - 1);
+          setStatus('like');
+        } else {
+          setDislikes(dislikes + 1);
+          setLikes(likes - 1);
+          setStatus('dislike');
+        }
+      } else if (data.message === 'Liked') {
+        if (type === 0) {
+          setLikes(likes + 1);
+          setStatus('like');
+        } else {
+          setDislikes(dislikes + 1);
+          setStatus('dislike');
         }
       }
     } catch {
@@ -97,4 +99,3 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
     </>
   );
 }
-


### PR DESCRIPTION
## Summary
- add LikeRequest DTO and refactor article like API to use GUID and toggle likes properly
- clean up like service logic and expose GetArticleByGUID
- improve ReactionButtons fetch request with credentials and error handling

## Testing
- `dotnet build`
- `npm test` (fails: No test files found)

------
https://chatgpt.com/codex/tasks/task_e_689c770fdaac8327a09c776bcdf62e28