### PR TITLE
feat: enhance breaking news slider

### DIFF
--- a/WT4Q/src/components/BreakingNewsBar.tsx
+++ b/WT4Q/src/components/BreakingNewsBar.tsx
@@ -1,24 +1,6 @@
-import BreakingNewsSlider, { BreakingArticle } from './BreakingNewsSlider';
-import { API_ROUTES } from '@/lib/api';
+import BreakingNewsSlider from './BreakingNewsSlider';
 import styles from './BreakingNewsBar.module.css';
 
-export default async function BreakingNewsBar() {
-  try {
-    // Fetch all articles so the bar shows the latest news rather than
-    // only items flagged as "breaking".
-    const res = await fetch(API_ROUTES.ARTICLE.GET_ALL, { cache: 'no-store' });
-    if (!res.ok) return null;
-
-    // Map the API response to the minimal shape expected by the slider.
-    const allArticles = (await res.json()) as { id: string; title: string }[];
-    const articles: BreakingArticle[] = (allArticles || []).map((a) => ({
-      id: a.id,
-      title: a.title,
-    }));
-
-    if (articles.length === 0) return null;
-    return <BreakingNewsSlider articles={articles} className={styles.bar} />;
-  } catch {
-    return null;
-  }
+export default function BreakingNewsBar() {
+  return <BreakingNewsSlider className={styles.bar} />;
 }

--- a/WT4Q/src/components/BreakingNewsSlider.module.css
+++ b/WT4Q/src/components/BreakingNewsSlider.module.css
@@ -1,3 +1,4 @@
+
 .slider {
   background:#c6bbbb00;
   color: #0000006d;
@@ -6,14 +7,30 @@
   border-radius: 4px;
   text-align: center;
   position: relative;
+  overflow: hidden;
+}
+
+.itemWrapper {
+  overflow: hidden;
 }
 
 .item {
-  display: block;
+  display: inline-block;
   font-weight: bold;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+.marquee {
+  animation: marquee var(--scroll-duration) linear forwards;
+}
+
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(var(--scroll-distance));
+  }
 }
 
 .dots {
@@ -84,9 +101,13 @@
   font-size: 1.25rem;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: opacity 0.3s, transform 0.3s;
   padding: 0 0.25rem;
   z-index: 1;
+}
+
+.arrow:active {
+  transform: translateY(-50%) scale(0.9);
 }
 
 .slider:hover .arrow {
@@ -99,4 +120,30 @@
 
 .right {
   right: 0.25rem;
+}
+
+.slideLeft {
+  animation: slideLeft 0.3s ease;
+}
+
+.slideRight {
+  animation: slideRight 0.3s ease;
+}
+
+@keyframes slideLeft {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideRight {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }


### PR DESCRIPTION
## Summary
- fetch breaking news directly in the slider when no data is supplied
- animate arrow navigation and slide transitions
- scroll long titles so full headline shows

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a089aa0fe48327b70e32e9a238a6d3