### PR TITLE
Gracefully handle ipinfo rate limits

### DIFF
--- a/Northeast/Services/SiteVisitorServices.cs
+++ b/Northeast/Services/SiteVisitorServices.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Northeast.Models;
 using Northeast.Repository;
 using Northeast.Utilities;
 using System.Net;
-using System.Security.Claims;
 using System.Text.Json;
 
 namespace Northeast.Services
@@ -11,17 +12,28 @@ namespace Northeast.Services
     public class SiteVisitorServices
     {
         private readonly HttpClient _httpClient;
-        private readonly  GetConnectedUser _getConnectedUser;
+        private readonly GetConnectedUser _getConnectedUser;
         private readonly UserRepository _userRepository;
         private readonly VisitorsRepository _visitorsRepository;
         private readonly PageVisitRepository _pageVisitRepository;
-        public SiteVisitorServices(HttpClient httpClient, UserRepository userRepository, GetConnectedUser getConnectedUser, VisitorsRepository visitorsRepository, PageVisitRepository pageVisitRepository)
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<SiteVisitorServices> _logger;
+
+        public SiteVisitorServices(HttpClient httpClient,
+            UserRepository userRepository,
+            GetConnectedUser getConnectedUser,
+            VisitorsRepository visitorsRepository,
+            PageVisitRepository pageVisitRepository,
+            IMemoryCache cache,
+            ILogger<SiteVisitorServices> logger)
         {
             _httpClient = httpClient;
             _userRepository = userRepository;
             _getConnectedUser = getConnectedUser;
             _visitorsRepository = visitorsRepository;
             _pageVisitRepository = pageVisitRepository;
+            _cache = cache;
+            _logger = logger;
         }
 
 
@@ -34,11 +46,20 @@ namespace Northeast.Services
                 return null;
             }
 
-            var apiUrl = $"https://ipinfo.io/{ipAddress}/json";
+            var cacheKey = $"ipinfo:{ipAddress}";
+            if (!_cache.TryGetValue(cacheKey, out IpinfoResponse? locationData))
+            {
+                locationData = await FetchIpInfo(ipAddress);
+                if (locationData != null)
+                {
+                    _cache.Set(cacheKey, locationData, TimeSpan.FromHours(24));
+                }
+            }
 
-
-            var response = await _httpClient.GetStringAsync(apiUrl);
-            var locationData = JsonSerializer.Deserialize<IpinfoResponse>(response);
+            if (locationData == null)
+            {
+                return null;
+            }
 
             Visitors? visitors = null;
 
@@ -66,72 +87,107 @@ namespace Northeast.Services
                 visitors = await _visitorsRepository.GetGuestByIpAsync(ipAddress) ?? new Visitors();
                 visitors.IsGuest = true;
             }
-            if (locationData != null)
+            var now = DateTime.UtcNow;
+            bool duplicate = visitors.Id != 0 && visitors.VisitTime.HasValue &&
+                Math.Abs((now - visitors.VisitTime.Value).TotalMinutes) < 1 &&
+                visitors.IpAddress == locationData.Ip &&
+                visitors.Location == locationData.Loc &&
+                visitors.City == locationData.City &&
+                visitors.Country == locationData.Country &&
+                visitors.Region == locationData.Region &&
+                visitors.Org == locationData.Org &&
+                visitors.PostalCode == locationData.Postal &&
+                visitors.Timezone == locationData.Timezone;
+
+            if (duplicate)
             {
-                var now = DateTime.UtcNow;
-                bool duplicate = visitors.Id != 0 && visitors.VisitTime.HasValue &&
-                    Math.Abs((now - visitors.VisitTime.Value).TotalMinutes) < 1 &&
-                    visitors.IpAddress == locationData.Ip &&
-                    visitors.Location == locationData.Loc &&
-                    visitors.City == locationData.City &&
-                    visitors.Country == locationData.Country &&
-                    visitors.Region == locationData.Region &&
-                    visitors.Org == locationData.Org &&
-                    visitors.PostalCode == locationData.Postal &&
-                    visitors.Timezone == locationData.Timezone;
-
-                if (duplicate)
-                {
-                    return visitors;
-                }
-
-                if (locationData.Ip!=null) {
-                    visitors.IpAddress = locationData.Ip;
-                };
-                if(locationData.Org!=null)
-                {
-                    visitors.Org = locationData.Org;
-                }
-                if(locationData.Loc!=null)
-                {
-                    visitors.Location = locationData.Loc;
-                }
-                if(locationData.City!=null)
-                {
-                    visitors.City = locationData.City;
-                }
-                if(locationData.Country!=null)
-                {
-                    visitors.Country = locationData.Country;
-                }
-                if(locationData.Postal!=null)
-                {
-                    visitors.PostalCode= locationData.Postal;
-                }
-                if(locationData.Timezone!=null) {
-                    visitors.Timezone = locationData.Timezone;
-                }
-                if (locationData.Region!=null) {
-                    visitors.Region = locationData.Region;
-                }
-                visitors.VisitTime = now;
-
-                if (visitors.Id == 0)
-                {
-                    await _visitorsRepository.Add(visitors);
-                }
-                else
-                {
-                    await _visitorsRepository.Update(visitors);
-                }
-
                 return visitors;
+            }
 
