### PR TITLE
Render HTML content for articles and breaking news

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -216,7 +216,10 @@ export default async function ArticlePage(
             dangerouslySetInnerHTML={{ __html: article.embededCode }}
           />
         )}
-        <p className={styles.content}>{article.content}</p>
+        <div
+          className={styles.content}
+          dangerouslySetInnerHTML={{ __html: article.content }}
+        />
         <ReactionButtons
           articleId={id}
           initialLikes={likeCount}

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -71,9 +71,10 @@ export default function BreakingNewsSlider({
           )}
           <h3 className={styles.detailTitle}>{current.title}</h3>
           {current.content && (
-            <p className={styles.snippet}>
-              {current.content.split(/\s+/).slice(0, 20).join(' ')}...
-            </p>
+            <div
+              className={styles.snippet}
+              dangerouslySetInnerHTML={{ __html: current.content }}
+            />
           )}
           <PrefetchLink href={`/articles/${current.id}`} className={styles.readMore}>
             Read more


### PR DESCRIPTION
## Summary
- render article body using `dangerouslySetInnerHTML`
- allow breaking news slider to display HTML content snippets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a05016f17c8327a0b1d4bff33eb409