### PR TITLE
Handle background service cancellation

### DIFF
--- a/Northeast/Data/MigrationExtensions.cs
+++ b/Northeast/Data/MigrationExtensions.cs
@@ -1,5 +1,7 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Northeast.Data;
 
@@ -9,6 +11,15 @@ public static class MigrationExtensions
     {
         using var scope = services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        await context.Database.MigrateAsync();
+        var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("MigrationExtensions");
+        try
+        {
+            await context.Database.MigrateAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred while applying database migrations.");
+        }
     }
 }

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Http.Resilience;
 using Microsoft.EntityFrameworkCore;
 using System.Net;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 using Northeast.Services;
 using Northeast.Services.Similarity;
 using Northeast.Data;
@@ -36,6 +37,11 @@ builder.Services.AddSwaggerGen();
 
 // --- DbContext ---
 builder.Services.AddDbContext<AppDbContext>();
+
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
+});
 
 // --- Register Application Services ---
 builder.Services.AddScoped<UserRegistration>();

--- a/Northeast/Services/AiNewsServices.cs
+++ b/Northeast/Services/AiNewsServices.cs
@@ -286,6 +286,10 @@ public sealed class AiTrendingNewsPollingService : BackgroundService
                 catch (Exception ex) { _log.LogError(ex, "AI trending tick failed."); }
             }
         }
+        catch (OperationCanceledException)
+        {
+            // Expected when the service is stopping
+        }
         finally
         {
             timer.Dispose();
@@ -452,6 +456,10 @@ public sealed class AiRandomArticleWriterService : BackgroundService
                 catch (OperationCanceledException) { }
                 catch (Exception ex) { _log.LogError(ex, "AI random writer tick failed."); }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the service is stopping
         }
         finally
         {


### PR DESCRIPTION
## Summary
- prevent host shutdown from background service cancellations
- log migration failures instead of crashing host
- ignore background service exceptions at host level

## Testing
- `dotnet build Northeast/Northeast.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a0c822e4ac8327ab290bf9f698888f