### PR TITLE
Add Gemini-powered news ingestion and auto writer

### DIFF
--- a/Northeast/Clients/GeminiClient.cs
+++ b/Northeast/Clients/GeminiClient.cs
@@ -1,0 +1,64 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Northeast.Clients
+{
+    /// <summary>
+    /// Minimal Gemini REST client. Calls /v1beta/models/{model}:generateContent.
+    /// </summary>
+    public class GeminiOptions
+    {
+        public string ApiKey { get; set; } = string.Empty;
+        public string Model { get; set; } = "models/gemini-2.0-flash";
+        public double Temperature { get; set; } = 0.7;
+        public int MaxOutputTokens { get; set; } = 1024;
+    }
+
+    public sealed class GeminiClient
+    {
+        private readonly HttpClient _http;
+        private readonly GeminiOptions _opt;
+
+        public GeminiClient(HttpClient http, IOptions<GeminiOptions> opt)
+        {
+            _http = http;
+            _opt = opt.Value;
+            _http.BaseAddress = new Uri("https://generativelanguage.googleapis.com/v1beta/");
+        }
+
+        /// <summary>
+        /// Calls the Gemini REST API with a simple text prompt and returns the text response.
+        /// </summary>
+        public async Task<string> GenerateAsync(string prompt, CancellationToken ct = default)
+        {
+            var body = new
+            {
+                contents = new[]
+                {
+                    new { parts = new[] { new { text = prompt } } }
+                },
+                generationConfig = new
+                {
+                    temperature = _opt.Temperature,
+                    maxOutputTokens = _opt.MaxOutputTokens
+                }
+            };
+
+            var url = $"{_opt.Model}:generateContent?key={_opt.ApiKey}";
+            using var resp = await _http.PostAsJsonAsync(url, body, ct);
+            resp.EnsureSuccessStatusCode();
+
+            var json = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            var text = json
+                .GetProperty("candidates")[0]
+                .GetProperty("content")
+                .GetProperty("parts")[0]
+                .GetProperty("text")
+                .GetString();
+
+            return text ?? string.Empty;
+        }
+    }
+}

--- a/Northeast/Clients/NewsRssClient.cs
+++ b/Northeast/Clients/NewsRssClient.cs
@@ -1,0 +1,73 @@
+using System.ServiceModel.Syndication;
+using System.Xml;
+using Northeast.Utilities;
+
+namespace Northeast.Clients
+{
+    /// <summary>
+    /// Lightweight RSS client that aggregates several trending feeds.
+    /// </summary>
+    public class NewsRssClient
+    {
+        private readonly HttpClient _http;
+
+        // Global trending feeds.
+        private static readonly string[] Feeds = new[]
+        {
+            "https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en",
+            "https://feeds.reuters.com/reuters/topNews",
+            "https://apnews.com/apf-topnews?output=rss"
+        };
+
+        public NewsRssClient(HttpClient http) => _http = http;
+
+        public async Task<IReadOnlyList<TrendingItem>> GetTrendingAsync(CancellationToken ct)
+        {
+            var items = new List<TrendingItem>();
+
+            foreach (var feedUrl in Feeds)
+            {
+                using var stream = await _http.GetStreamAsync(feedUrl, ct);
+                using var reader = XmlReader.Create(stream);
+                var feed = SyndicationFeed.Load(reader);
+                if (feed == null) continue;
+
+                foreach (var e in feed.Items)
+                {
+                    var link = e.Links?.FirstOrDefault()?.Uri?.ToString() ?? string.Empty;
+                    var title = HtmlText.Strip(e.Title?.Text ?? string.Empty);
+                    var summary = HtmlText.Strip(e.Summary?.Text ?? string.Empty);
+                    var published = e.PublishDate.UtcDateTime == default ? DateTime.UtcNow : e.PublishDate.UtcDateTime;
+                    var source = feed.Title?.Text ?? "Unknown";
+
+                    if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(link))
+                        continue;
+
+                    items.Add(new TrendingItem
+                    {
+                        Title = title,
+                        Url = link,
+                        Summary = summary,
+                        Source = source,
+                        PublishedUtc = published,
+                        CountryName = null,
+                        CountryCode = null
+                    });
+                }
+            }
+
+            return items;
+        }
+    }
+
+    public class TrendingItem
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+        public string Summary { get; set; } = string.Empty;
+        public string Source { get; set; } = string.Empty;
+        public DateTime PublishedUtc { get; set; }
+        public string? CountryName { get; set; }
+        public string? CountryCode { get; set; }
+    }
+}

