### PR TITLE
Trust proxy headers and resolve real client IP

### DIFF
--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -219,7 +219,11 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
         ForwardedHeaders.XForwardedProto |
         ForwardedHeaders.XForwardedHost;
 
-    options.KnownProxies.Add(IPAddress.Parse("127.0.0.1"));
+    // Trust forwarded headers from any proxy in front of the app.
+    // The reverse proxy is responsible for sanitizing the headers.
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+    options.ForwardLimit = 2; // defensive cap on the number of entries
 });
 
 var dataProtection = builder.Services.AddDataProtection()

--- a/Northeast/Services/SiteVisitorServices.cs
+++ b/Northeast/Services/SiteVisitorServices.cs
@@ -28,19 +28,11 @@ namespace Northeast.Services
         public async Task<Visitors> VisitorLog()
         {
             var ipAddress = _getConnectedUser.GetUserIP();
-            
-            // Fallback if running on a loopback address (will return the server's location)
-            if (string.IsNullOrWhiteSpace(ipAddress) || ipAddress == "::1" || ipAddress == "127.0.0.1")
-            {
 
-                ipAddress = await _httpClient.GetStringAsync("https://api64.ipify.org");
-
-            }
-            if (!IPAddress.TryParse(ipAddress, out _))
+            if (!IPAddress.TryParse(ipAddress ?? string.Empty, out _))
             {
                 return null;
             }
-    
 
             var apiUrl = $"https://ipinfo.io/{ipAddress}/json";
 


### PR DESCRIPTION
## Summary
- trust proxy forwarded headers and cap header chain
- resolve client IP from CDN/proxy headers and drop ipify fallback

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a17c6fcb788327b3aa6d43550b918b