### PR TITLE
Add air quality, UV index, and alerts to weather search

### DIFF
--- a/Northeast/Controllers/WeatherController.cs
+++ b/Northeast/Controllers/WeatherController.cs
@@ -4,6 +4,7 @@ using Northeast.Services;
 using System;
 using System.Text.Json;
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 
 namespace Northeast.Controllers
 {
@@ -68,6 +69,138 @@ namespace Northeast.Controllers
             _cache.Set(cacheKey, result, TimeSpan.FromMinutes(10));
 
             return Ok(result);
+        }
+
+        [HttpGet("details")]
+        [ResponseCache(Duration = 300, Location = ResponseCacheLocation.Any)]
+        public async Task<IActionResult> GetDetails()
+        {
+            var visitor = await _siteVisitorServices.VisitorLog();
+            if (visitor == null || string.IsNullOrEmpty(visitor.Location))
+            {
+                return BadRequest(new { message = "Unable to determine location." });
+            }
+
+            var parts = visitor.Location.Split(',');
+            if (parts.Length != 2 ||
+                !double.TryParse(parts[0], out var lat) ||
+                !double.TryParse(parts[1], out var lon))
+            {
+                return BadRequest(new { message = "Invalid location." });
+            }
+
+            var cacheKey = $"details-{lat}-{lon}";
+            if (_cache.TryGetValue(cacheKey, out object cached))
+            {
+                return Ok(cached);
+            }
+
+            try
+            {
+                var url = $"https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}&current_weather=true";
+                var json = await _httpClient.GetStringAsync(url);
+                using var doc = JsonDocument.Parse(json);
+                if (!doc.RootElement.TryGetProperty("current_weather", out var current))
+                {
+                    return BadRequest(new { message = "Weather data unavailable" });
+                }
+
+                decimal? airQuality = null;
+                try
+                {
+                    var aqiUrl = $"https://air-quality-api.open-meteo.com/v1/air-quality?latitude={lat}&longitude={lon}&current=us_aqi";
+                    var aqiJson = await _httpClient.GetStringAsync(aqiUrl);
+                    using var aqiDoc = JsonDocument.Parse(aqiJson);
+                    if (aqiDoc.RootElement.TryGetProperty("current", out var aqiCurrent) &&
+                        aqiCurrent.TryGetProperty("us_aqi", out var aqiProp))
+                    {
+                        airQuality = aqiProp.GetDecimal();
+                    }
+                }
+                catch
+                {
+                    airQuality = null;
+                }
+
+                decimal? uvIndex = null;
+                try
+                {
+                    var uvUrl = $"https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}&current=uv_index";
+                    var uvJson = await _httpClient.GetStringAsync(uvUrl);
+                    using var uvDoc = JsonDocument.Parse(uvJson);
+                    if (uvDoc.RootElement.TryGetProperty("current", out var uvCurrent) &&
+                        uvCurrent.TryGetProperty("uv_index", out var uvProp))
+                    {
+                        uvIndex = uvProp.GetDecimal();
+                    }
+                }
+                catch
+                {
+                    uvIndex = null;
+                }
+
+                var alerts = new List<string>();
+                try
+                {
+                    var alertRequest = new HttpRequestMessage(HttpMethod.Get,
+                        $"https://api.met.no/weatherapi/metalerts/2.0/complete?lat={lat}&lon={lon}");
+                    alertRequest.Headers.Add("User-Agent", "WT4Q/1.0 https://example.com");
+                    alertRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    var alertResponse = await _httpClient.SendAsync(alertRequest);
+                    if (alertResponse.IsSuccessStatusCode)
+                    {
+                        var alertJson = await alertResponse.Content.ReadAsStringAsync();
+                        using var alertDoc = JsonDocument.Parse(alertJson);
+                        if (alertDoc.RootElement.TryGetProperty("features", out var features))
+                        {
+                            foreach (var feature in features.EnumerateArray())
+                            {
+                                if (feature.TryGetProperty("properties", out var props))
+                                {
+                                    if (props.TryGetProperty("event", out var evt))
+                                    {
+                                        var name = evt.GetString();
+                                        if (!string.IsNullOrWhiteSpace(name))
+                                            alerts.Add(name);
+                                    }
+                                    else if (props.TryGetProperty("headline", out var head))
+                                    {
+                                        var title = head.GetString();
+                                        if (!string.IsNullOrWhiteSpace(title))
+                                            alerts.Add(title);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    alerts = new List<string>();
+                }
+
+                var result = new
+                {
+                    temperature = current.GetProperty("temperature").GetDecimal(),
+                    weathercode = current.GetProperty("weathercode").GetInt32(),
+                    isDay = current.TryGetProperty("is_day", out var isDayProperty) &&
+                            isDayProperty.GetInt32() == 1,
+                    windspeed = current.TryGetProperty("windspeed", out var speed)
+                        ? speed.GetDecimal()
+                        : (decimal)0,
+                    airQuality,
+                    uvIndex,
+                    alerts
+                };
+
+                _cache.Set(cacheKey, result, TimeSpan.FromMinutes(10));
+
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "Request failed", detail = ex.Message });
+            }
         }
 
         [HttpGet("forecast")]

--- a/WT4Q/src/app/api/weather/by-city/route.ts
+++ b/WT4Q/src/app/api/weather/by-city/route.ts
@@ -1,3 +1,6 @@
+type CacheEntry = { data: unknown; expires: number };
+const cache = new Map<string, CacheEntry>();
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const city = searchParams.get('city');
@@ -27,6 +30,15 @@ export async function GET(request: Request) {
     }
     const { latitude, longitude, name, country } = geoData.results[0];
 
+    const cacheKey = `${latitude},${longitude}`;
+    const cached = cache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) {
+      return new Response(JSON.stringify(cached.data), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
     const weatherRes = await fetch(
       `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true`
     );
@@ -44,22 +56,78 @@ export async function GET(request: Request) {
         headers: { 'content-type': 'application/json' },
       });
     }
-    return new Response(
-      JSON.stringify({
-        city: name,
-        country,
-        latitude,
-        longitude,
-        temperature: current.temperature,
-        weathercode: current.weathercode,
-        isDay: current.is_day === 1,
-        windspeed: current.windspeed ?? null,
-      }),
-      {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
+
+    let airQuality: number | null = null;
+    try {
+      const aqiRes = await fetch(
+        `https://air-quality-api.open-meteo.com/v1/air-quality?latitude=${latitude}&longitude=${longitude}&current=us_aqi`
+      );
+      if (aqiRes.ok) {
+        const aqiData = await aqiRes.json();
+        airQuality = aqiData.current?.us_aqi ?? null;
       }
-    );
+    } catch {
+      airQuality = null;
+    }
+
+    let uvIndex: number | null = null;
+    try {
+      const uvRes = await fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=uv_index`
+      );
+      if (uvRes.ok) {
+        const uvData = await uvRes.json();
+        uvIndex = uvData.current?.uv_index ?? null;
+      }
+    } catch {
+      uvIndex = null;
+    }
+
+    let alerts: string[] = [];
+    try {
+      const alertRes = await fetch(
+        `https://api.met.no/weatherapi/metalerts/2.0/complete?lat=${latitude}&lon=${longitude}`,
+        {
+          headers: {
+            'User-Agent': 'WT4Q/1.0 https://example.com',
+            Accept: 'application/json',
+          },
+        }
+      );
+      if (alertRes.ok) {
+        const alertData = await alertRes.json().catch(() => null);
+        if (Array.isArray(alertData?.features)) {
+          alerts = (alertData.features as {
+            properties?: { event?: string; headline?: string };
+          }[])
+            .map((f) => f.properties?.event ?? f.properties?.headline)
+            .filter((v): v is string => Boolean(v));
+        }
+      }
+    } catch {
+      alerts = [];
+    }
+
+    const result = {
+      city: name,
+      country,
+      latitude,
+      longitude,
+      temperature: current.temperature,
+      weathercode: current.weathercode,
+      isDay: current.is_day === 1,
+      windspeed: current.windspeed ?? null,
+      airQuality,
+      uvIndex,
+      alerts,
+    };
+
+    cache.set(cacheKey, { data: result, expires: Date.now() + 10 * 60 * 1000 });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
   } catch {
     return new Response(JSON.stringify({ message: 'Request failed' }), {
       status: 500,

--- a/WT4Q/src/app/weather/weather.module.css
+++ b/WT4Q/src/app/weather/weather.module.css
@@ -128,6 +128,18 @@
   font-size: 0.875rem;
 }
 
+.extra {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  margin: 0.25rem 0;
+  gap: 0.125rem;
+}
+
+.alerts {
+  margin: 0.25rem 0 0 1rem;
+}
+
 .smallIcon {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary
- Expose new `api/weather/details` backend endpoint that returns air quality index, UV index, and nearby alerts with in-memory caching and safe error handling
- Enrich city weather API route with AQI, UV, alerts and add simple TTL cache to limit external calls
- Display AQI, UV index, and severe weather alerts in search results and saved city cards while persisting data in localStorage

## Testing
- `npm test`
- `npm run lint`
- `dotnet build Northeast`


------
https://chatgpt.com/codex/tasks/task_e_68a34be0e37c832789fc703552fed67e