--- a/Northeast/DTOs/ArticleRecommendationDto.cs
+++ b/Northeast/DTOs/ArticleRecommendationDto.cs
@@ -10,3 +10,4 @@ namespace Northeast.DTOs
         public Category Category { get; set; }
         public ArticleType ArticleType { get; set; }
     }
+}

--- a/Northeast/Data/AppDbContext.cs
+++ b/Northeast/Data/AppDbContext.cs
@@ -45,6 +45,10 @@ namespace Northeast.Data
                 .HasForeignKey(i => i.ArticleId);
 
             modelBuilder.Entity<Article>()
+                .HasIndex(a => a.Title)
+                .IsUnique();
+
+            modelBuilder.Entity<Article>()
                 .Navigation(a => a.Images)
                 .AutoInclude();
 

--- a/Northeast/Northeast.csproj
+++ b/Northeast/Northeast.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
+    <PackageReference Include="System.ServiceModel.Syndication" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -1,4 +1,5 @@
 ﻿using MaxMind.GeoIP2;
+using Northeast.Clients;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -58,6 +59,14 @@ builder.Services.AddScoped<CommentReportRepository>();
 builder.Services.AddScoped<ITokenizationService, TokenizationService>();
 builder.Services.AddScoped<ISimilarityService, SimilarityService>();
 builder.Services.AddScoped<IArticleRecommendationService, ArticleRecommendationService>();
+builder.Services.Configure<GeminiOptions>(builder.Configuration.GetSection("Gemini"));
+builder.Services.AddHttpClient<GeminiClient>();
+builder.Services.AddHttpClient<NewsRssClient>();
+builder.Services.AddScoped<Deduplication>();
+builder.Services.AddScoped<AuthorResolver>();
+builder.Services.AddScoped<ArticleFactory>();
+builder.Services.AddHostedService<TrendingNewsPollingService>();
+builder.Services.AddHostedService<AutoArticleWriterService>();
 
 // --- Configure Authentication ---
 builder.Services.AddAuthentication(options =>

--- a/Northeast/Services/ArticleFactory.cs
+++ b/Northeast/Services/ArticleFactory.cs
@@ -1,0 +1,86 @@
+using Northeast.Clients;
+using Northeast.Models;
+using Northeast.Utilities;
+
+namespace Northeast.Services
+{
+    /// <summary>
+    /// Builds Article entities using Gemini output.
+    /// </summary>
+    public class ArticleFactory
+    {
+        private readonly GeminiClient _gemini;
+        public ArticleFactory(GeminiClient gemini) => _gemini = gemini;
+
+        public async Task<Article> FromTrendingAsync(Guid authorId, Category category, string title, string source, string url, string? summary, CancellationToken ct)
+        {
+            var prompt = ContentBuilder.BuildParaphrasePrompt(title, source, url, summary, category.ToString());
+            var html = await _gemini.GenerateAsync(prompt, ct);
+            html = ContentBuilder.EnforceDiv(html);
+            var keywords = ContentBuilder.ExtractKeywords(html);
+            var imageLink = ImageLinkProvider.BuildRoyaltyFreeLink(string.Join(" ", keywords.DefaultIfEmpty(category.ToString())));
+            var (alt, caption) = ImageLinkProvider.BuildMeta(title, url);
+
+            return new Article
+            {
+                Id = Guid.NewGuid(),
+                AuthorId = authorId,
+                Title = title,
+                Category = category,
+                ArticleType = ArticleType.News,
+                CreatedDate = DateTime.UtcNow,
+                Content = html,
+                IsBreakingNews = true,
+                Images = new List<ArticleImage>
+                {
+                    new ArticleImage
+                    {
+                        Photo = null,
+                        PhotoLink = imageLink,
+                        AltText = alt,
+                        Caption = caption
+                    }
+                },
+                CountryName = null,
+                CountryCode = null,
+                Keywords = keywords
+            };
+        }
+
+        public async Task<Article> FromRandomCategoryAsync(Guid authorId, Category category, CancellationToken ct)
+        {
+            var seedTitle = $"What's happening in {category} right now";
+            var prompt = $@"Write a timely, original short article in simple words for the category: {category}.\nFollow the same HTML/output rules as before (div.article, h2 sub-headings, What's next, meta keywords).\nFocus on a current trend or explainer many readers ask this week. No fluff.";
+            var html = await _gemini.GenerateAsync(prompt, ct);
+            html = ContentBuilder.EnforceDiv(html);
+            var keywords = ContentBuilder.ExtractKeywords(html);
+            var imageLink = ImageLinkProvider.BuildRoyaltyFreeLink(string.Join(" ", keywords.DefaultIfEmpty(category.ToString())));
+            var (alt, caption) = ImageLinkProvider.BuildMeta(seedTitle, "https://example.com");
+
+            return new Article
+            {
+                Id = Guid.NewGuid(),
+                AuthorId = authorId,
+                Title = seedTitle,
+                Category = category,
+                ArticleType = ArticleType.Article,
+                CreatedDate = DateTime.UtcNow,
+                Content = html,
+                IsBreakingNews = false,
+                Images = new List<ArticleImage>
+                {
+                    new ArticleImage
+                    {
+                        Photo = null,
+                        PhotoLink = imageLink,
+                        AltText = alt,
+                        Caption = caption
+                    }
+                },
+                CountryName = null,
+                CountryCode = null,
+                Keywords = keywords
+            };
+        }
+    }
+}

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -61,10 +61,10 @@ namespace Northeast.Services
                 }).ToList(),
             };
             if (articleDto.ArticleType == 0)
