### PR TITLE
Fix admin login redirect loop

### DIFF
--- a/WT4Q/src/app/admin-login/page.tsx
+++ b/WT4Q/src/app/admin-login/page.tsx
@@ -1,11 +1,41 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import AdminLoginClient from './AdminLoginClient';
+import { API_ROUTES } from '@/lib/api';
+import type { AdminInfo } from '@/hooks/useAdminGuard';
+
+const ALLOWED_ROLES = ['admin', 'superadmin'];
 
 export default async function AdminLoginPage() {
   const cookieStore = await cookies();
-  if (cookieStore.get('JwtToken')) {
-    redirect('/admin/dashboard');
+  const token = cookieStore.get('JwtToken');
+
+  if (token) {
+    try {
+      const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+        headers: { Cookie: `JwtToken=${token.value}` },
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        const data: AdminInfo = await res.json();
+        const roles: string[] = [];
+        if (typeof data.role === 'string') {
+          roles.push(data.role.toLowerCase());
+        }
+        if (Array.isArray(data.roles)) {
+          data.roles.forEach((r) => roles.push(r.toLowerCase()));
+        }
+        if (data.isAdmin) roles.push('admin');
+        if (data.isSuperAdmin) roles.push('superadmin');
+
+        if (roles.some((r) => ALLOWED_ROLES.includes(r))) {
+          redirect('/admin/dashboard');
+        }
+      }
+    } catch {
+      // ignore errors and show login
+    }
   }
+
   return <AdminLoginClient />;
 }


### PR DESCRIPTION
## Summary
- prevent invalid admin tokens from causing redirect loops by verifying roles before redirecting to dashboard

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c82a4c62c8327916a9ede9c88f612