### PR TITLE
Prefetch internal links for faster navigation

### DIFF
--- a/WT4Q/src/app/admin/cocktails/CocktailDashboardClient.tsx
+++ b/WT4Q/src/app/admin/cocktails/CocktailDashboardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, FormEvent, useTransition } from 'react';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES } from '@/lib/api';
 import styles from '../dashboard/dashboard.module.css';
 import { useAdminGuard } from '@/hooks/useAdminGuard';
@@ -66,9 +66,9 @@ export default function CocktailDashboardClient() {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Cocktail Manager</h1>
-      <Link href="/admin/dashboard" className={styles.button}>
+      <PrefetchLink href="/admin/dashboard" className={styles.button}>
         Back to Dashboard
-      </Link>
+      </PrefetchLink>
       {error && <p className={styles.error}>{error}</p>}
       {success && <p className={styles.success}>{success}</p>}
       <form onSubmit={handleSubmit} className={styles.form}>

--- a/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
+++ b/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
@@ -7,7 +7,7 @@ import {
   useTransition,
 } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES } from '@/lib/api';
 import { ARTICLE_TYPES } from '@/lib/articleTypes';
 import { UPLOADCATEGORIES } from '@/lib/categories';
@@ -319,7 +319,7 @@ export default function DashboardClient() {
           {isPending ? 'Publishing...' : 'Publish'}
         </button>
       </form>
-      <Link href="/admin/cocktails" className={styles.button} style={{marginTop:'1rem'}}>Upload Cocktail</Link>
+      <PrefetchLink href="/admin/cocktails" className={styles.button} style={{marginTop:'1rem'}}>Upload Cocktail</PrefetchLink>
       <h2 className={styles.subtitle}>Your Articles</h2>
       <ul className={styles.list}>
         {articles.map((a) => (

--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -7,7 +7,7 @@ import { API_ROUTES } from '@/lib/api';
 import type { Metadata } from 'next';
 import styles from '../article.module.css';
 import type { ArticleImage } from '@/lib/models';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 
 /* ---------------------- types ---------------------- */
 
@@ -163,7 +163,7 @@ export default async function ArticlePage(
             <p className={styles.relatedBar}>
               {related.map((a, i) => (
                 <span key={a.id}>
-                  <Link href={`/articles/${a.id}`}>{a.title}</Link>
+                  <PrefetchLink href={`/articles/${a.id}`}>{a.title}</PrefetchLink>
                   {i < related.length - 1 && (
                     <span className={styles.separator}>|</span>
                   )}

--- a/WT4Q/src/app/error.tsx
+++ b/WT4Q/src/app/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { useEffect } from 'react';
 import HomeIcon from '../components/HomeIcon';
 import styles from './error-page.module.css';
@@ -16,10 +16,10 @@ export default function Error({ error }: { error: Error & { digest?: string }; r
         <span className={styles.heading}>Breaking News</span>
         <h1 className={styles.headline}>Something went wrong</h1>
         <p className={styles.message}>Sorry, an unexpected error occurred.</p>
-        <Link href="/" className={styles.homeLink}>
+        <PrefetchLink href="/" className={styles.homeLink}>
           <HomeIcon className={styles.homeIcon} />
           Back to the homepage
-        </Link>
+        </PrefetchLink>
       </div>
     </div>
   );

--- a/WT4Q/src/app/forgot-password/ForgotPasswordClient.tsx
+++ b/WT4Q/src/app/forgot-password/ForgotPasswordClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, FormEvent } from 'react';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import styles from './ForgotPassword.module.css';
 import { API_ROUTES } from '@/lib/api';
 
@@ -112,9 +112,9 @@ export default function ForgotPasswordClient() {
       {step === 3 && (
         <div className={styles.form}>
           {message && <p className={styles.success}>{message}</p>}
-          <Link href="/login" className={styles.link}>
+          <PrefetchLink href="/login" className={styles.link}>
             Return to login
-          </Link>
+          </PrefetchLink>
         </div>
       )}
     </main>

--- a/WT4Q/src/app/global-error.tsx
+++ b/WT4Q/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { useEffect } from 'react';
 import HomeIcon from '../components/HomeIcon';
 import styles from './error-page.module.css';
@@ -17,10 +17,10 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
           <span className={styles.heading}>Breaking News</span>
           <h1 className={styles.headline}>Something went wrong</h1>
           <p className={styles.message}>Sorry, an unexpected error occurred.</p>
-          <Link href="/" className={styles.homeLink}>
+          <PrefetchLink href="/" className={styles.homeLink}>
             <HomeIcon className={styles.homeIcon} />
             Back to the homepage
-          </Link>
+          </PrefetchLink>
         </div>
       </body>
     </html>

--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import Image from 'next/image';
 import styles from './Login.module.css';
 import Button from '@/components/Button';
@@ -141,9 +141,9 @@ const LoginClient: FC<Props> = ({ from }) => {
               </button>
             </div>
             <p className={styles.forgot}>
-              <Link href="/forgot-password" className={styles.switchLink}>
+              <PrefetchLink href="/forgot-password" className={styles.switchLink}>
                 Forgot password?
-              </Link>
+              </PrefetchLink>
             </p>
           </div>
 
@@ -167,9 +167,9 @@ const LoginClient: FC<Props> = ({ from }) => {
         </Button>
         <p className={styles.switch}>
           Don&apos;t have an account?{' '}
-          <Link href="/register" className={styles.switchLink}>
+          <PrefetchLink href="/register" className={styles.switchLink}>
             Register
-          </Link>
+          </PrefetchLink>
         </p>
       </section>
     </main>

--- a/WT4Q/src/app/not-found.tsx
+++ b/WT4Q/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import HomeIcon from '../components/HomeIcon';
 import styles from './error-page.module.css';
 
@@ -9,10 +9,10 @@ export default function NotFound() {
         <span className={styles.heading}>Breaking News</span>
         <h1 className={styles.headline}>Page not found</h1>
         <p className={styles.message}>Sorry, we couldn&apos;t find the page you were looking for.</p>
-        <Link href="/" className={styles.homeLink}>
+        <PrefetchLink href="/" className={styles.homeLink}>
           <HomeIcon className={styles.homeIcon} />
           Back to the homepage
-        </Link>
+        </PrefetchLink>
       </div>
     </div>
   );

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -6,7 +6,6 @@ import type { ArticleImage } from '@/lib/models';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import styles from './page.module.css';
 import WeatherWidget from '@/components/WeatherWidget';
 
@@ -152,9 +151,9 @@ export default async function Home() {
       <footer className={styles.footer}>
         <nav className={styles.footerNav}>
           {CATEGORIES.map((c) => (
-            <Link key={c} href={`/category/${encodeURIComponent(c)}`} className={styles.footerLink}>
+            <PrefetchLink key={c} href={`/category/${encodeURIComponent(c)}`} className={styles.footerLink}>
               {c}
-            </Link>
+            </PrefetchLink>
           ))}
         </nav>
       </footer>*/}

--- a/WT4Q/src/app/register/RegisterClient.tsx
+++ b/WT4Q/src/app/register/RegisterClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { FC, useState, FormEvent, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import Image from 'next/image';
 import styles from './Register.module.css';
 import Button from '@/components/Button';
@@ -213,9 +213,9 @@ const Register: FC = () => {
         </Button>
         <p className={styles.switch}>
           Already have an account?{' '}
-          <Link href="/login" className={styles.switchLink}>
+          <PrefetchLink href="/login" className={styles.switchLink}>
             Sign In
-          </Link>
+          </PrefetchLink>
         </p>
       </section>
     </main>

--- a/WT4Q/src/app/search/page.tsx
+++ b/WT4Q/src/app/search/page.tsx
@@ -4,7 +4,7 @@ export const dynamic = 'force-dynamic';
 
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import { API_ROUTES } from '@/lib/api';
 import styles from './search.module.css';
@@ -63,9 +63,9 @@ function SearchContent() {
           Search
         </button>
       </form>
-      <Link href="/search/advanced" className={styles.advancedLink}>
+      <PrefetchLink href="/search/advanced" className={styles.advancedLink}>
         Advanced search
-      </Link>
+      </PrefetchLink>
       <div className={styles.results}>
         {results.map((a) => (
           <ArticleCard key={a.id} article={a} />

--- a/WT4Q/src/components/ArticleCard.tsx
+++ b/WT4Q/src/components/ArticleCard.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import styles from './ArticleCard.module.css';
 
 export interface Article {
@@ -9,10 +9,10 @@ export interface Article {
 
 export default function ArticleCard({ article }: { article: Article }) {
   return (
-    <Link href={`/articles/${article.id}`} className={styles.card}>
+    <PrefetchLink href={`/articles/${article.id}`} className={styles.card}>
       <h2 className={styles.title}>{article.title}</h2>
       <p className={styles.summary}>{article.summary}</p>
       <span className={styles.readMore}>Read more</span>
-    </Link>
+    </PrefetchLink>
   );
 }

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import styles from './BreakingNewsSlider.module.css';
 import type { ArticleImage } from '@/lib/models';
 
@@ -75,14 +75,14 @@ export default function BreakingNewsSlider({
               {current.content.split(/\s+/).slice(0, 20).join(' ')}...
             </p>
           )}
-          <Link href={`/articles/${current.id}`} className={styles.readMore}>
+          <PrefetchLink href={`/articles/${current.id}`} className={styles.readMore}>
             Read more
-          </Link>
+          </PrefetchLink>
         </div>
       ) : (
-        <Link href={`/articles/${current.id}`} className={styles.item}>
+        <PrefetchLink href={`/articles/${current.id}`} className={styles.item}>
           {current.title}
-        </Link>
+        </PrefetchLink>
       )}
       <div className={styles.dots}>
         {articles.map((_, i) => (

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, FormEvent, useEffect } from 'react';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES } from '@/lib/api';
 import styles from './CommentsSection.module.css';
 
@@ -155,7 +155,7 @@ export default function CommentsSection({
         </form>
       ) : (
         <p className={styles.loginPrompt}>
-          <Link href={loginHref}>Log in to comment</Link>
+          <PrefetchLink href={loginHref}>Log in to comment</PrefetchLink>
         </p>
       )}
     </section>

--- a/WT4Q/src/components/Footer.tsx
+++ b/WT4Q/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import styles from './Footer.module.css';
 
 export default function Footer() {
@@ -7,13 +7,13 @@ export default function Footer() {
       <div className={styles.inner}>
         &copy; {new Date().getFullYear()} WT4Q News{' '}
         <span aria-hidden="true">|</span>{' '}
-        <Link href="/terms">Terms &amp; Cookies</Link>{' '}
+        <PrefetchLink href="/terms">Terms &amp; Cookies</PrefetchLink>{' '}
         <span aria-hidden="true">|</span>{' '}
-        <Link href="/about">About</Link>{' '}
+        <PrefetchLink href="/about">About</PrefetchLink>{' '}
         <span aria-hidden="true">|</span>{' '}
-        <Link href="/contact?type=problem">Report a Problem</Link>{' '}
+        <PrefetchLink href="/contact?type=problem">Report a Problem</PrefetchLink>{' '}
         <span aria-hidden="true">|</span>{' '}
-        <Link href="/contact">Contact Us</Link>
+        <PrefetchLink href="/contact">Contact Us</PrefetchLink>
       </div>
     </footer>
   );

--- a/WT4Q/src/components/NotificationBell.tsx
+++ b/WT4Q/src/components/NotificationBell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
+import PrefetchLink from "@/components/PrefetchLink";
 import { API_ROUTES } from "@/lib/api";
 import styles from "./NotificationBell.module.css";
 
@@ -24,10 +24,10 @@ export default function NotificationBell() {
   }, []);
 
   return (
-    <Link href="/notifications" className={styles.bell} aria-label="Notifications">
+    <PrefetchLink href="/notifications" className={styles.bell} aria-label="Notifications">
       <span>🔔</span>
       {unread > 0 && <span className={styles.badge}>{unread}</span>}
-    </Link>
+    </PrefetchLink>
   );
 }
 

--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES } from '@/lib/api';
 import styles from './ReactionButtons.module.css';
 
@@ -92,7 +92,7 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
         <div className={styles.overlay} onClick={() => setShowLogin(false)}>
           <div className={styles.prompt} onClick={(e) => e.stopPropagation()}>
             <p>Login to react</p>
-            <Link href={loginHref}>Go to login</Link>
+            <PrefetchLink href={loginHref}>Go to login</PrefetchLink>
           </div>
         </div>
       )}

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import PrefetchLink from '@/components/PrefetchLink';
 import { useRouter } from 'next/navigation';
 import styles from './UserMenu.module.css';
 import { API_ROUTES } from '@/lib/api';
@@ -44,7 +44,7 @@ export default function UserMenu() {
 
   if (!user) {
     return (
-      <Link href="/login" className={styles.loginLink}>
+      <PrefetchLink href="/login" className={styles.loginLink}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
@@ -58,7 +58,7 @@ export default function UserMenu() {
           />
         </svg>
         <span className={styles.loginText}>Sign In</span>
-      </Link>
+      </PrefetchLink>
     );
   }
 
@@ -73,9 +73,9 @@ export default function UserMenu() {
       </button>
       {open && (
         <div className={styles.dropdown}>
-          <Link href="/profile" className={styles.item} onClick={() => setOpen(false)}>
+          <PrefetchLink href="/profile" className={styles.item} onClick={() => setOpen(false)}>
             Profile
-          </Link>
+          </PrefetchLink>
           <button onClick={handleLogout} className={styles.item}>
             Logout
           </button>


### PR DESCRIPTION
## Summary
- replace Next.js `<Link>` usage with `PrefetchLink` to prefetch destinations on hover
- update footer and navigation elements to ensure all internal routes are prefetched
- switch notification bell and user menu to use `PrefetchLink` for faster access

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689cc9e2413883278e361dfffdaf4164