-            {
-                article.CountryName = articleDto.CountryName ?? "Global";
-                article.CountryCode = articleDto.CountryCode ?? "GL";
-            }
+        {
+            article.CountryName = articleDto.CountryName;
+            article.CountryCode = articleDto.CountryCode;
+        }
             await _articleRepository.Add(article);
 
         }
@@ -168,8 +168,8 @@ namespace Northeast.Services
             if (articleDto.ArticleType == 0)
             {
 
-                article.CountryName = articleDto.CountryName ?? "Global";
-                article.CountryCode = articleDto.CountryCode ?? "GL";
+                article.CountryName = articleDto.CountryName;
+                article.CountryCode = articleDto.CountryCode;
             }
             else
             {

--- a/Northeast/Services/AuthorResolver.cs
+++ b/Northeast/Services/AuthorResolver.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Northeast.Data;
+using Northeast.Models;
+
+namespace Northeast.Services
+{
+    /// <summary>
+    /// Resolves a SuperAdmin user to use as article author.
+    /// </summary>
+    public class AuthorResolver
+    {
+        private readonly AppDbContext _db;
+        public AuthorResolver(AppDbContext db) => _db = db;
+
+        public async Task<Guid> GetAuthorIdAsync(CancellationToken ct)
+        {
+            var user = await _db.Set<User>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Role == Role.SuperAdmin || (int)u.Role == 2, ct);
+
+            if (user == null)
+                throw new InvalidOperationException("No SuperAdmin author found.");
+
+            return user.Id;
+        }
+    }
+}

