### PR TITLE
Fix CSS module root selector error by scoping variables

### DIFF
--- a/WT4Q/src/app/page.module.css
+++ b/WT4Q/src/app/page.module.css
@@ -1,7 +1,9 @@
 /* app/page.module.css */
 
 /* --- Palette & rhythm --- */
-:root {
+
+.newspaper {
+  /* Custom properties scoped to this layout */
   --paper: #f7f5ef00;          /* slightly warm paper */
   --ink: #111;               /* rich black */
   --muted-ink: #333;         /* text rules */
@@ -10,9 +12,7 @@
   --accent: #6a0000;         /* deep burgundy for kickers */
   --gutter: 2rem;
   --col-gap: 2.25rem;
-}
 
-.newspaper {
   background: var(--paper);
   background-image: url('/images/paper_background.webp');
   color: var(--ink);


### PR DESCRIPTION
## Summary
- scope page-level CSS custom properties to `.newspaper` class to avoid invalid `:root` selector in CSS module

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: various lint errors)*
- `npm run build -- --no-lint` *(fails: prerender error on /contact page)*

------
https://chatgpt.com/codex/tasks/task_e_689cc87394f483279c6283390cd58c29