### PR TITLE
style related article links with small caps

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -160,21 +160,9 @@ export default async function ArticlePage(
             {article.countryName ? ` | ${article.countryName}` : ''}
             {article.author?.adminName ? ` – ${article.author.adminName}` : ''}
           </p>
-          {related.length > 0 && (
-            <p className={styles.relatedBar}>
-              {related.map((a, i) => (
-                <span key={a.id}>
-                  <PrefetchLink href={`/articles/${a.id}`}>{a.title}</PrefetchLink>
-                  {i < related.length - 1 && (
-                    <span className={styles.separator}>|</span>
-                  )}
-                </span>
-              ))}
-            </p>
-          )}
-          {article.images && article.images.length > 0 && (
-            <div className={article.images.length > 1 ? styles.gallery : undefined}>
-              {article.images.map((img, idx) => {
+        {article.images && article.images.length > 0 && (
+          <div className={article.images.length > 1 ? styles.gallery : undefined}>
+            {article.images.map((img, idx) => {
               const base64 = img.photo ? `data:image/jpeg;base64,${img.photo}` : undefined;
               const validLink = img.photoLink && isValidImageForNextImage(img.photoLink)
                 ? img.photoLink
@@ -230,6 +218,18 @@ export default async function ArticlePage(
           initialComments={article.comments ?? []}
         />
       </article>
-      </div>
-    );
-  }
+      {related.length > 0 && (
+        <aside className={styles.sidebar}>
+          <h2 className={styles.relatedHeading}>Related Articles</h2>
+          <div className={styles.relatedBar}>
+            {related.map((a) => (
+              <PrefetchLink key={a.id} href={`/articles/${a.id}`}>
+                {a.title}
+              </PrefetchLink>
+            ))}
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -95,11 +95,14 @@
 .relatedBar {
   margin: 1rem 0;
   font-size: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.separator {
-  margin: 0 0.5rem;
-  color: #b6b6b6;
+/* Style links within the related articles bar */
+.relatedBar a {
+  font-variant: small-caps;
 }
 
 .breaking {


### PR DESCRIPTION
## Summary
- style links in related article bar with small-caps typography
- display related articles in a vertical sidebar separated by a border

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a06d75c8dc83278bf2cf51d43716e7