### PR TITLE
feat: harden services and fix warnings

### DIFF
--- a/.env
+++ b/.env
@@ -41,7 +41,10 @@ SuperAdmin__Email=anamoljang@gmail.com
 SuperAdmin__Password=Adgjmptw0605626422#
 
 # Gemini
-Gemini__ApiKey=AIzaSyDJUOWKrkhGpf1T-_kHTqD409FOYDGz_Bw
+Gemini__ApiKey=
 Gemini__Model=models/gemini-2.5-Pro
 Gemini__Temperature=0.7
 Gemini__MaxOutputTokens=1024
+
+# DataProtection certificate password (if using a PFX)
+DP_CERT_PASSWORD=

--- a/Northeast/DTOs/ArticleRecommendationDto.cs
+++ b/Northeast/DTOs/ArticleRecommendationDto.cs
@@ -6,14 +6,8 @@ namespace Northeast.DTOs
     public class ArticleRecommendationDto
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
+        public string Title { get; set; } = string.Empty;
         public Category Category { get; set; }
         public ArticleType ArticleType { get; set; }
     }
-<<<<<<< HEAD
-
 }
-
-=======
-}
->>>>>>> e3d7d77ac9e16aca8c916bf1e7e136100de0f21f

--- a/Northeast/Northeast.csproj
+++ b/Northeast/Northeast.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/WT4Q/next.config.ts
+++ b/WT4Q/next.config.ts
@@ -1,3 +1,4 @@
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -6,22 +7,15 @@ const nextConfig: NextConfig = {
 
   // ✅ Allow remote images for <Image />
   images: {
-    // Simple allow-list (keep in sync with any hosts you actually use)
-    domains: [
-      "encrypted-tbn0.gstatic.com",
-      // "cdn.yoursite.com",
-      // "images.unsplash.com",
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "encrypted-tbn0.gstatic.com",
+        pathname: "/**",
+      },
+      // { protocol: "https", hostname: "cdn.yoursite.com", pathname: "/**" },
+      // { protocol: "https", hostname: "images.unsplash.com", pathname: "/**" },
     ],
-
-    // Or (optionally) use remotePatterns for tighter control
-    // remotePatterns: [
-    //   {
-    //     protocol: "https",
-    //     hostname: "encrypted-tbn0.gstatic.com",
-    //     pathname: "/images/**",
-    //   },
-    // ],
-
     formats: ["image/avif", "image/webp"],
   },
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,16 @@ services:
         condition: service_healthy
     volumes:
       - ./wait-for-it.sh:/wait-for-it.sh
+      - dpkeys:/keys
+      - certs:/certs:ro
     # Wait until Postgres:5432 is accepting TCP, then run the API
     command: ["/wait-for-it.sh", "postgres:5432", "--", "dotnet", "Northeast.dll"]
     env_file:
       - .env
     # Use *your .env* to fill these values
     environment:
-
+      ASPNETCORE_URLS: http://+:8080
+      DP_CERT_PASSWORD: ${DP_CERT_PASSWORD}
       ConnectionStrings__DefaultConnection: Host=postgres;Port=5432;Database=${DATABASE_NAME};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
     ports:
       - "8081:8080"
@@ -48,3 +51,5 @@ services:
 
 volumes:
   postgres_data:
+  dpkeys:
+  certs:


### PR DESCRIPTION
## Summary
- persist ASP.NET Data Protection keys and optionally encrypt with certificate
- send Gemini API key via header and add error logging
- skip failing RSS feeds and add HTTP resilience policies
- replace deprecated Next.js image domains config

## Testing
- `npm test`
- `dotnet build Northeast/Northeast.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689f6e50a29c8327965f542a907cca60