### PR TITLE
Enforce minimum word count for articles

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -40,6 +40,10 @@ namespace Northeast.Controllers
                 await articleUpload.Publish(article);
                 return Ok(article);
             }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
             catch (Exception ex)
             {
                 return StatusCode(500, new { message = "Internal error while publishing article", error = ex.Message });
@@ -130,8 +134,19 @@ namespace Northeast.Controllers
             {
                 return NotFound(new { message = "Sorry, there is no Articles with this ID" });
             }
-            await articleUpload.ModifyArticle(Id, Article);
-            return Ok(article);
+            try
+            {
+                await articleUpload.ModifyArticle(Id, Article);
+                return Ok(article);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "Internal error while editing article", error = ex.Message });
+            }
         }
 
         [Authorize(Policy = "AdminOnly")]

--- a/Northeast/Services/AiNewsServices.cs
+++ b/Northeast/Services/AiNewsServices.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Northeast.Data;
 using Northeast.Models;
+using Northeast.Utilities;
 
 namespace Northeast.Services;
 
@@ -284,6 +285,7 @@ public sealed class AiTrendingNewsPollingService : BackgroundService
         {
             if (string.IsNullOrWhiteSpace(d.Title) || string.IsNullOrWhiteSpace(d.ArticleHtml)) continue;
             if (!titles.Add(d.Title)) { _log.LogDebug("Duplicate title skipped: {Title}", d.Title); continue; }
+            if (HtmlText.CountWords(d.ArticleHtml) < 50) { _log.LogDebug("AI content too short for title {Title}", d.Title); continue; }
 
             var category = ParseCategory(d.Category);
 
@@ -443,7 +445,7 @@ public sealed class AiRandomArticleWriterService : BackgroundService
         var titles = new HashSet<string>(recent, StringComparer.OrdinalIgnoreCase);
         foreach (var d in batch.Items)
         {
-            if (string.IsNullOrWhiteSpace(d.Title) || !titles.Add(d.Title)) continue;
+            if (string.IsNullOrWhiteSpace(d.Title) || string.IsNullOrWhiteSpace(d.ArticleHtml) || !titles.Add(d.Title) || HtmlText.CountWords(d.ArticleHtml) < 50) continue;
 
             var article = new Article
             {

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -38,7 +38,12 @@ namespace Northeast.Services
         }
         public async Task Publish(ArticleDto articleDto)
         {
-           var u = _connectedUser;
+            if (HtmlText.CountWords(articleDto.Content) < 50)
+            {
+                throw new ArgumentException("Article content must be at least 50 words long.");
+            }
+
+            var u = _connectedUser;
             Guid userId = u.Id;
 
             Article article = new Article()
@@ -61,13 +66,14 @@ namespace Northeast.Services
                 }).ToList(),
             };
             if (articleDto.ArticleType == 0)
-        {
-            article.CountryName = articleDto.CountryName;
-            article.CountryCode = articleDto.CountryCode;
-        }
+            {
+                article.CountryName = articleDto.CountryName;
+                article.CountryCode = articleDto.CountryCode;
+            }
             await _articleRepository.Add(article);
 
         }
+
         public async Task<IEnumerable<Article>> getAllArticle() {
             return await _articleRepository.GetAll();
         }
@@ -135,6 +141,11 @@ namespace Northeast.Services
 
         public async Task ModifyArticle(Guid id, ArticleDto articleDto)
         {
+            if (HtmlText.CountWords(articleDto.Content) < 50)
+            {
+                throw new ArgumentException("Article content must be at least 50 words long.");
+            }
+
             var article = await _articleRepository.GetByGUId(id);
             if (article == null)
             {

--- a/Northeast/Utilities/HtmlText.cs
+++ b/Northeast/Utilities/HtmlText.cs
@@ -23,5 +23,12 @@ namespace Northeast.Utilities
             s = Regex.Replace(s, "[^a-z0-9]+", "-");
             return s.Trim('-');
         }
+
+        public static int CountWords(string? text)
+        {
+            var stripped = Strip(text);
+            if (string.IsNullOrWhiteSpace(stripped)) return 0;
+            return stripped.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Validate article content to contain at least 50 words before publishing or updating
- Return BadRequest when article content is too short
- Skip AI-generated articles under 50 words and reuse shared word-counter

## Testing
- `dotnet test Northeast/Northeast.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a072c573b483278dc37a89d3153ba5