### PR TITLE
Rename Lifestyle category and update references

### DIFF
--- a/Northeast/Models/Category.cs
+++ b/Northeast/Models/Category.cs
@@ -7,7 +7,7 @@
         Entertainment,
         Business,
         Health,
-        lifestyle,
+        Lifestyle,
         Technology,
         Sports,
         Info

--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -4,7 +4,7 @@ export const UPLOADCATEGORIES = [
   'Entertainment',
   'Business',
   'Health',
-  'lifestyle',
+  'Lifestyle',
   'Technology',
   'Sports',
   'Info'
@@ -16,7 +16,7 @@ export const CATEGORIES = [
   'Entertainment',
   'Business',
     'Health',
-    'lifestyle',
+    'Lifestyle',
   'Technology',
   'Sports',
   'Info'
@@ -30,7 +30,7 @@ export const CATEGORIES = [
         Entertainment,
         Business,
         Health,
-        lifestyle,
+        Lifestyle,
         Technology,
         Sports,
         Info


### PR DESCRIPTION
## Summary
- Rename category enum value to `Lifestyle` for consistency
- Update front-end category lists to use `Lifestyle`

## Testing
- `npm test --prefix WT4Q`
- `dotnet test Northeast/Northeast.sln` *(fails: no tests found)*
- `dotnet ef database update --project Northeast/Northeast.csproj --startup-project Northeast/Northeast.csproj` *(fails: The ConnectionString property has not been initialized.)*


------
https://chatgpt.com/codex/tasks/task_e_68a04b1a893c8327b92e2eefe5b70bd1