### PR TITLE
style breaking news and titles

### DIFF
--- a/WT4Q/lib/text.ts
+++ b/WT4Q/lib/text.ts
@@ -1,0 +1,11 @@
+export function truncateWords(text: string, count = 20): string {
+  const words = text.trim().split(/\s+/);
+  if (words.length <= count) {
+    return text.trim();
+  }
+  return words.slice(0, count).join(' ') + '...';
+}
+
+export function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}

--- a/WT4Q/src/app/globals.css
+++ b/WT4Q/src/app/globals.css
@@ -119,6 +119,11 @@ a:focus-visible, button:focus-visible {
   border-radius: 8px;
 }
 
+/* Headings */
+h1, h2, h3, h4, h5, h6 {
+  font-variant: small-caps;
+}
+
 /* Reduce motion preference */
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; }

--- a/WT4Q/src/components/ArticleCard.tsx
+++ b/WT4Q/src/components/ArticleCard.tsx
@@ -1,5 +1,6 @@
 import PrefetchLink from '@/components/PrefetchLink';
 import styles from './ArticleCard.module.css';
+import { truncateWords } from '@/lib/text';
 
 export interface Article {
   id: string;
@@ -8,10 +9,11 @@ export interface Article {
 }
 
 export default function ArticleCard({ article }: { article: Article }) {
+  const snippet = truncateWords(article.summary);
   return (
     <PrefetchLink href={`/articles/${article.id}`} className={styles.card}>
       <h2 className={styles.title}>{article.title}</h2>
-      <p className={styles.summary}>{article.summary}</p>
+      <p className={styles.summary}>{snippet}</p>
       <span className={styles.readMore}>Read more</span>
     </PrefetchLink>
   );

--- a/WT4Q/src/components/BreakingNewsSlider.module.css
+++ b/WT4Q/src/components/BreakingNewsSlider.module.css
@@ -11,6 +11,9 @@
 .item {
   display: block;
   font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .dots {
@@ -56,11 +59,13 @@
 .detailTitle {
   margin: 0.5rem 0;
   color: black;
+  overflow-wrap: anywhere;
 }
 
 .snippet {
   margin: 0.5rem 0;
   font-size: large;
+  overflow-wrap: anywhere;
 }
 
 .readMore {

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import PrefetchLink from '@/components/PrefetchLink';
 import styles from './BreakingNewsSlider.module.css';
 import type { ArticleImage } from '@/lib/models';
+import { stripHtml, truncateWords } from '@/lib/text';
 
 export interface BreakingArticle {
   id: string;
@@ -38,6 +39,9 @@ export default function BreakingNewsSlider({
   const first = current.images?.[0];
   const base64 = first?.photo ? `data:image/jpeg;base64,${first.photo}` : undefined;
   const imageSrc = first?.photoLink || base64;
+  const snippet = current.content
+    ? truncateWords(stripHtml(current.content))
+    : undefined;
 
   return (
     <div className={`${styles.slider} ${className ?? ''}`.trim()}>
@@ -70,12 +74,7 @@ export default function BreakingNewsSlider({
             </figure>
           )}
           <h3 className={styles.detailTitle}>{current.title}</h3>
-          {current.content && (
-            <div
-              className={styles.snippet}
-              dangerouslySetInnerHTML={{ __html: current.content }}
-            />
-          )}
+          {snippet && <p className={styles.snippet}>{snippet}</p>}
           <PrefetchLink href={`/articles/${current.id}`} className={styles.readMore}>
             Read more
           </PrefetchLink>


### PR DESCRIPTION
## Summary
- make headings render in small-caps sitewide
- clamp breaking news text inside its box and show short snippets with read more
- shorten article previews to about 20 words

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a06a335d2083278e22b0d036e41c68