### PR TITLE
fix: handle undefined input in truncateWords

### DIFF
--- a/WT4Q/lib/text.test.ts
+++ b/WT4Q/lib/text.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { truncateWords } from './text';
+
+describe('truncateWords', () => {
+  it('truncates text to the specified number of words', () => {
+    const text = 'one two three four five';
+    expect(truncateWords(text, 3)).toBe('one two three...');
+  });
+
+  it('returns an empty string when input is undefined', () => {
+    expect(truncateWords(undefined, 3)).toBe('');
+  });
+});

--- a/WT4Q/lib/text.ts
+++ b/WT4Q/lib/text.ts
@@ -1,4 +1,4 @@
-export function truncateWords(text: string, count = 20): string {
+export function truncateWords(text = '', count = 20): string {
   const words = text.trim().split(/\s+/);
   if (words.length <= count) {
     return text.trim();


### PR DESCRIPTION
## Summary
- prevent truncateWords from failing when text is undefined
- add tests covering truncateWords behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06d70d6408327856f03423018157d