+            if (locationData.Ip != null)
+            {
+                visitors.IpAddress = locationData.Ip;
+            }
+            if (locationData.Org != null)
+            {
+                visitors.Org = locationData.Org;
+            }
+            if (locationData.Loc != null)
+            {
+                visitors.Location = locationData.Loc;
+            }
+            if (locationData.City != null)
+            {
+                visitors.City = locationData.City;
+            }
+            if (locationData.Country != null)
+            {
+                visitors.Country = locationData.Country;
+            }
+            if (locationData.Postal != null)
+            {
+                visitors.PostalCode = locationData.Postal;
+            }
+            if (locationData.Timezone != null)
+            {
+                visitors.Timezone = locationData.Timezone;
+            }
+            if (locationData.Region != null)
+            {
+                visitors.Region = locationData.Region;
+            }
+            visitors.VisitTime = now;
+
+            if (visitors.Id == 0)
+            {
+                await _visitorsRepository.Add(visitors);
+            }
+            else
+            {
+                await _visitorsRepository.Update(visitors);
+            }
+
+            return visitors;
+        }
+
+        private async Task<IpinfoResponse?> FetchIpInfo(string ipAddress)
+        {
+            var token = Environment.GetEnvironmentVariable("IPINFO_TOKEN");
+            var apiUrl = $"https://ipinfo.io/{ipAddress}/json";
+            if (!string.IsNullOrEmpty(token))
+            {
+                apiUrl += $"?token={token}";
+            }
+
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                try
+                {
+                    var response = await _httpClient.GetAsync(apiUrl);
+                    if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                    {
+                        _logger.LogWarning("ipinfo.io rate limit exceeded for {IP}", ipAddress);
+                        await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt + 1)));
+                        continue;
+                    }
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning("Failed to fetch IP info for {IP}: {StatusCode}", ipAddress, response.StatusCode);
+                        return null;
+                    }
+
+                    var content = await response.Content.ReadAsStringAsync();
+                    return JsonSerializer.Deserialize<IpinfoResponse>(content);
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.LogError(ex, "Error fetching IP info for {IP}", ipAddress);
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt + 1)));
+                }
             }
 
             return null;
-
-
         }
 
         public async Task LogPageVisit(string pageUrl)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Set the `SuperAdmin:Email` and `SuperAdmin:Password` environment variables to
 seed the initial super administrator account. The API will run on the port
 configured in the project settings.
 
+The API logs visitor locations using data from ipinfo.io. To avoid hitting
+their anonymous rate limits, supply an API token via the `IPINFO_TOKEN`
+environment variable. Results for each IP address are cached in memory for 24
+hours to minimize external requests.
+
 ### Applying Migrations
 
 When new migrations are added (for example, a migration named `AddIsGuestToVisitors`), update the database by running:


### PR DESCRIPTION
## Summary
- handle ipinfo 429 responses with retries and logging
- cache IP info lookups and support optional IPINFO_TOKEN
- document IPINFO_TOKEN usage in README

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a243a3e3388327ba0bc510393d7488