### PR TITLE
Restrict admin access and add hidden admin registration

### DIFF
--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -4,6 +4,7 @@ export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost
 export const API_ROUTES = {
   ADMIN_AUTH: {
     LOGIN: `${API_BASE_URL}/api/Admin/Adminlogin`,
+    REGISTER: `${API_BASE_URL}/api/Admin/Adminregister`,
     LOGOUT: `${API_BASE_URL}/api/Admin/Adminlogout`,
     ME: `${API_BASE_URL}/api/Admin/me`,
   },

--- a/WT4Q/src/app/admin-login/AdminLogin.module.css
+++ b/WT4Q/src/app/admin-login/AdminLogin.module.css
@@ -71,6 +71,16 @@
   box-shadow: 0 4px 10px rgba(0,0,0,0.3);
 }
 
+.success {
+  background: #2e7d32;
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+}
+
 .form {
   display: flex;
   flex-direction: column;

--- a/WT4Q/src/app/admin-login/page.tsx
+++ b/WT4Q/src/app/admin-login/page.tsx
@@ -1,11 +1,30 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import AdminLoginClient from './AdminLoginClient';
+import { API_ROUTES } from '@/lib/api';
 
 export default async function AdminLoginPage() {
   const cookieStore = await cookies();
   if (cookieStore.get('JwtToken')) {
-    redirect('/admin/dashboard');
+    try {
+      const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+        headers: { Cookie: cookieStore.toString() },
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        const admin = await res.json();
+        const isAdmin =
+          admin?.role === 'Admin' ||
+          admin?.role === 'SuperAdmin' ||
+          admin?.roles?.includes?.('Admin') ||
+          admin?.roles?.includes?.('SuperAdmin');
+        if (isAdmin) {
+          redirect('/admin/dashboard');
+        }
+      }
+    } catch {
+      // ignore
+    }
   }
   return <AdminLoginClient />;
 }

--- a/WT4Q/src/app/admin/cocktails/page.tsx
+++ b/WT4Q/src/app/admin/cocktails/page.tsx
@@ -1,10 +1,27 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import CocktailDashboardClient from './CocktailDashboardClient';
+import { API_ROUTES } from '@/lib/api';
 
 export default async function CocktailDashboardPage() {
   const cookieStore = await cookies();
   if (!cookieStore.get('JwtToken')) {
+    redirect('/admin-login');
+  }
+  try {
+    const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+      headers: { Cookie: cookieStore.toString() },
+      cache: 'no-store',
+    });
+    if (!res.ok) redirect('/admin-login');
+    const admin = await res.json();
+    const isAdmin =
+      admin?.role === 'Admin' ||
+      admin?.role === 'SuperAdmin' ||
+      admin?.roles?.includes?.('Admin') ||
+      admin?.roles?.includes?.('SuperAdmin');
+    if (!isAdmin) redirect('/admin-login');
+  } catch {
     redirect('/admin-login');
   }
   return <CocktailDashboardClient />;

--- a/WT4Q/src/app/admin/edit/[id]/page.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import EditArticleClient from './EditArticleClient';
+import { API_ROUTES } from '@/lib/api';
 
 export default async function EditArticlePage({
   params,
@@ -9,6 +10,22 @@ export default async function EditArticlePage({
 }) {
   const cookieStore = await cookies();
   if (!cookieStore.get('JwtToken')) {
+    redirect('/admin-login');
+  }
+  try {
+    const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+      headers: { Cookie: cookieStore.toString() },
+      cache: 'no-store',
+    });
+    if (!res.ok) redirect('/admin-login');
+    const admin = await res.json();
+    const isAdmin =
+      admin?.role === 'Admin' ||
+      admin?.role === 'SuperAdmin' ||
+      admin?.roles?.includes?.('Admin') ||
+      admin?.roles?.includes?.('SuperAdmin');
+    if (!isAdmin) redirect('/admin-login');
+  } catch {
     redirect('/admin-login');
   }
   const { id } = await params;

--- a/WT4Q/src/app/admin/register/AdminRegisterClient.tsx
+++ b/WT4Q/src/app/admin/register/AdminRegisterClient.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, FormEvent, useTransition } from 'react';
+import { API_ROUTES } from '@/lib/api';
+import Button from '@/components/Button';
+import styles from '../../admin-login/AdminLogin.module.css';
+
+interface AdminRegisterRequest {
+  adminName: string;
+  email: string;
+  password: string;
+}
+
+export default function AdminRegisterClient() {
+  const [adminName, setAdminName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(API_ROUTES.ADMIN_AUTH.REGISTER, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ adminName, email, password } as AdminRegisterRequest),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(data.message || 'Registration failed');
+        }
+        setSuccess('Admin registered');
+        setAdminName('');
+        setEmail('');
+        setPassword('');
+      } catch (err) {
+        if (err instanceof Error) setError(err.message);
+        else setError('Registration failed');
+      }
+    });
+  };
+
+  return (
+    <main className={styles.container}>
+      <section className={styles.card} aria-labelledby="admin-register-title">
+        <h1 id="admin-register-title" className={styles.title}>
+          Admin Registration
+        </h1>
+        {error && <p className={styles.error}>{error}</p>}
+        {success && <p className={styles.success}>{success}</p>}
+        <form onSubmit={handleSubmit} className={styles.form} noValidate>
+          <div className={styles.field}>
+            <label htmlFor="name" className={styles.label}>
+              Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              required
+              value={adminName}
+              onChange={(e) => setAdminName(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="email" className={styles.label}>
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="password" className={styles.label}>
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className={styles.input}
+            />
+          </div>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? 'Loading...' : 'Register'}
+          </Button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/WT4Q/src/app/admin/register/page.tsx
+++ b/WT4Q/src/app/admin/register/page.tsx
@@ -1,9 +1,9 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import DashboardClient from './DashboardClient';
 import { API_ROUTES } from '@/lib/api';
+import AdminRegisterClient from './AdminRegisterClient';
 
-export default async function DashboardPage() {
+export default async function AdminRegisterPage() {
   const cookieStore = await cookies();
   if (!cookieStore.get('JwtToken')) {
     redirect('/admin-login');
@@ -15,14 +15,14 @@ export default async function DashboardPage() {
     });
     if (!res.ok) redirect('/admin-login');
     const admin = await res.json();
-    const isAdmin =
-      admin?.role === 'Admin' ||
+    const isSuperAdmin =
       admin?.role === 'SuperAdmin' ||
-      admin?.roles?.includes?.('Admin') ||
       admin?.roles?.includes?.('SuperAdmin');
-    if (!isAdmin) redirect('/admin-login');
+    if (!isSuperAdmin) {
+      redirect('/admin-login');
+    }
   } catch {
     redirect('/admin-login');
   }
-  return <DashboardClient />;
+  return <AdminRegisterClient />;
 }


### PR DESCRIPTION
## Summary
- secure admin pages by verifying user role before rendering
- add superadmin-only registration page for creating new admins
- avoid redirect loop for non-admin users hitting admin login

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689c7ccdc9088327a2e00e88785ea187