### PR TITLE
Add AdSense verification meta tag and ads.txt

### DIFF
--- a/WT4Q/public/ads.txt
+++ b/WT4Q/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2858608482723109, DIRECT, f08c47fec0942fa0

--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -52,6 +52,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <meta
+          name="google-adsense-account"
+          content="ca-pub-2858608482723109"
+        />
         <Script
           async
           src="https://www.googletagmanager.com/gtag/js?id=G-0NKNBEMWC2"


### PR DESCRIPTION
## Summary
- add AdSense verification meta tag to root layout
- include ads.txt for AdSense publisher verification

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a229407ee88327b3160778f7e7bbc5