--- a/Northeast/Services/AutoArticleWriterService.cs
+++ b/Northeast/Services/AutoArticleWriterService.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Northeast.Data;
+using Northeast.Models;
+
+namespace Northeast.Services
+{
+    /// <summary>
+    /// Background service that writes a random category article every 10 minutes.
+    /// </summary>
+    public class AutoArticleWriterService : BackgroundService
+    {
+        private readonly ILogger<AutoArticleWriterService> _log;
+        private readonly AuthorResolver _author;
+        private readonly ArticleFactory _factory;
+        private readonly AppDbContext _db;
+        private readonly Random _rng = new();
+
+        public AutoArticleWriterService(ILogger<AutoArticleWriterService> log,
+            AuthorResolver author,
+            ArticleFactory factory,
+            AppDbContext db)
+        {
+            _log = log;
+            _author = author;
+            _factory = factory;
+            _db = db;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var timer = new PeriodicTimer(TimeSpan.FromMinutes(10));
+            _log.LogInformation("AutoArticleWriterService started.");
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await TickAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogError(ex, "Auto writer tick failed.");
+                }
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+        }
+
+        private async Task TickAsync(CancellationToken ct)
+        {
+            var authorId = await _author.GetAuthorIdAsync(ct);
+            var cats = Enum.GetValues(typeof(Category)).Cast<Category>().ToArray();
+            var category = cats[_rng.Next(cats.Length)];
+            var article = await _factory.FromRandomCategoryAsync(authorId, category, ct);
+            _db.Set<Article>().Add(article);
+            await _db.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/Northeast/Services/TrendingNewsPollingService.cs
+++ b/Northeast/Services/TrendingNewsPollingService.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Northeast.Clients;
+using Northeast.Data;
+using Northeast.Models;
+using Northeast.Utilities;
+
+namespace Northeast.Services
+{
+    /// <summary>
+    /// Background service that polls trending news feeds every 5 minutes.
+    /// </summary>
+    public class TrendingNewsPollingService : BackgroundService
+    {
+        private readonly ILogger<TrendingNewsPollingService> _log;
+        private readonly NewsRssClient _rss;
+        private readonly AuthorResolver _author;
+        private readonly ArticleFactory _factory;
+        private readonly AppDbContext _db;
+        private readonly Deduplication _dedup;
+
+        public TrendingNewsPollingService(ILogger<TrendingNewsPollingService> log,
+            NewsRssClient rss,
+            AuthorResolver author,
+            ArticleFactory factory,
+            AppDbContext db,
+            Deduplication dedup)
+        {
+            _log = log;
+            _rss = rss;
+            _author = author;
+            _factory = factory;
+            _db = db;
+            _dedup = dedup;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var timer = new PeriodicTimer(TimeSpan.FromMinutes(5));
+            _log.LogInformation("TrendingNewsPollingService started.");
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await TickAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogError(ex, "Trending polling tick failed.");
+                }
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+        }
+
+        private async Task TickAsync(CancellationToken ct)
+        {
+            var items = await _rss.GetTrendingAsync(ct);
+            if (items.Count == 0) return;
+            var authorId = await _author.GetAuthorIdAsync(ct);
+
+            foreach (var item in items.Take(12))
+            {
+                var category = InferCategory(item);
+                if (await _dedup.ExistsAsync(item.Title, item.Url, ct))
+                    continue;
+
+                var article = await _factory.FromTrendingAsync(authorId, category, item.Title, item.Source, item.Url, item.Summary, ct);
+                _db.Set<Article>().Add(article);
+            }
+
+            await _db.SaveChangesAsync(ct);
+        }
+
+        private static Category InferCategory(TrendingItem it)
+        {
+            var t = it.Title.ToLowerInvariant();
+            if (t.Contains("crypto") || t.Contains("market") || t.Contains("bank") || t.Contains("stock"))
+                return Category.Business;
+            if (t.Contains("covid") || t.Contains("health") || t.Contains("cancer"))
+                return Category.Health;
+            if (t.Contains("iphone") || t.Contains("ai") || t.Contains("microsoft") || t.Contains("google"))
+                return Category.Technology;
+            if (t.Contains("football") || t.Contains("olympics") || t.Contains("tennis"))
+                return Category.Sports;
+            if (t.Contains("film") || t.Contains("music") || t.Contains("celebrity"))
+                return Category.Entertainment;
+            if (t.Contains("crime") || t.Contains("police") || t.Contains("court"))
+                return Category.Crime;
+            if (t.Contains("election") || t.Contains("parliament") || t.Contains("president"))
+                return Category.Politics;
+            return Category.Info;
+        }
+    }
+}

--- a/Northeast/Utilities/ContentBuilder.cs
+++ b/Northeast/Utilities/ContentBuilder.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Northeast.Utilities
+{
+    public static class ContentBuilder
+    {
+        public static string BuildParaphrasePrompt(string title, string source, string url, string? summary, string categoryName)
+        {
+            return $@"You are a skilled human news writer. Paraphrase the story below into ORIGINAL copy.
+
+Rules:
+- Use simple, natural language (human tone).
+- Output EXACTLY ONE HTML block: <div class=""article""> ... </div>
+- Include a short intro and at least two <h2> sub-headings.
+- Add a <h3>What's next?</h3> section with a clear, reasoned outlook.
+- Minimum 170 words.
+- Do NOT invent facts. If details are unclear, add a brief 'What we know so far' note.
+- Add a line at the end: <meta data-keywords=""comma, separated, keywords""></meta>
+
+Story facts:
+Title: {title}
+Source: {source}
+Link: {url}
+Category: {categoryName}
+Summary (may be empty): {summary}
+
+Now write the article (HTML only).";
+        }
+
+        public static string EnforceDiv(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html)) return @"<div class=""article""><p>(empty)</p></div>";
+            var trimmed = html.Trim();
+            if (trimmed.StartsWith("<div", StringComparison.OrdinalIgnoreCase)) return trimmed;
+            return $@"<div class=""article"">{html}</div>";
+        }
+
+        public static List<string> ExtractKeywords(string html)
+        {
+            var marker = "data-keywords=\"";
+            var idx = html.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) return new List<string>();
+            var start = idx + marker.Length;
+            var end = html.IndexOf('"', start);
+            if (end <= start) return new List<string>();
+            var csv = html.Substring(start, end - start);
+            return csv.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                      .Select(k => k.Trim())
+                      .Where(k => k.Length > 1)
+                      .Distinct(StringComparer.OrdinalIgnoreCase)
+                      .ToList();
+        }
+    }
+}

