### PR TITLE
Configure production domains and Docker deployment

### DIFF
--- a/Northeast/Dockerfile
+++ b/Northeast/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Northeast.dll"]

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -122,7 +122,10 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy(originsPolicy, policy =>
     {
-        policy.WithOrigins("https://localhost:7122", "http://localhost:3000", "https://localhost:3000", "http://localhost:3001", "https://localhost:3001")
+        policy.WithOrigins(
+            "https://www.wt4q.com",
+            "https://wt4q.com"
+        )
               .AllowAnyMethod()
               .AllowAnyHeader()
               .AllowCredentials();

--- a/Northeast/Properties/launchSettings.json
+++ b/Northeast/Properties/launchSettings.json
@@ -5,27 +5,27 @@
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Production"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:7122"
+      "applicationUrl": "http://server.wt4q.com"
     },
     "https": {
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Production"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "https://localhost:7122"
+      "applicationUrl": "https://server.wt4q.com"
     },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Production"
       }
     },
     "Container (Dockerfile)": {
@@ -45,8 +45,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:32133",
-      "sslPort": 44358
+      "applicationUrl": "https://server.wt4q.com",
+      "sslPort": 443
     }
   }
 }

--- a/Northeast/Services/SiteVisitorServices.cs
+++ b/Northeast/Services/SiteVisitorServices.cs
@@ -29,7 +29,7 @@ namespace Northeast.Services
         {
             var ipAddress = _getConnectedUser.GetUserIP();
             
-            // Fallback in case of localhost (will return the server's location)
+            // Fallback if running on a loopback address (will return the server's location)
             if (string.IsNullOrWhiteSpace(ipAddress) || ipAddress == "::1" || ipAddress == "127.0.0.1")
             {
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ npm run dev
 This project uses `cross-env` to set the `HTTPS` environment variable so the
 development server runs correctly on all platforms, including Windows.
 
-This starts the Next.js development server on https://localhost:3000.
+This starts the Next.js development server on your local machine (for example,
+https://127.0.0.1:3000). The production site is served at
+https://www.wt4q.com.
 
 Authentication cookies from the API are issued with the `Secure` and
 `SameSite=None` attributes (see

--- a/WT4Q/Dockerfile
+++ b/WT4Q/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine AS production
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/WT4Q/README.md
+++ b/WT4Q/README.md
@@ -17,7 +17,9 @@ bun dev
 `npm run dev` relies on `cross-env` to set the `HTTPS` environment variable so
 the development server works on Windows and Unix-based systems alike.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [https://www.wt4q.com](https://www.wt4q.com) to view the live site or
+visit your local development server (for example,
+[http://127.0.0.1:3000](http://127.0.0.1:3000)).
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -1,5 +1,6 @@
 
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:7122';
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'https://server.wt4q.com';
 
 export const API_ROUTES = {
   ADMIN_AUTH: {

--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -91,7 +91,8 @@ export async function generateMetadata(
   const article = await fetchArticle(id);
   if (!article) return {};
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
   const url = new URL(`/articles/${id}`, siteUrl).toString();
 
   const description =

--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -18,7 +18,8 @@ async function fetchArticles(cat: string): Promise<Article[]> {
 
 export async function generateMetadata({ params }: { params: Promise<{ category: string }> }): Promise<Metadata> {
   const { category } = await params;
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
   const url = `${siteUrl}/category/${encodeURIComponent(category)}`;
   const title = `${category} - WT4Q`;
   return {

--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -17,7 +17,8 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
 
 export const metadata: Metadata = {
   title: {

--- a/WT4Q/src/app/robots.txt/route.ts
+++ b/WT4Q/src/app/robots.txt/route.ts
@@ -3,7 +3,8 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-static';
 
 export function GET() {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
   const content = `User-agent: *\nAllow: /\nSitemap: ${siteUrl}/sitemap.xml`;
   return new NextResponse(content, {
     headers: { 'Content-Type': 'text/plain' },

--- a/WT4Q/src/app/sitemap.xml/route.ts
+++ b/WT4Q/src/app/sitemap.xml/route.ts
@@ -15,7 +15,8 @@ async function fetchUrls(): Promise<string[]> {
 }
 
 export async function GET() {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
   const articlePaths = await fetchUrls();
   const pages = ['/', '/search', '/terms', '/profile'];
   const urls = [...pages, ...articlePaths];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
-
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:15
     restart: always
     environment:
-      POSTGRES_USER: {POSTGRES_USER}
-      POSTGRES_PASSWORD: {POSTGRES_PASSWORD}
-      POSTGRES_DB: {DATABASE_NAME}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${DATABASE_NAME}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:
@@ -17,14 +18,26 @@ services:
   webapi:
     build: ./Northeast
     restart: always
-    user: "1654:1654"
-    volumes:
-      - ./Northeast:/app/src
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__DefaultConnection: Host=postgres;Port=5432;Database=${DATABASE_NAME};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
     ports:
-      - "5000:8080"
-    command: ["dotnet", "Northeast.dll"]
+      - "8080:8080"
+
+  frontend:
+    build: ./WT4Q
+    restart: always
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: https://server.wt4q.com
+      NEXT_PUBLIC_SITE_URL: https://www.wt4q.com
+    depends_on:
+      - webapi
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- point frontend defaults and API base URL to `wt4q.com` and `server.wt4q.com`
- allow production origins in backend CORS policy and launch settings
- add Dockerfiles and compose stack for Next.js frontend, .NET API, and Postgres

## Testing
- `npm test`
- `dotnet build Northeast`


------
https://chatgpt.com/codex/tasks/task_e_689dbeff68908327a49cb52425b4f29e