### PR TITLE
Remove unsupported thinkingConfig and harden RSS feed reader

### DIFF
--- a/Northeast/Clients/GeminiClient.cs
+++ b/Northeast/Clients/GeminiClient.cs
@@ -49,13 +49,8 @@ namespace Northeast.Clients
                 {
                     temperature = _opt.Temperature,
                     maxOutputTokens = _opt.MaxOutputTokens
-                },
-                // NEW: thinkingConfig is supported for 2.5 models.
-                // For Pro, thinking cannot be disabled; pick a reasonable budget to control cost.
-                thinkingConfig = new
-                {
-                    thinkingBudget = 2048  // try 1024–4096 for paraphrasing/news; Pro allows up to ~32k
                 }
+                // thinkingConfig is not supported by the REST endpoint; use SDKs if needed.
             };
 
             var url = $"{modelPath}:generateContent";

--- a/Northeast/Clients/NewsRssClient.cs
+++ b/Northeast/Clients/NewsRssClient.cs
@@ -17,7 +17,7 @@ namespace Northeast.Clients
         private static readonly string[] Feeds = new[]
         {
             "https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en",
-            "https://feeds.reuters.com/reuters/topNews",
+            "https://news.google.com/rss/search?q=site:reuters.com&hl=en-US&gl=US&ceid=US:en",
             "https://apnews.com/apf-topnews?output=rss"
         };
 
@@ -36,7 +36,12 @@ namespace Northeast.Clients
                 try
                 {
                     using var stream = await _http.GetStreamAsync(feedUrl, ct);
-                    using var reader = XmlReader.Create(stream);
+                    var xmlSettings = new XmlReaderSettings
+                    {
+                        DtdProcessing = DtdProcessing.Ignore,
+                        XmlResolver = null
+                    };
+                    using var reader = XmlReader.Create(stream, xmlSettings);
                     var feed = SyndicationFeed.Load(reader);
                     if (feed == null) continue;
 


### PR DESCRIPTION
## Summary
- drop unsupported `thinkingConfig` from Gemini REST request
- ignore DTDs and replace retired Reuters RSS with Google News

## Testing
- `dotnet build Northeast/Northeast.sln` *(fails: merge conflict markers in ArticleRecommendationDto.cs)*

------
https://chatgpt.com/codex/tasks/task_e_689f9f0db4d4832797e4a336a895620e