### PR TITLE
feat: restrict admin pages by role

### DIFF
--- a/WT4Q/src/app/admin/cocktails/CocktailDashboardClient.tsx
+++ b/WT4Q/src/app/admin/cocktails/CocktailDashboardClient.tsx
@@ -3,6 +3,7 @@ import { useState, FormEvent, useTransition } from 'react';
 import Link from 'next/link';
 import { API_ROUTES } from '@/lib/api';
 import styles from '../dashboard/dashboard.module.css';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 
 interface IngredientInput {
   name: string;
@@ -10,6 +11,7 @@ interface IngredientInput {
 }
 
 export default function CocktailDashboardClient() {
+  useAdminGuard();
   const [name, setName] = useState('');
   const [content, setContent] = useState('');
   const [ingredients, setIngredients] = useState<IngredientInput[]>([

--- a/WT4Q/src/app/admin/cocktails/page.tsx
+++ b/WT4Q/src/app/admin/cocktails/page.tsx
@@ -1,11 +1,7 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 import CocktailDashboardClient from './CocktailDashboardClient';
+import { ensureAdmin } from '@/app/admin/ensureAdmin';
 
 export default async function CocktailDashboardPage() {
-  const cookieStore = await cookies();
-  if (!cookieStore.get('JwtToken')) {
-    redirect('/admin-login');
-  }
+  await ensureAdmin();
   return <CocktailDashboardClient />;
 }

--- a/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
+++ b/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
@@ -13,9 +13,11 @@ import { ARTICLE_TYPES } from '@/lib/articleTypes';
 import { UPLOADCATEGORIES } from '@/lib/categories';
 import styles from './dashboard.module.css';
 import countries from '../../../../public/datas/Countries.json';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 
 export default function DashboardClient() {
   const router = useRouter();
+  const admin = useAdminGuard();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [type, setType] = useState('');
@@ -35,12 +37,8 @@ export default function DashboardClient() {
 
   useEffect(() => {
     async function load() {
+      if (!admin?.id) return;
       try {
-        const adminRes = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
-          credentials: 'include',
-        });
-        if (!adminRes.ok) return;
-        const admin = await adminRes.json();
         const res = await fetch(API_ROUTES.ARTICLE.SEARCH_BY_AUTHOR(admin.id), {
           credentials: 'include',
         });
@@ -52,7 +50,7 @@ export default function DashboardClient() {
       }
     }
     load();
-  }, []);
+  }, [admin]);
 
 
   const handleLogout = async () => {

--- a/WT4Q/src/app/admin/dashboard/page.tsx
+++ b/WT4Q/src/app/admin/dashboard/page.tsx
@@ -1,11 +1,7 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 import DashboardClient from './DashboardClient';
+import { ensureAdmin } from '@/app/admin/ensureAdmin';
 
 export default async function DashboardPage() {
-  const cookieStore = await cookies();
-  if (!cookieStore.get('JwtToken')) {
-    redirect('/admin-login');
-  }
+  await ensureAdmin();
   return <DashboardClient />;
 }

--- a/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
@@ -8,6 +8,7 @@ import { CATEGORIES } from '@/lib/categories';
 import countries from '../../../../../public/datas/Countries.json';
 import styles from '../../dashboard/dashboard.module.css';
 import type { ArticleImage } from '@/lib/models';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 
 interface ArticleDetails {
   title: string;
@@ -24,6 +25,7 @@ interface ArticleDetails {
 
 export default function EditArticleClient({ id }: { id: string }) {
   const router = useRouter();
+  const admin = useAdminGuard();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [type, setType] = useState('');
@@ -41,6 +43,7 @@ export default function EditArticleClient({ id }: { id: string }) {
 
   useEffect(() => {
     async function load() {
+      if (!admin) return;
       try {
         const res = await fetch(API_ROUTES.ARTICLE.GET_BY_ID(id), {
           credentials: 'include',
@@ -71,7 +74,7 @@ export default function EditArticleClient({ id }: { id: string }) {
       }
     }
     load();
-  }, [id]);
+  }, [id, admin]);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/WT4Q/src/app/admin/edit/[id]/page.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/page.tsx
@@ -1,16 +1,12 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 import EditArticleClient from './EditArticleClient';
+import { ensureAdmin } from '@/app/admin/ensureAdmin';
 
 export default async function EditArticlePage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const cookieStore = await cookies();
-  if (!cookieStore.get('JwtToken')) {
-    redirect('/admin-login');
-  }
+  await ensureAdmin();
   const { id } = await params;
   return <EditArticleClient id={id} />;
 }

--- a/WT4Q/src/app/admin/ensureAdmin.ts
+++ b/WT4Q/src/app/admin/ensureAdmin.ts
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { API_ROUTES } from '@/lib/api';
+import type { AdminInfo } from '@/hooks/useAdminGuard';
+
+const ALLOWED_ROLES = ['admin', 'superadmin'];
+
+export async function ensureAdmin() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('JwtToken');
+  if (!token) {
+    redirect('/admin-login');
+  }
+
+  const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+    headers: {
+      Cookie: `JwtToken=${token.value}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    redirect('/admin-login');
+  }
+
+  const data: AdminInfo = await res.json();
+  const roles: string[] = [];
+  if (typeof data.role === 'string') {
+    roles.push(data.role.toLowerCase());
+  }
+  if (Array.isArray(data.roles)) {
+    data.roles.forEach((r) => roles.push(r.toLowerCase()));
+  }
+  if (data.isAdmin) roles.push('admin');
+  if (data.isSuperAdmin) roles.push('superadmin');
+
+  if (!roles.some((r) => ALLOWED_ROLES.includes(r))) {
+    redirect('/admin-login');
+  }
+
+  return data;
+}

--- a/WT4Q/src/hooks/useAdminGuard.ts
+++ b/WT4Q/src/hooks/useAdminGuard.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { API_ROUTES } from '@/lib/api';
+
+const ALLOWED_ROLES = ['admin', 'superadmin'];
+
+export interface AdminInfo {
+  id?: string;
+  role?: string;
+  roles?: string[];
+  isAdmin?: boolean;
+  isSuperAdmin?: boolean;
+  [key: string]: unknown;
+}
+
+export function useAdminGuard() {
+  const router = useRouter();
+  const [admin, setAdmin] = useState<AdminInfo | null>(null);
+
+  useEffect(() => {
+    async function check() {
+      try {
+        const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          router.replace('/admin-login');
+          return;
+        }
+        const data: AdminInfo = await res.json();
+        const roles: string[] = [];
+        if (typeof data.role === 'string') {
+          roles.push(data.role.toLowerCase());
+        }
+        if (Array.isArray(data.roles)) {
+          data.roles.forEach((r) => roles.push(r.toLowerCase()));
+        }
+        if (data.isAdmin) roles.push('admin');
+        if (data.isSuperAdmin) roles.push('superadmin');
+
+        if (!roles.some((r) => ALLOWED_ROLES.includes(r))) {
+          router.replace('/admin-login');
+          return;
+        }
+
+        setAdmin(data);
+      } catch {
+        router.replace('/admin-login');
+      }
+    }
+    check();
+  }, [router]);
+
+  return admin;
+}
+


### PR DESCRIPTION
## Summary
- add shared `ensureAdmin` server utility
- add `useAdminGuard` hook for client-side role verification
- guard admin routes and dashboards to require admin or superadmin roles

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c7eec861c832796cd751f67c80b2a