### PR TITLE
Fetch local article using country data

### DIFF
--- a/WT4Q/src/components/LocalArticleSection.tsx
+++ b/WT4Q/src/components/LocalArticleSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import { API_ROUTES } from '@/lib/api';
+import countries from '../../public/datas/Countries.json';
 import styles from './LocalArticleSection.module.css';
 
 export default function LocalArticleSection() {
@@ -15,12 +16,31 @@ export default function LocalArticleSection() {
         if (!locRes.ok) return;
         const loc = await locRes.json();
         if (!loc?.country) return;
-        const artRes = await fetch(
-          `${API_ROUTES.ARTICLE.SEARCH_ADVANCED}?country=${encodeURIComponent(loc.country)}`
+
+        const country = (countries as { name: string; code: string }[]).find(
+          (c) =>
+            c.code.toLowerCase() === loc.country.toLowerCase() ||
+            c.name.toLowerCase() === loc.country.toLowerCase()
         );
-        if (!artRes.ok) return;
-        const list: Article[] = await artRes.json();
-        if (list.length > 0) setArticle(list[0]);
+
+        const fetchBy = async (param: string, value: string) => {
+          const res = await fetch(
+            `${API_ROUTES.ARTICLE.FILTER}?${param}=${encodeURIComponent(value)}`
+          );
+          if (!res.ok) return null;
+          const list: Article[] = await res.json();
+          return list.length > 0 ? list[0] : null;
+        };
+
+        let art: Article | null = null;
+        if (country?.code) {
+          art = await fetchBy('countryCode', country.code);
+        }
+        if (!art && country?.name) {
+          art = await fetchBy('countryName', country.name);
+        }
+
+        if (art) setArticle(art);
       } catch {
         // swallow errors
       }


### PR DESCRIPTION
## Summary
- map visitor country code to full country name using bundled Countries.json
- retrieve articles via ArticleFilter using country code then name for localized news

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b3d6565083279f3a4dd4ce603f2c