### PR TITLE
Refine BreakingNewsSlider error handling

### DIFF
--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -85,8 +85,8 @@ export default function BreakingNewsSlider({
       const data: { id: string; title: string }[] = await res.json();
       setArticles(data.map((a) => ({ id: a.id, title: a.title })));
       setIndex(0);
-    })().catch((err: any) => {
-      if (err?.name !== 'AbortError') {
+    })().catch((err: unknown) => {
+      if (!(err instanceof Error) || err.name !== 'AbortError') {
         // Optional: keep empty to render null, or set a fallback message article
         setArticles([]);
       }


### PR DESCRIPTION
## Summary
- avoid `any` in BreakingNewsSlider fetch error handling by using `unknown` and checking for `Error`

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Error occurred prerendering page "/tools/world-clock" (ENETUNREACH))*

------
https://chatgpt.com/codex/tasks/task_e_68a17c741fdc8327833626fa61d12f34