### PR TITLE
Add Google AdSense script to head

### DIFF
--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -65,6 +65,11 @@ export default function RootLayout({
             gtag('config', 'G-0NKNBEMWC2');
           `}
         </Script>
+        <Script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2858608482723109"
+          crossOrigin="anonymous"
+        />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <PageVisitReporter />


### PR DESCRIPTION
## Summary
- load Google AdSense in the global layout head so ads can be rendered across the site

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1de2d1c5c8327ad4ecd5c65460592