### PR TITLE
feat: add city-specific weather SEO

### DIFF
--- a/WT4Q/src/app/weather/WeatherClient.tsx
+++ b/WT4Q/src/app/weather/WeatherClient.tsx
@@ -50,8 +50,8 @@ function iconFromSymbol(symbol: string | null, className: string): ReactElement 
   return <WeatherIcon code={3} isDay={isDay} className={className} />;
 }
 
-export default function WeatherPage() {
-  const [city, setCity] = useState('');
+export default function WeatherPage({ initialCity }: { initialCity?: string }) {
+  const [city, setCity] = useState(initialCity || '');
   const [weather, setWeather] = useState<Weather | null>(null);
   const [forecast, setForecast] = useState<ForecastEntry[]>([]);
   const [error, setError] = useState('');
@@ -149,6 +149,13 @@ export default function WeatherPage() {
       setForecast([]);
     }
   };
+
+  useEffect(() => {
+    if (initialCity) {
+      setCity(initialCity);
+      void loadCity(initialCity);
+    }
+  }, [initialCity]);
 
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/WT4Q/src/app/weather/[city]/page.tsx
+++ b/WT4Q/src/app/weather/[city]/page.tsx
@@ -1,0 +1,24 @@
+import WeatherClient from '../WeatherClient';
+import type { Metadata } from 'next';
+
+export async function generateMetadata({ params }: { params: Promise<{ city: string }> }): Promise<Metadata> {
+  const { city } = await params;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
+  const url = `${siteUrl}/weather/${encodeURIComponent(city)}`;
+  const title = `Weather in ${city} - WT4Q`;
+  return {
+    title,
+    description: `Check current weather and forecasts for ${city}.`,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      url,
+      type: 'website',
+    },
+  };
+}
+
+export default async function WeatherByCityPage({ params }: { params: Promise<{ city: string }> }) {
+  const { city } = await params;
+  return <WeatherClient initialCity={city} />;
+}


### PR DESCRIPTION
## Summary
- add dynamic weather page for individual cities
- support preloading weather info via `initialCity` prop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a362d0e89883278b1eb6795b0640f3