### PR TITLE
Enhance tools & games SEO with responsive styling

### DIFF
--- a/WT4Q/src/app/games/2048_game_online/2048Game.module.css
+++ b/WT4Q/src/app/games/2048_game_online/2048Game.module.css
@@ -10,6 +10,7 @@
   --ly: 35%;
 
   max-width: 640px;
+  width: 100%;
   margin: 32px auto 64px;
   padding: 16px;
   border-radius: 24px;
@@ -97,6 +98,20 @@
   -webkit-backdrop-filter: blur(8px) saturate(120%);
 }
 .row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+
+@media (max-width: 480px) {
+  .wrapper {
+    margin: 16px auto 32px;
+    padding: 8px;
+  }
+  .board {
+    padding: 8px;
+    gap: 8px;
+  }
+  .row {
+    gap: 8px;
+  }
+}
 
 /* TILES: 3D POLISHED GLASS ------------------------------------------------- */
 .cell {

--- a/WT4Q/src/app/games/2048_game_online/head.tsx
+++ b/WT4Q/src/app/games/2048_game_online/head.tsx
@@ -1,0 +1,11 @@
+export default function Head() {
+  return (
+    <>
+      <title>2048 Game – Merge tiles and reach 2048</title>
+      <meta
+        name="description"
+        content="Play the classic 2048 puzzle game online on any device."
+      />
+    </>
+  );
+}

--- a/WT4Q/src/app/games/Games.module.css
+++ b/WT4Q/src/app/games/Games.module.css
@@ -1,0 +1,44 @@
+.main {
+  padding: 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.item {
+  position: relative;
+  border: 4px double #4b5563;
+  padding: 0.75rem;
+  margin: 0.75rem 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+}
+
+.preview {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 0.5rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  z-index: 10;
+}
+
+.item:hover .preview {
+  display: block;
+}
+
+.preview img {
+  max-width: 200px;
+  height: auto;
+  display: block;
+}

--- a/WT4Q/src/app/games/page.tsx
+++ b/WT4Q/src/app/games/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import PrefetchLink from '@/components/PrefetchLink';
+import styles from './Games.module.css';
 
 export const metadata: Metadata = {
   title: 'Games',
@@ -8,14 +9,22 @@ export const metadata: Metadata = {
 
 export default function GamesPage() {
   return (
-    <main style={{ padding: '1rem' }}>
+    <main className={styles.main}>
       <h1>Games</h1>
-      <ul>
-        <li>
-          <PrefetchLink href="/games/2048_game_online">2048</PrefetchLink>
-        </li>
-        <li>
-          <PrefetchLink href="/games/MergeFire/mergefire.html">MergeFire</PrefetchLink>
+      <ul className={styles.list}>
+        <li className={styles.item}>
+          <PrefetchLink
+            href="/games/2048_game_online"
+            title="Play the classic 2048 puzzle game"
+          >
+            2048
+          </PrefetchLink>
+          <div className={styles.preview}>
+            <img
+              src="https://via.placeholder.com/200?text=2048"
+              alt="2048 preview"
+            />
+          </div>
         </li>
       </ul>
     </main>

--- a/WT4Q/src/app/tools/Tools.module.css
+++ b/WT4Q/src/app/tools/Tools.module.css
@@ -1,0 +1,21 @@
+.main {
+  padding: 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.item {
+  border: 4px double #4b5563;
+  padding: 0.75rem;
+  margin: 0.75rem 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+}

--- a/WT4Q/src/app/tools/mememaker/head.tsx
+++ b/WT4Q/src/app/tools/mememaker/head.tsx
@@ -1,0 +1,11 @@
+export default function Head() {
+  return (
+    <>
+      <title>MemeMaker – Create Custom Memes</title>
+      <meta
+        name="description"
+        content="Create personalized memes with images and text using MemeMaker."
+      />
+    </>
+  );
+}

--- a/WT4Q/src/app/tools/page.tsx
+++ b/WT4Q/src/app/tools/page.tsx
@@ -1,26 +1,32 @@
 import { Metadata } from 'next';
 import PrefetchLink from '@/components/PrefetchLink';
+import styles from './Tools.module.css';
 
 export const metadata: Metadata = {
   title: 'Tools',
   description:
-    'Handy utilities including a free online Photoshop-like editor and a world clock.',
+    'Handy utilities including a meme generator and a world clock.',
 };
 
 export default function ToolsPage() {
   return (
-    <main style={{ padding: '1rem' }}>
+    <main className={styles.main}>
       <h1>Tools</h1>
-      <ul>
-        <li>
-          <PrefetchLink href="/tools/world-clock">World Clock</PrefetchLink>
+      <ul className={styles.list}>
+        <li className={styles.item}>
+          <PrefetchLink
+            href="/tools/world-clock"
+            title="World Clock – current times around the globe"
+          >
+            World Clock
+          </PrefetchLink>
         </li>
-        <li>
-          <PrefetchLink href="/tools/mememaker">Mememaker</PrefetchLink>
-        </li>
-        <li>
-          <PrefetchLink href="/tools/online-photoshop">
-            Free Online Photoshop
+        <li className={styles.item}>
+          <PrefetchLink
+            href="/tools/mememaker"
+            title="MemeMaker – create custom memes"
+          >
+            Mememaker
           </PrefetchLink>
         </li>
       </ul>

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -44,13 +44,6 @@ export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
           >
             Mememaker
           </PrefetchLink>
-          <PrefetchLink
-            href="/tools/online-photoshop"
-            className={styles.link}
-            onClick={onNavigate}
-          >
-            Free Online Photoshop
-          </PrefetchLink>
 
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove obsolete links from tools and games navigation
- Add SEO head metadata for MemeMaker and 2048 pages
- Style tools and games lists with double borders, hover previews, and responsive 2048 board

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dbad932b48327af6088833aabc7ef