### PR TITLE
Sort news by date and tidy auth

### DIFF
--- a/WT4Q/src/app/admin-login/page.tsx
+++ b/WT4Q/src/app/admin-login/page.tsx
@@ -15,6 +15,7 @@ export default async function AdminLoginPage() {
       const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
         headers: { Cookie: `JwtToken=${token.value}` },
         cache: 'no-store',
+        credentials: 'include',
       });
       if (res.ok) {
         const data: AdminInfo = await res.json();

--- a/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
+++ b/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
@@ -33,7 +33,9 @@ export default function DashboardClient() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const [articles, setArticles] = useState<{ id: string; title: string }[]>([]);
+  const [articles, setArticles] = useState<
+    { id: string; title: string; createdDate?: string }[]
+  >([]);
 
   useEffect(() => {
     async function load() {
@@ -43,7 +45,13 @@ export default function DashboardClient() {
           credentials: 'include',
         });
         if (!res.ok) return;
-        const data = await res.json();
+        const data: { id: string; title: string; createdDate?: string }[] =
+          await res.json();
+        data.sort(
+          (a, b) =>
+            new Date(b.createdDate ?? 0).getTime() -
+            new Date(a.createdDate ?? 0).getTime(),
+        );
         setArticles(data);
       } catch {
         // ignore

--- a/WT4Q/src/app/admin/ensureAdmin.ts
+++ b/WT4Q/src/app/admin/ensureAdmin.ts
@@ -17,6 +17,7 @@ export async function ensureAdmin() {
       Cookie: `JwtToken=${token.value}`,
     },
     cache: 'no-store',
+    credentials: 'include',
   });
 
   if (!res.ok) {

--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -10,7 +10,12 @@ async function fetchArticles(cat: string): Promise<Article[]> {
       { cache: 'no-store' }
     );
     if (!res.ok) return [];
-    return await res.json();
+    const data: Article[] = await res.json();
+    return data.sort(
+      (a, b) =>
+        new Date(b.createdDate ?? 0).getTime() -
+        new Date(a.createdDate ?? 0).getTime(),
+    );
   } catch {
     return [];
   }

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -23,7 +23,12 @@ async function fetchArticlesByCategory(cat: string): Promise<Article[]> {
       { cache: 'no-store' }
     );
     if (!res.ok) return [];
-    return await res.json();
+    const data: Article[] = await res.json();
+    return data.sort(
+      (a, b) =>
+        new Date(b.createdDate ?? 0).getTime() -
+        new Date(a.createdDate ?? 0).getTime(),
+    );
   } catch {
     return [];
   }
@@ -34,12 +39,18 @@ async function fetchBreakingNews(): Promise<BreakingArticle[]> {
     const res = await fetch(API_ROUTES.ARTICLE.BREAKING, { cache: 'no-store' });
     if (!res.ok) return [];
     const data = (await res.json()) as BreakingArticle[];
-    return (data || []).map((a) => ({
-      id: a.id,
-      title: a.title,
-      content: a.content,
-      images: a.images as ArticleImage[],
-    }));
+    return (data || [])
+      .sort(
+        (a, b) =>
+          new Date(b.createdDate ?? 0).getTime() -
+          new Date(a.createdDate ?? 0).getTime(),
+      )
+      .map((a) => ({
+        id: a.id,
+        title: a.title,
+        content: a.content,
+        images: a.images as ArticleImage[],
+      }));
   } catch {
     return [];
   }

--- a/WT4Q/src/app/search/advanced/page.tsx
+++ b/WT4Q/src/app/search/advanced/page.tsx
@@ -28,7 +28,13 @@ export default function AdvancedSearchPage() {
     try {
       const res = await fetch(`${API_ROUTES.ARTICLE.FILTER}?${params.toString()}`);
       if (res.ok) {
-        setResults(await res.json());
+        const data: Article[] = await res.json();
+        data.sort(
+          (a, b) =>
+            new Date(b.createdDate ?? 0).getTime() -
+            new Date(a.createdDate ?? 0).getTime(),
+        );
+        setResults(data);
       } else {
         setResults([]);
       }

--- a/WT4Q/src/app/search/page.tsx
+++ b/WT4Q/src/app/search/page.tsx
@@ -31,6 +31,11 @@ function SearchContent() {
         const res = await fetch(API_ROUTES.ARTICLE.SEARCH(q));
         if (res.ok) {
           const data: Article[] = await res.json();
+          data.sort(
+            (a, b) =>
+              new Date(b.createdDate ?? 0).getTime() -
+              new Date(a.createdDate ?? 0).getTime(),
+          );
           setResults(data);
         } else {
           setResults([]);

--- a/WT4Q/src/components/ArticleCard.tsx
+++ b/WT4Q/src/components/ArticleCard.tsx
@@ -6,6 +6,7 @@ export interface Article {
   id: string;
   title: string;
   summary: string;
+  createdDate?: string;
 }
 
 export default function ArticleCard({ article }: { article: Article }) {

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -11,6 +11,7 @@ export interface BreakingArticle {
   title: string;
   content?: string;
   images?: ArticleImage[];
+  createdDate?: string;
 }
 
 type Props = {
@@ -82,8 +83,13 @@ export default function BreakingNewsSlider({
         // don’t silently loop on 4xx/5xx
         throw new Error(`HTTP ${res.status}`);
       }
-      const data: { id: string; title: string }[] = await res.json();
-      setArticles(data.map((a) => ({ id: a.id, title: a.title })));
+      const data: { id: string; title: string; createdDate?: string }[] = await res.json();
+      data.sort(
+        (a, b) =>
+          new Date(b.createdDate ?? 0).getTime() -
+          new Date(a.createdDate ?? 0).getTime(),
+      );
+      setArticles(data.map((a) => ({ id: a.id, title: a.title, createdDate: a.createdDate })));
       setIndex(0);
     })().catch((err: unknown) => {
       if (!(err instanceof Error) || err.name !== 'AbortError') {

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -38,6 +38,7 @@ export default function UserMenu() {
       method: 'POST',
       credentials: 'include',
     });
+    document.cookie = 'JwtToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
     setUser(null);
     router.refresh();
   };


### PR DESCRIPTION
## Summary
- show newest articles first across homepage, categories and search
- ensure admin auth requests include credentials and clear cookies on logout
- remove JwtToken cookie on user logout for a full sign-out

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a303a8da5883278f0454d98bbd83b4