### PR TITLE
Optimize caching headers and link prefetching

### DIFF
--- a/WT4Q/src/components/PrefetchLink.tsx
+++ b/WT4Q/src/components/PrefetchLink.tsx
@@ -2,24 +2,35 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { AnchorHTMLAttributes } from 'react';
+import React, { AnchorHTMLAttributes, useRef } from 'react';
 
 interface PrefetchLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
 }
 
-export default function PrefetchLink({ href, onMouseEnter, children, ...props }: PrefetchLinkProps) {
+/**
+ * Prefetch once on hover. We disable Link's built-in viewport prefetch
+ * to avoid repeated fetches when lists re-render.
+ */
+export default function PrefetchLink({
+  href,
+  onMouseEnter,
+  children,
+  ...props
+}: PrefetchLinkProps) {
   const router = useRouter();
+  const didPrefetch = useRef(false);
 
-  const handleMouseEnter = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    router.prefetch(href);
-    if (onMouseEnter) {
-      onMouseEnter(e);
+  const handleMouseEnter = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!didPrefetch.current) {
+      router.prefetch(href);
+      didPrefetch.current = true; // one-shot per mount
     }
+    onMouseEnter?.(e);
   };
 
   return (
-    <Link href={href} {...props} onMouseEnter={handleMouseEnter}>
+    <Link href={href} prefetch={false} onMouseEnter={handleMouseEnter} {...props}>
       {children}
     </Link>
   );


### PR DESCRIPTION
## Summary
- refine Next.js caching headers to prevent stale HTML and API revalidation storms
- switch custom Link to one-shot hover prefetch with auto-prefetch disabled

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a173cc2af883279ffbbabf06b47ca6