### PR TITLE
chore: simplify admin auth guards

### DIFF
--- a/WT4Q/src/app/admin-login/page.tsx
+++ b/WT4Q/src/app/admin-login/page.tsx
@@ -2,9 +2,6 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import AdminLoginClient from './AdminLoginClient';
 import { API_ROUTES } from '@/lib/api';
-import type { AdminInfo } from '@/hooks/useAdminGuard';
-
-const ALLOWED_ROLES = ['admin', 'superadmin'];
 
 export default async function AdminLoginPage() {
   const cookieStore = await cookies();
@@ -18,20 +15,8 @@ export default async function AdminLoginPage() {
         credentials: 'include',
       });
       if (res.ok) {
-        const data: AdminInfo = await res.json();
-        const roles: string[] = [];
-        if (typeof data.role === 'string') {
-          roles.push(data.role.toLowerCase());
-        }
-        if (Array.isArray(data.roles)) {
-          data.roles.forEach((r) => roles.push(r.toLowerCase()));
-        }
-        if (data.isAdmin) roles.push('admin');
-        if (data.isSuperAdmin) roles.push('superadmin');
-
-        if (roles.some((r) => ALLOWED_ROLES.includes(r))) {
-          redirect('/admin/dashboard');
-        }
+        // A 200 response implies the user is an admin due to server-side policy
+        redirect('/admin/dashboard');
       }
     } catch {
       // ignore errors and show login

--- a/WT4Q/src/app/admin/ensureAdmin.ts
+++ b/WT4Q/src/app/admin/ensureAdmin.ts
@@ -3,8 +3,6 @@ import { redirect } from 'next/navigation';
 import { API_ROUTES } from '@/lib/api';
 import type { AdminInfo } from '@/hooks/useAdminGuard';
 
-const ALLOWED_ROLES = ['admin', 'superadmin'];
-
 export async function ensureAdmin() {
   const cookieStore = await cookies();
   const token = cookieStore.get('JwtToken');
@@ -12,32 +10,22 @@ export async function ensureAdmin() {
     redirect('/admin-login');
   }
 
-  const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
-    headers: {
-      Cookie: `JwtToken=${token.value}`,
-    },
-    cache: 'no-store',
-    credentials: 'include',
-  });
+  try {
+    const res = await fetch(API_ROUTES.ADMIN_AUTH.ME, {
+      headers: {
+        Cookie: `JwtToken=${token.value}`,
+      },
+      cache: 'no-store',
+      credentials: 'include',
+    });
 
-  if (!res.ok) {
+    if (!res.ok) {
+      redirect('/admin-login');
+    }
+
+    const data: AdminInfo = await res.json();
+    return data;
+  } catch {
     redirect('/admin-login');
   }
-
-  const data: AdminInfo = await res.json();
-  const roles: string[] = [];
-  if (typeof data.role === 'string') {
-    roles.push(data.role.toLowerCase());
-  }
-  if (Array.isArray(data.roles)) {
-    data.roles.forEach((r) => roles.push(r.toLowerCase()));
-  }
-  if (data.isAdmin) roles.push('admin');
-  if (data.isSuperAdmin) roles.push('superadmin');
-
-  if (!roles.some((r) => ALLOWED_ROLES.includes(r))) {
-    redirect('/admin-login');
-  }
-
-  return data;
 }

--- a/WT4Q/src/hooks/useAdminGuard.ts
+++ b/WT4Q/src/hooks/useAdminGuard.ts
@@ -4,14 +4,10 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { API_ROUTES } from '@/lib/api';
 
-const ALLOWED_ROLES = ['admin', 'superadmin'];
-
 export interface AdminInfo {
   id?: string;
-  role?: string;
-  roles?: string[];
-  isAdmin?: boolean;
-  isSuperAdmin?: boolean;
+  adminName?: string;
+  email?: string;
   [key: string]: unknown;
 }
 
@@ -30,21 +26,6 @@ export function useAdminGuard() {
           return;
         }
         const data: AdminInfo = await res.json();
-        const roles: string[] = [];
-        if (typeof data.role === 'string') {
-          roles.push(data.role.toLowerCase());
-        }
-        if (Array.isArray(data.roles)) {
-          data.roles.forEach((r) => roles.push(r.toLowerCase()));
-        }
-        if (data.isAdmin) roles.push('admin');
-        if (data.isSuperAdmin) roles.push('superadmin');
-
-        if (!roles.some((r) => ALLOWED_ROLES.includes(r))) {
-          router.replace('/admin-login');
-          return;
-        }
-
         setAdmin(data);
       } catch {
         router.replace('/admin-login');


### PR DESCRIPTION
## Summary
- rely on server-side policy for admin checks
- add error handling to admin auth helper
- streamline admin login and guard hooks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3838a560c8327b15508dd7b0bd556