### PR TITLE
Enforce minimum word count for articles

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -40,6 +40,10 @@ namespace Northeast.Controllers
                 await articleUpload.Publish(article);
                 return Ok(article);
             }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
             catch (Exception ex)
             {
                 return StatusCode(500, new { message = "Internal error while publishing article", error = ex.Message });
@@ -130,8 +134,19 @@ namespace Northeast.Controllers
             {
                 return NotFound(new { message = "Sorry, there is no Articles with this ID" });
             }
-            await articleUpload.ModifyArticle(Id, Article);
-            return Ok(article);
+            try
+            {
+                await articleUpload.ModifyArticle(Id, Article);
+                return Ok(article);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "Internal error while editing article", error = ex.Message });
+            }
         }
 
         [Authorize(Policy = "AdminOnly")]

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -38,7 +38,12 @@ namespace Northeast.Services
         }
         public async Task Publish(ArticleDto articleDto)
         {
-           var u = _connectedUser;
+            if (CountWords(articleDto.Content) < 50)
+            {
+                throw new ArgumentException("Article content must be at least 50 words long.");
+            }
+
+            var u = _connectedUser;
             Guid userId = u.Id;
 
             Article article = new Article()
@@ -61,12 +66,22 @@ namespace Northeast.Services
                 }).ToList(),
             };
             if (articleDto.ArticleType == 0)
-        {
-            article.CountryName = articleDto.CountryName;
-            article.CountryCode = articleDto.CountryCode;
-        }
+            {
+                article.CountryName = articleDto.CountryName;
+                article.CountryCode = articleDto.CountryCode;
+            }
             await _articleRepository.Add(article);
 
+        }
+
+        private static int CountWords(string? content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return 0;
+            }
+
+            return content.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
         }
         public async Task<IEnumerable<Article>> getAllArticle() {
             return await _articleRepository.GetAll();
@@ -135,6 +150,11 @@ namespace Northeast.Services
 
         public async Task ModifyArticle(Guid id, ArticleDto articleDto)
         {
+            if (CountWords(articleDto.Content) < 50)
+            {
+                throw new ArgumentException("Article content must be at least 50 words long.");
+            }
+
             var article = await _articleRepository.GetByGUId(id);
             if (article == null)
             {


### PR DESCRIPTION
## Summary
- validate article content to contain at least 50 words before publishing or updating
- return BadRequest when article content is too short

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a072c573b483278dc37a89d3153ba5