--- a/Northeast/Utilities/Deduplication.cs
+++ b/Northeast/Utilities/Deduplication.cs
@@ -1,0 +1,32 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Northeast.Data;
+using Northeast.Models;
+
+namespace Northeast.Utilities
+{
+    /// <summary>
+    /// Simple helper to prevent duplicate articles.
+    /// </summary>
+    public class Deduplication
+    {
+        private readonly AppDbContext _db;
+        public Deduplication(AppDbContext db) => _db = db;
+
+        public static string Fingerprint(string title, string url)
+        {
+            var norm = $"{title.Trim().ToLowerInvariant()}|{url.Trim().ToLowerInvariant()}";
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(norm));
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+
+        public async Task<bool> ExistsAsync(string title, string url, CancellationToken ct)
+        {
+            return await _db.Set<Article>()
+                .AsNoTracking()
+                .AnyAsync(a => a.Title.ToLower() == title.ToLower(), ct);
+        }
+    }
+}

--- a/Northeast/Utilities/HtmlText.cs
+++ b/Northeast/Utilities/HtmlText.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+
+namespace Northeast.Utilities
+{
+    /// <summary>
+    /// Helpers for basic HTML sanitizing and slug creation.
+    /// </summary>
+    public static class HtmlText
+    {
+        private static readonly Regex Tags = new("<.*?>", RegexOptions.Singleline | RegexOptions.Compiled);
+        private static readonly Regex Ws = new(@"\s+", RegexOptions.Compiled);
+
+        public static string Strip(string? html)
+        {
+            if (string.IsNullOrWhiteSpace(html)) return string.Empty;
+            var t = Tags.Replace(html, " ");
+            return Ws.Replace(t, " ").Trim();
+        }
+
+        public static string Slug(string input)
+        {
+            var s = input.ToLowerInvariant();
+            s = Regex.Replace(s, "[^a-z0-9]+", "-");
+            return s.Trim('-');
+        }
+    }
+}

--- a/Northeast/Utilities/ImageLinkProvider.cs
+++ b/Northeast/Utilities/ImageLinkProvider.cs
@@ -1,0 +1,21 @@
+namespace Northeast.Utilities
+{
+    /// <summary>
+    /// Builds royalty-free image links (Unsplash source) with alt text and captions.
+    /// </summary>
+    public static class ImageLinkProvider
+    {
+        public static string BuildRoyaltyFreeLink(string query)
+        {
+            var q = Uri.EscapeDataString(query);
+            return $"https://source.unsplash.com/featured/?{q}";
+        }
+
+        public static (string alt, string caption) BuildMeta(string title, string sourceUrl)
+        {
+            var alt = $"Illustration for: {title}";
+            var caption = $"Royalty-free image (Unsplash). Source preview: {sourceUrl}";
+            return (alt, caption);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Gemini client and RSS fetcher
- add background services for trending news and scheduled articles
- enforce unique article titles and update country defaults

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689efb561fec8327b26f8fd0267880f5