### PR TITLE
Suppress hydration warnings in SearchBar

### DIFF
--- a/WT4Q/src/components/SearchBar.tsx
+++ b/WT4Q/src/components/SearchBar.tsx
@@ -15,13 +15,19 @@ export default function SearchBar() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className={styles.form} role="search">
+    <form
+      onSubmit={handleSubmit}
+      className={styles.form}
+      role="search"
+      suppressHydrationWarning
+    >
       <input
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search..."
         className={styles.input}
+        suppressHydrationWarning
       />
       <button type="submit" className={styles.button} aria-label="search">
         🔍


### PR DESCRIPTION
## Summary
- silence React hydration mismatch warnings caused by extension-injected attributes on the search form

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689dca2c30988327bd5b30ddeb28e6a3