### PR TITLE
Enforce freshness and add external media sourcing for AI news

### DIFF
--- a/Northeast/Services/ImagePicker.cs
+++ b/Northeast/Services/ImagePicker.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using System.Linq;
+using System.Net.Http;
+using Northeast.Models;
+
+namespace Northeast.Services;
+
+public interface IImagePicker
+{
+    Task<List<ArticleImage>> FindAsync(string title, IEnumerable<string> keywords, int max, CancellationToken ct);
+}
+
+public sealed class WikimediaImagePicker : IImagePicker
+{
+    private readonly HttpClient _http;
+    public WikimediaImagePicker(HttpClient http) => _http = http;
+
+    public async Task<List<ArticleImage>> FindAsync(string title, IEnumerable<string> keywords, int max, CancellationToken ct)
+    {
+        var q = Uri.EscapeDataString(title);
+        var url = $"https://commons.wikimedia.org/w/api.php?action=query&generator=search&gsrsearch={q}&gsrlimit=8&prop=imageinfo|info&iiprop=url|extmetadata&inprop=url&format=json&origin=*";
+        using var res = await _http.GetAsync(url, ct);
+        if (!res.IsSuccessStatusCode) return new();
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync(ct));
+        if (!doc.RootElement.TryGetProperty("query", out var qEl) || !qEl.TryGetProperty("pages", out var pages)) return new();
+
+        var list = new List<ArticleImage>();
+        foreach (var p in pages.EnumerateObject().Select(o => o.Value))
+        {
+            if (!p.TryGetProperty("imageinfo", out var ii) || ii.GetArrayLength() == 0) continue;
+            var info = ii[0];
+            var link = info.GetProperty("url").GetString();
+            if (string.IsNullOrWhiteSpace(link)) continue;
+
+            var caption = p.TryGetProperty("title", out var t) ? t.GetString() : title;
+            list.Add(new ArticleImage
+            {
+                PhotoLink = link,
+                AltText = caption,
+                Caption = caption
+            });
+            if (list.Count >= max) break;
+        }
+        return list;
+    }
+}

--- a/Northeast/Services/NewsFetcher.cs
+++ b/Northeast/Services/NewsFetcher.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+
+namespace Northeast.Services;
+
+public interface INewsFetcher
+{
+    Task<List<(string Title, string Url, DateTimeOffset PublishedUtc)>> FetchAsync(int max, CancellationToken ct);
+}
+
+public sealed class BingNewsFetcher : INewsFetcher
+{
+    private readonly HttpClient _http;
+    private readonly string _key;
+    public BingNewsFetcher(HttpClient http, IConfiguration cfg)
+    {
+        _http = http;
+        _key = cfg["Bing:NewsKey"] ?? string.Empty;
+    }
+
+    public async Task<List<(string, string, DateTimeOffset)>> FetchAsync(int max, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, $"https://api.bing.microsoft.com/v7.0/news/search?q=top%20news&count={max}&mkt=en-US&freshness=Month");
+        req.Headers.TryAddWithoutValidation("Ocp-Apim-Subscription-Key", _key);
+        using var res = await _http.SendAsync(req, ct);
+        if (!res.IsSuccessStatusCode) return new();
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync(ct));
+        var list = new List<(string, string, DateTimeOffset)>();
+        foreach (var v in doc.RootElement.GetProperty("value").EnumerateArray())
+        {
+            var title = v.GetProperty("name").GetString() ?? string.Empty;
+            var url = v.GetProperty("url").GetString() ?? string.Empty;
+            var date = v.TryGetProperty("datePublished", out var d) && DateTimeOffset.TryParse(d.GetString(), out var ts) ? ts : DateTimeOffset.UtcNow;
+            list.Add((title, url, date));
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary
- enforce max age and breaking windows with event timestamps
- fetch real headlines and images when generating AI news
- add Wikimedia image picker and Bing News fetcher

## Testing
- `dotnet build Northeast/Northeast.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a225b6a6a08327a7e04a62e9522d81