### PR TITLE
fix: await search params

### DIFF
--- a/WT4Q/src/app/login/page.tsx
+++ b/WT4Q/src/app/login/page.tsx
@@ -10,11 +10,13 @@ export const metadata = {
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams?: { from?: string };
+  searchParams?: Promise<{ from?: string }>;
 }) {
   const cookieStore = await cookies();
   if (cookieStore.get('JwtToken')) {
     redirect('/');
   }
-  return <LoginClient from={searchParams?.from} />;
+
+  const params = await searchParams;
+  return <LoginClient from={params?.from} />;
 }


### PR DESCRIPTION
## Summary
- await searchParams in login page before using query

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689ca8ef8b2c8327b84f867d6171987a