### PR TITLE
feat: add MetroTrade game

### DIFF
--- a/WT4Q/lib/metrotrade/constants.ts
+++ b/WT4Q/lib/metrotrade/constants.ts
@@ -1,0 +1,50 @@
+import type { Tile } from "./types";
+
+// Board: 40 tiles with original names (no Monopoly IP).
+export const START_CASH = 1500;
+export const PASS_START_BONUS = 200;
+export const JAIL_INDEX = 10;
+export const GO_TO_JAIL_INDEX = 30;
+
+export const BOARD: Tile[] = [
+  { i:0, name:"Metro Hub", type:"GO" },
+  { i:1, name:"Lime Street", type:"PROPERTY", property:{ cost:60, group:"Greenline", baseRent:[2,10,30,90,160,250], owner:null, upgrades:0 }},
+  { i:2, name:"Transit Fund", type:"FUND" },
+  { i:3, name:"Cedar Avenue", type:"PROPERTY", property:{ cost:60, group:"Greenline", baseRent:[4,20,60,180,320,450], owner:null, upgrades:0 }},
+  { i:4, name:"City Tax", type:"TAX", taxAmount:200 },
+  { i:5, name:"Central Station", type:"TRANSIT", property:{ cost:200, group:"Transit", baseRent:[25,50,100,200,200,200], owner:null, upgrades:0 }},
+  { i:6, name:"Harbor Lane", type:"PROPERTY", property:{ cost:100, group:"Bluebelt", baseRent:[6,30,90,270,400,550], owner:null, upgrades:0 }},
+  { i:7, name:"Event", type:"EVENT" },
+  { i:8, name:"Violet Road", type:"PROPERTY", property:{ cost:100, group:"Bluebelt", baseRent:[6,30,90,270,400,550], owner:null, upgrades:0 }},
+  { i:9, name:"Indigo Way", type:"PROPERTY", property:{ cost:120, group:"Bluebelt", baseRent:[8,40,100,300,450,600], owner:null, upgrades:0 }},
+  { i:10, name:"Metro Detention (Visit)", type:"VISIT" },
+  { i:11, name:"Bronze Street", type:"PROPERTY", property:{ cost:140, group:"Bronzeway", baseRent:[10,50,150,450,625,750], owner:null, upgrades:0 }},
+  { i:12, name:"Utilities Co.", type:"UTILITY", property:{ cost:150, group:"Utility", baseRent:[4,10,30,90,160,250], owner:null, upgrades:0 }},
+  { i:13, name:"Copper Lane", type:"PROPERTY", property:{ cost:140, group:"Bronzeway", baseRent:[10,50,150,450,625,750], owner:null, upgrades:0 }},
+  { i:14, name:"Amber Alley", type:"PROPERTY", property:{ cost:160, group:"Bronzeway", baseRent:[12,60,180,500,700,900], owner:null, upgrades:0 }},
+  { i:15, name:"Riverside Station", type:"TRANSIT", property:{ cost:200, group:"Transit", baseRent:[25,50,100,200,200,200], owner:null, upgrades:0 }},
+  { i:16, name:"Lilac Terrace", type:"PROPERTY", property:{ cost:180, group:"Lilac Row", baseRent:[14,70,200,550,750,950], owner:null, upgrades:0 }},
+  { i:17, name:"Transit Fund", type:"FUND" },
+  { i:18, name:"Skyline Drive", type:"PROPERTY", property:{ cost:180, group:"Lilac Row", baseRent:[14,70,200,550,750,950], owner:null, upgrades:0 }},
+  { i:19, name:"Cobalt Court", type:"PROPERTY", property:{ cost:200, group:"Lilac Row", baseRent:[16,80,220,600,800,1000], owner:null, upgrades:0 }},
+  { i:20, name:"Free Parking", type:"PARKING" },
+  { i:21, name:"Crimson Street", type:"PROPERTY", property:{ cost:220, group:"Crimson Block", baseRent:[18,90,250,700,875,1050], owner:null, upgrades:0 }},
+  { i:22, name:"Event", type:"EVENT" },
+  { i:23, name:"Ruby Road", type:"PROPERTY", property:{ cost:220, group:"Crimson Block", baseRent:[18,90,250,700,875,1050], owner:null, upgrades:0 }},
+  { i:24, name:"Garnet Gate", type:"PROPERTY", property:{ cost:240, group:"Crimson Block", baseRent:[20,100,300,750,925,1100], owner:null, upgrades:0 }},
+  { i:25, name:"Uptown Station", type:"TRANSIT", property:{ cost:200, group:"Transit", baseRent:[25,50,100,200,200,200], owner:null, upgrades:0 }},
+  { i:26, name:"Emerald Esplanade", type:"PROPERTY", property:{ cost:260, group:"Emerald Row", baseRent:[22,110,330,800,975,1150], owner:null, upgrades:0 }},
+  { i:27, name:"Opal Avenue", type:"PROPERTY", property:{ cost:260, group:"Emerald Row", baseRent:[22,110,330,800,975,1150], owner:null, upgrades:0 }},
+  { i:28, name:"Grid Utilities", type:"UTILITY", property:{ cost:150, group:"Utility", baseRent:[4,10,30,90,160,250], owner:null, upgrades:0 }},
+  { i:29, name:"Jade Junction", type:"PROPERTY", property:{ cost:280, group:"Emerald Row", baseRent:[24,120,360,850,1025,1200], owner:null, upgrades:0 }},
+  { i:30, name:"Go To Detention", type:"GO_TO_JAIL" },
+  { i:31, name:"Sunset Boulevard", type:"PROPERTY", property:{ cost:300, group:"Sunset", baseRent:[26,130,390,900,1100,1275], owner:null, upgrades:0 }},
+  { i:32, name:"Coral Crescent", type:"PROPERTY", property:{ cost:300, group:"Sunset", baseRent:[26,130,390,900,1100,1275], owner:null, upgrades:0 }},
+  { i:33, name:"Transit Fund", type:"FUND" },
+  { i:34, name:"Topaz Trail", type:"PROPERTY", property:{ cost:320, group:"Sunset", baseRent:[28,150,450,1000,1200,1400], owner:null, upgrades:0 }},
+  { i:35, name:"Harbor Station", type:"TRANSIT", property:{ cost:200, group:"Transit", baseRent:[25,50,100,200,200,200], owner:null, upgrades:0 }},
+  { i:36, name:"Event", type:"EVENT" },
+  { i:37, name:"Aurora Avenue", type:"PROPERTY", property:{ cost:350, group:"Aurora", baseRent:[35,175,500,1100,1300,1500], owner:null, upgrades:0 }},
+  { i:38, name:"Luxury Tax", type:"TAX", taxAmount:100 },
+  { i:39, name:"Crown Heights", type:"PROPERTY", property:{ cost:400, group:"Aurora", baseRent:[50,200,600,1400,1700,2000], owner:null, upgrades:0 }},
+];

--- a/WT4Q/lib/metrotrade/engine.ts
+++ b/WT4Q/lib/metrotrade/engine.ts
@@ -1,0 +1,201 @@
+import type { GameState, InitOptions, Player } from "./types";
+import { BOARD, START_CASH, PASS_START_BONUS } from "./constants";
+import { rollDice, wrap, nextSeed } from "./utils";
+import { adjustNetWorth, computeRent, jailPlayer, leaveJail } from "./rules";
+import { LearningAgent } from "../../services/metrotrade/LearningAgent";
+
+function clone<T>(x:T):T { return JSON.parse(JSON.stringify(x)); }
+
+function makePlayers(opts: InitOptions): Player[] {
+  const players: Player[] = [];
+  for (let i=0;i<opts.players;i++) {
+    const isHuman = i < opts.humans;
+    players.push({ id:i, name: isHuman?`You ${i+1}`:`CPU ${i+1}`, isHuman, cash: START_CASH, pos:0, inJail:false, jailTurns:0, bankrupt:false, netWorth:START_CASH });
+  }
+  return players;
+}
+
+function shuffledDeck(len: number, seed: number){
+  const arr = [...Array(len).keys()];
+  let s = seed; for (let i=arr.length-1;i>0;i--){ s = nextSeed(s); const j = Math.floor(((s>>>0)%1000)/1000 * (i+1)); const k = (j % (i+1)); [arr[i],arr[k]]=[arr[k],arr[i]]; }
+  return arr;
+}
+
+export function initGame(opts: InitOptions): GameState {
+  const seed = Date.now() >>> 0;
+  const g: GameState = {
+    turn: 0,
+    dice: null,
+    tiles: clone(BOARD),
+    players: makePlayers(opts),
+    deckEvent: shuffledDeck(14, seed^0xabc),
+    deckFund: shuffledDeck(14, seed^0xdef),
+    prompts: { canBuy:false, mustPay:0, landedTile:null },
+    lastActionAt: Date.now(),
+    rngSeed: seed,
+    settings: opts,
+    log: [{ t: Date.now(), text: `Game started with ${opts.players} players (${opts.humans} human).` }]
+  };
+  adjustNetWorth(g);
+  return g;
+}
+
+export function rollAndAdvance(g: GameState): GameState {
+  g = clone(g);
+  const me = g.players[g.turn];
+  if (me.bankrupt) return g;
+  if (me.inJail) {
+    // Try to leave jail after 1 turn by paying 50
+    me.jailTurns++;
+    if (me.jailTurns >= 1 && me.cash >= 50) { me.cash -= 50; leaveJail(me); g.log.push({t:Date.now(), text:`${me.name} paid 50 to leave Detention.`}); }
+    else { g.log.push({t:Date.now(), text:`${me.name} waits in Detention.`}); return g; }
+  }
+  const r = rollDice(g.rngSeed); g.rngSeed = r.seed; g.dice = [r.d1, r.d2];
+  const steps = r.d1 + r.d2;
+  const old = me.pos; const next = wrap(old + steps);
+  if (next < old) { me.cash += PASS_START_BONUS; g.log.push({ t:Date.now(), text:`${me.name} passed Metro Hub (+${PASS_START_BONUS}).`}); }
+  me.pos = next;
+  g.prompts.landedTile = me.pos; g.prompts.canBuy = false; g.prompts.mustPay = 0;
+  return g;
+}
+
+function countOwnedInGroup(g: GameState, ownerId: number, group: string){
+  return g.tiles.filter(t => t.property && t.property.owner===ownerId && t.property.group===group).length;
+}
+
+export function resolveLanding(g: GameState): GameState {
+  g = clone(g);
+  const me = g.players[g.turn];
+  const tile = g.tiles[me.pos];
+  if (!tile) return g;
+
+  switch(tile.type){
+    case "GO": g.log.push({t:Date.now(), text:`${me.name} is at Metro Hub.`}); break;
+    case "PROPERTY":
+    case "TRANSIT":
+    case "UTILITY": {
+      if (!tile.property) break;
+      if (tile.property.owner===null) {
+        g.prompts.canBuy = true; g.log.push({t:Date.now(), text:`${me.name} can buy ${tile.name} for ${tile.property.cost}.`});
+      } else if (tile.property.owner!==me.id && !tile.property.mortgaged) {
+        const owner = g.players[tile.property.owner];
+        const count = countOwnedInGroup(g, owner.id, tile.property.group);
+        const rent = computeRent(tile, count);
+        me.cash -= rent; owner.cash += rent; g.prompts.mustPay = rent;
+        g.log.push({t:Date.now(), text:`${me.name} pays ${rent} to ${owner.name} for ${tile.name}.`});
+      }
+      break;
+    }
+    case "TAX": { const amt = tile.taxAmount||0; me.cash -= amt; g.prompts.mustPay = amt; g.log.push({t:Date.now(), text:`${me.name} pays tax ${amt}.`}); break; }
+    case "EVENT": { // simple events
+      const r = (g.rngSeed % 6) - 3; g.rngSeed = nextSeed(g.rngSeed);
+      const amt = r*50; me.cash += amt; g.log.push({t:Date.now(), text:`Event card: ${(amt>=0?"Gain":"Lose")} ${Math.abs(amt)}.`});
+      break; }
+    case "FUND": { const amt = 100; me.cash += amt; g.log.push({t:Date.now(), text:`Transit fund grant +${amt}.`}); break; }
+    case "GO_TO_JAIL": { jailPlayer(me); g.log.push({t:Date.now(), text:`${me.name} sent to Detention.`}); break; }
+    case "VISIT": case "PARKING": default: { g.log.push({t:Date.now(), text:`${me.name} is safe at ${tile.name}.`}); }
+  }
+  adjustNetWorth(g);
+  return g;
+}
+
+export function buyCurrent(g: GameState): GameState {
+  g = clone(g);
+  const me = g.players[g.turn];
+  const tile = g.tiles[me.pos];
+  if (tile.property && tile.property.owner===null && me.cash >= tile.property.cost){
+    const before = clone(g);
+    me.cash -= tile.property.cost; tile.property.owner = me.id;
+    g.prompts.canBuy = false; g.log.push({t:Date.now(), text:`${me.name} bought ${tile.name}.`});
+    adjustNetWorth(g);
+    // learning
+    if (!me.isHuman) new LearningAgent(me.id).learnBuy(before, g, true);
+  } else if (!tile.property?.owner && !me.isHuman) {
+    // learning negative signal for skipping when cannot afford
+    const before = clone(g); adjustNetWorth(before); const after = clone(g); adjustNetWorth(after);
+    new LearningAgent(me.id).learnBuy(before, after, false);
+  }
+  return g;
+}
+
+export function buildOnOwned(g: GameState, tileIndex: number): GameState {
+  g = clone(g);
+  const me = g.players[g.turn];
+  const tile = g.tiles[tileIndex];
+  if (!tile.property || tile.property.owner!==me.id) return g;
+  const cost = Math.floor(tile.property.cost * 0.6);
+  if (tile.property.upgrades < 5 && me.cash >= cost) {
+    const before = clone(g);
+    me.cash -= cost; tile.property.upgrades += 1;
+    g.log.push({t:Date.now(), text:`${me.name} upgraded ${tile.name} (lvl ${tile.property.upgrades}).`});
+    adjustNetWorth(g);
+    if (!me.isHuman) new LearningAgent(me.id).learnBuild(before, g, true);
+  }
+  return g;
+}
+
+export function toggleMortgage(g: GameState, tileIndex: number): GameState {
+  g = clone(g);
+  const me = g.players[g.turn];
+  const tile = g.tiles[tileIndex];
+  if (!tile.property || tile.property.owner!==me.id) return g;
+  if (tile.property.mortgaged){ tile.property.mortgaged=false; me.cash -= Math.floor(tile.property.cost*0.55); }
+  else { tile.property.mortgaged=true; me.cash += Math.floor(tile.property.cost*0.5); }
+  adjustNetWorth(g);
+  return g;
+}
+
+export function endTurn(g: GameState): GameState {
+  g = clone(g);
+  g.turn = (g.turn + 1) % g.players.length;
+  g.dice = null; g.prompts = { canBuy:false, mustPay:0, landedTile:null };
+  adjustNetWorth(g);
+  return runUntilHuman(g);
+}
+
+export function runUntilHuman(g: GameState): GameState {
+  let state = clone(g);
+  let guard = 0;
+  while (!state.players[state.turn].isHuman && !state.players[state.turn].bankrupt && guard < 20) {
+    state = aiTakeTurn(state);
+    guard++;
+  }
+  return state;
+}
+
+export function aiTakeTurn(g: GameState): GameState {
+  let state = clone(g);
+  const actor = state.players[state.turn];
+  if (actor.isHuman || actor.bankrupt) return state;
+  const agent = new LearningAgent(actor.id);
+
+  // 1) Roll & resolve
+  state = rollAndAdvance(state);
+  const before = clone(state);
+  state = resolveLanding(state);
+
+  // 2) If can buy, decide
+  const tile = state.tiles[state.players[state.turn].pos];
+  if (tile.property && tile.property.owner===null) {
+    const want = agent.decideBuy(before);
+    if (want && state.players[state.turn].cash >= tile.property.cost) state = buyCurrent(state);
+    else agent.learnBuy(before, state, false);
+  }
+  // 3) Opportunistic build on owned groups if cash healthy
+  const me = state.players[state.turn];
+  if (me.cash > 250) {
+    for (let i=0;i<state.tiles.length;i++) {
+      const t = state.tiles[i];
+      if (t.property && t.property.owner===me.id && t.property.upgrades<5) {
+        if (agent.decideBuild(state, i)) state = buildOnOwned(state, i);
+      }
+    }
+  }
+  // 4) End turn (human-safe: no recursive AI)
+  state.turn = (state.turn + 1) % state.players.length;
+  state.dice = null; state.prompts = { canBuy:false, mustPay:0, landedTile:null };
+  adjustNetWorth(state);
+  return state;
+}
+
+export function resetGame(opts?: InitOptions){ return initGame(opts || { players:2, humans:1 }); }

--- a/WT4Q/lib/metrotrade/rules.ts
+++ b/WT4Q/lib/metrotrade/rules.ts
@@ -1,0 +1,25 @@
+import type { GameState, Player, Tile } from "./types";
+import { PASS_START_BONUS, JAIL_INDEX } from "./constants";
+
+export function passStartBonus(player: Player) { player.cash += PASS_START_BONUS; }
+
+export function computeRent(tile: Tile, ownerPropsInGroup: number): number {
+  if (!tile.property) return 0;
+  const lvl = tile.property.upgrades;
+  const base = tile.property.baseRent[Math.min(lvl, tile.property.baseRent.length-1)] || 0;
+  // small group bonus: +50% if owner holds 3+ in group and tile has <1 upgrade
+  const monoBonus = (ownerPropsInGroup >= 3 && lvl === 0) ? Math.floor(base * 1.5) : base;
+  return tile.property.mortgaged ? 0 : monoBonus;
+}
+
+export function jailPlayer(p: Player) { p.inJail = true; p.jailTurns = 0; p.pos = JAIL_INDEX; }
+export function leaveJail(p: Player) { p.inJail = false; p.jailTurns = 0; }
+
+export function adjustNetWorth(g: GameState) {
+  for (const p of g.players) {
+    // rough estimate of property value
+    const propVal = g.tiles.reduce((sum, t) => sum + (t.property && t.property.owner===p.id ? Math.floor(t.property.cost * (1 + 0.5*t.property.upgrades)) : 0), 0);
+    p.netWorth = p.cash + propVal;
+    if (p.cash < -500) p.bankrupt = true; // simple bankruptcy condition
+  }
+}

--- a/WT4Q/lib/metrotrade/types.ts
+++ b/WT4Q/lib/metrotrade/types.ts
@@ -1,0 +1,55 @@
+export type PlayerId = number;
+export type TileIndex = number;
+
+export interface InitOptions { players: number; humans: number; }
+
+export type TileType = "GO" | "PROPERTY" | "TRANSIT" | "UTILITY" | "JAIL" | "VISIT" | "PARKING" | "GO_TO_JAIL" | "EVENT" | "FUND" | "TAX";
+
+export interface Property {
+  cost: number;
+  group: string; // color/group name
+  baseRent: number[]; // length 6 (0..5 upgrades)
+  owner: PlayerId | null;
+  upgrades: number; // 0..5
+  mortgaged?: boolean;
+}
+
+export interface Tile {
+  i: TileIndex;
+  name: string;
+  type: TileType;
+  property?: Property;
+  taxAmount?: number;
+}
+
+export interface Player {
+  id: PlayerId;
+  name: string;
+  isHuman: boolean;
+  cash: number;
+  pos: TileIndex;
+  inJail: boolean;
+  jailTurns: number;
+  bankrupt: boolean;
+  netWorth: number; // cash + props value
+}
+
+export interface LogEntry { t: number; text: string; }
+
+export interface GameState {
+  turn: number; // index into players[]
+  dice: [number, number] | null;
+  tiles: Tile[];
+  players: Player[];
+  deckEvent: number[];
+  deckFund: number[];
+  prompts: {
+    canBuy: boolean;
+    mustPay: number; // rent/tax just computed
+    landedTile: TileIndex | null;
+  };
+  lastActionAt: number; // timestamp
+  rngSeed: number;
+  settings: InitOptions;
+  log: LogEntry[];
+}

--- a/WT4Q/lib/metrotrade/utils.ts
+++ b/WT4Q/lib/metrotrade/utils.ts
@@ -1,0 +1,15 @@
+export function rand(seed: number) { // mulberry32
+  let t = seed + 0x6D2B79F5;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+export function nextSeed(seed: number) {
+  return (seed * 1664525 + 1013904223) >>> 0;
+}
+export function rollDice(seed: number): { d1: number; d2: number; seed: number } {
+  const s1 = nextSeed(seed); const r1 = Math.floor(rand(s1) * 6) + 1;
+  const s2 = nextSeed(s1); const r2 = Math.floor(rand(s2) * 6) + 1;
+  return { d1: r1, d2: r2, seed: nextSeed(s2) };
+}
+export function wrap(pos: number) { return ((pos % 40) + 40) % 40; }

--- a/WT4Q/package-lock.json
+++ b/WT4Q/package-lock.json
@@ -11,6 +11,7 @@
         "fabric": "^6.0.0-beta15",
         "html-to-image": "^1.11.11",
         "html2canvas": "^1.4.1",
+        "immer": "^10.1.1",
         "lint": "^0.8.19",
         "lucide-react": "^0.469.0",
         "next": "^15.4.2",
@@ -18,6 +19,7 @@
         "react-dom": "^19.1.0",
         "react-dropzone": "^14.2.3",
         "turbo": "^2.5.5",
+        "uuid": "^9.0.1",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -30,6 +32,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^9",
         "eslint-config-next": "15.3.4",
+        "happy-dom": "^18.0.1",
         "jsdom": "^24.0.0",
         "typescript": "^5",
         "vitest": "^3.2.4"
@@ -2056,6 +2059,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.35.1",
@@ -5466,6 +5476,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/happy-dom": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
+      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5696,6 +5731,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -8152,6 +8197,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9633,13 +9688,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/verror": {

--- a/WT4Q/package.json
+++ b/WT4Q/package.json
@@ -13,6 +13,7 @@
     "fabric": "^6.0.0-beta15",
     "html-to-image": "^1.11.11",
     "html2canvas": "^1.4.1",
+    "immer": "^10.1.1",
     "lint": "^0.8.19",
     "lucide-react": "^0.469.0",
     "next": "^15.4.2",
@@ -20,6 +21,7 @@
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",
     "turbo": "^2.5.5",
+    "uuid": "^9.0.1",
     "zustand": "^4.5.2"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
+    "happy-dom": "^18.0.1",
     "jsdom": "^24.0.0",
     "typescript": "^5",
     "vitest": "^3.2.4"

--- a/WT4Q/services/metrotrade/LearningAgent.ts
+++ b/WT4Q/services/metrotrade/LearningAgent.ts
@@ -1,0 +1,82 @@
+import type { GameState, PlayerId } from "@/lib/metrotrade/types";
+import { storage } from "./storage";
+
+// Lightweight tabular learner for buy/build policy using discretized features.
+// State features: cash bucket, tile cost bucket, group holdings percentage, dice sum bucket.
+// Actions: BUY vs SKIP; BUILD vs HOLD. Epsilon-greedy; online updates with TD(0).
+
+type Action = "BUY" | "SKIP" | "BUILD" | "HOLD";
+
+interface QTable { [key: string]: number; }
+
+export class LearningAgent {
+  private q: QTable;
+  private eps: number;
+  private alpha: number;
+  private gamma: number;
+  private key: string;
+
+  constructor(id: PlayerId) {
+    this.key = `metrotrade.q.p${id}`;
+    this.q = storage.get<QTable>(this.key, {});
+    this.eps = 0.1;
+    this.alpha = 0.2;
+    this.gamma = 0.9;
+  }
+
+  private fCash(v: number){ return Math.min(6, Math.max(0, Math.floor(v/300))); }
+  private fCost(v: number){ return Math.min(6, Math.max(0, Math.floor(v/100))); }
+  private discretize(g: GameState, action: Action){
+    const me = g.players[g.turn];
+    const tile = g.tiles[me.pos];
+    const cost = tile.property?.cost || 0;
+    const ownInGroup = g.tiles.filter(t => t.property && t.property.owner===me.id && t.property.group===tile.property?.group).length;
+    const groupSize = g.tiles.filter(t => t.property && t.property.group===tile.property?.group).length || 1;
+    const feat = {
+      c: this.fCash(me.cash),
+      k: this.fCost(cost),
+      h: Math.floor((ownInGroup/groupSize)*3), // 0..3
+      d: g.dice ? Math.min(2, Math.floor(((g.dice[0]+g.dice[1])-2)/4)) : 1
+    };
+    return `a:${action}|c:${feat.c}|k:${feat.k}|h:${feat.h}|d:${feat.d}`;
+  }
+
+  private qv(s: string){ return this.q[s] ?? 0; }
+  private upd(s: string, r: number, s2: string){
+    const target = r + this.gamma * this.qv(s2);
+    const v = this.qv(s) + this.alpha * (target - this.qv(s));
+    this.q[s] = v; storage.set(this.key, this.q);
+  }
+
+  decideBuy(g: GameState): boolean {
+    const sBuy = this.discretize(g, "BUY");
+    const sSkip = this.discretize(g, "SKIP");
+    if (Math.random() < this.eps) return Math.random() < 0.5;
+    return this.qv(sBuy) >= this.qv(sSkip);
+  }
+
+  learnBuy(gBefore: GameState, gAfter: GameState, didBuy: boolean){
+    const s = this.discretize(gBefore, didBuy ? "BUY" : "SKIP");
+    const s2 = this.discretize(gAfter, didBuy ? "BUY" : "SKIP");
+    const meAfter = gAfter.players[gAfter.turn];
+    const meBefore = gBefore.players[gBefore.turn];
+    const r = (meAfter.netWorth - meBefore.netWorth) / 50; // scale reward
+    this.upd(s, r, s2);
+  }
+
+  decideBuild(g: GameState, _tileIndex: number): boolean {
+    const sBuild = this.discretize(g, "BUILD");
+    const sHold = this.discretize(g, "HOLD");
+    if (Math.random() < this.eps) return Math.random() < 0.5;
+    return this.qv(sBuild) >= this.qv(sHold);
+  }
+
+  learnBuild(gBefore: GameState, gAfter: GameState, did: boolean){
+    const s = this.discretize(gBefore, did ? "BUILD" : "HOLD");
+    const s2 = this.discretize(gAfter, did ? "BUILD" : "HOLD");
+    const meAfter = gAfter.players[gAfter.turn];
+    const meBefore = gBefore.players[gBefore.turn];
+    const r = (meAfter.netWorth - meBefore.netWorth) / 50;
+    this.upd(s, r, s2);
+  }
+}

--- a/WT4Q/services/metrotrade/storage.ts
+++ b/WT4Q/services/metrotrade/storage.ts
@@ -1,0 +1,10 @@
+export const storage = {
+  get<T>(key: string, fallback: T): T {
+    if (typeof window === "undefined") return fallback;
+    try { const v = window.localStorage.getItem(key); return v ? JSON.parse(v) as T : fallback; } catch { return fallback; }
+  },
+  set<T>(key: string, val: T) {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(key, JSON.stringify(val));
+  }
+};

--- a/WT4Q/src/app/games/metrotrade/page.tsx
+++ b/WT4Q/src/app/games/metrotrade/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import MetroTradeGame from '@/components/metrotrade';
+
+export const metadata: Metadata = {
+  title: 'Metropolotan Trader',
+  description: 'A strategy game set in the metro.',
+};
+
+export default function MetroTradePage() {
+  return <MetroTradeGame />;
+}

--- a/WT4Q/src/app/games/page.tsx
+++ b/WT4Q/src/app/games/page.tsx
@@ -26,6 +26,20 @@ export default function GamesPage() {
             />
           </div>
         </li>
+        <li className={styles.item}>
+          <PrefetchLink
+            href="/games/metrotrade"
+            title="Play Metropolotan Trader"
+          >
+            Metropolotan Trader
+          </PrefetchLink>
+          <div className={styles.preview}>
+            <img
+              src="https://via.placeholder.com/200?text=Metro"
+              alt="Metropolotan Trader preview"
+            />
+          </div>
+        </li>
       </ul>
     </main>
   );

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -47,9 +47,27 @@ export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
 
         </div>
       </div>
-      <PrefetchLink href="/games" className={styles.link} onClick={onNavigate}>
-        Games
-      </PrefetchLink>
+      <div className={styles.dropdown}>
+        <PrefetchLink href="/games" className={styles.link} onClick={onNavigate}>
+          Games
+        </PrefetchLink>
+        <div className={styles.dropdownMenu}>
+          <PrefetchLink
+            href="/games/2048_game_online"
+            className={styles.link}
+            onClick={onNavigate}
+          >
+            2048
+          </PrefetchLink>
+          <PrefetchLink
+            href="/games/metrotrade"
+            className={styles.link}
+            onClick={onNavigate}
+          >
+            Metropolotan Trader
+          </PrefetchLink>
+        </div>
+      </div>
       <PrefetchLink href="/weather" className={styles.link} onClick={onNavigate}>
         Weather
       </PrefetchLink>

--- a/WT4Q/src/components/metrotrade/Board.tsx
+++ b/WT4Q/src/components/metrotrade/Board.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useMetroStore } from "@/hooks/useMetroStore";
+import { BOARD } from "@/lib/metrotrade/constants";
+import Tile from "./Tile";
+import boardCss from "@/styles/metrotrade/board.module.css";
+
+export default function Board(){
+  const state = useMetroStore(s=>s.state);
+  return (
+    <div className={boardCss.grid}>
+      {BOARD.map((tile)=> (
+        <div key={tile.i} className={boardCss.tile}><Tile tile={state.tiles[tile.i]} /></div>
+      ))}
+    </div>
+  );
+}

--- a/WT4Q/src/components/metrotrade/Dice.tsx
+++ b/WT4Q/src/components/metrotrade/Dice.tsx
@@ -1,0 +1,7 @@
+"use client";
+export default function Dice({ d1, d2 }: { d1:number; d2:number; }){
+  return <div style={{display:"inline-flex",gap:8}}><Die v={d1}/><Die v={d2}/></div>;
+}
+function Die({ v }:{ v:number }){
+  return <div style={{width:28,height:28,border:"1px solid #777",borderRadius:6,display:"grid",placeItems:"center"}}>{v}</div>;
+}

--- a/WT4Q/src/components/metrotrade/HUD.tsx
+++ b/WT4Q/src/components/metrotrade/HUD.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useMetroStore } from "@/hooks/useMetroStore";
+import styles from "@/styles/metrotrade/ui.module.css";
+
+export default function HUD(){
+  const state = useMetroStore(s=>s.state);
+  const roll = useMetroStore(s=>s.roll);
+  const resolve = useMetroStore(s=>s.resolve);
+  const end = useMetroStore(s=>s.end);
+  const buy = useMetroStore(s=>s.buy);
+
+  const me = state.players[state.turn];
+  const canInteract = me.isHuman && !me.bankrupt;
+
+  return (
+    <div className={styles.hud}>
+      <div className={styles.turnRow}>
+        <div><strong>Turn:</strong> {me.name}</div>
+        <div><strong>Dice:</strong> {state.dice? `${state.dice[0]} + ${state.dice[1]}` : "—"}</div>
+      </div>
+      <div className={styles.buttons}>
+        <button disabled={!canInteract} onClick={roll}>Roll</button>
+        <button disabled={!canInteract} onClick={resolve}>Resolve</button>
+        <button disabled={!canInteract || !state.prompts.canBuy} onClick={buy}>Buy</button>
+        <button disabled={!canInteract} onClick={end}>End Turn</button>
+      </div>
+      <div className={styles.log}>
+        {state.log.slice(-8).map((l,i)=> <div key={i} className={styles.logLine}>{l.text}</div>)}
+      </div>
+    </div>
+  );
+}

--- a/WT4Q/src/components/metrotrade/MetroTradeGame.tsx
+++ b/WT4Q/src/components/metrotrade/MetroTradeGame.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useMemo, useState } from "react";
+import { useMetroStore } from "@/hooks/useMetroStore";
+import Board from "./Board";
+import HUD from "./HUD";
+import PlayerPanel from "./PlayerPanel";
+import styles from "@/styles/metrotrade/ui.module.css";
+
+export default function MetroTradeGame(){
+  const [players, setPlayers] = useState(2);
+  const [humans, setHumans] = useState(1);
+  const init = useMetroStore(s=>s.init);
+  const state = useMetroStore(s=>s.state);
+
+  const onStart = () => init({ players, humans });
+
+  const bankruptCount = useMemo(()=> state.players.filter(p=>p.bankrupt).length, [state.players]);
+  const gameOver = bankruptCount >= state.players.length-1;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.topBar}>
+        <div className={styles.brand}>MetroTrade</div>
+        <div className={styles.controls}>
+          <label>Players
+            <input type="number" min={2} max={5} value={players} onChange={e=>setPlayers(parseInt(e.target.value||"2"))}/>
+          </label>
+          <label>Humans
+            <input type="number" min={1} max={Math.max(1, players-1)} value={humans} onChange={e=>setHumans(parseInt(e.target.value||"1"))}/>
+          </label>
+          <button onClick={onStart} className={styles.primary}>Start</button>
+        </div>
+      </div>
+      <div className={styles.layout}>
+        <div className={styles.boardWrap}><Board/></div>
+        <div className={styles.side}>
+          <HUD/>
+          <PlayerPanel/>
+        </div>
+      </div>
+      {gameOver && <div className={styles.overlay}><div className={styles.modal}><h2>Game Over</h2><p>Winner: {state.players.sort((a,b)=>b.netWorth-a.netWorth)[0].name}</p><button onClick={()=>init({ players, humans })}>Play again</button></div></div>}
+    </div>
+  );
+}

--- a/WT4Q/src/components/metrotrade/PlayerPanel.tsx
+++ b/WT4Q/src/components/metrotrade/PlayerPanel.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useMetroStore } from "@/hooks/useMetroStore";
+import pcss from "@/styles/metrotrade/panels.module.css";
+
+export default function PlayerPanel(){
+  const state = useMetroStore(s=>s.state);
+  const build = useMetroStore(s=>s.build);
+  const mortgage = useMetroStore(s=>s.mortgage);
+  const me = state.players[state.turn];
+  return (
+    <div className={pcss.wrap}>
+      {state.players.map(p=> (
+        <div key={p.id} className={pcss.card} data-active={p.id===me.id}>
+          <div className={pcss.header}><span className={pcss.badge}>{p.id+1}</span> {p.name}</div>
+          <div className={pcss.row}><span>Cash</span><span>{p.cash}</span></div>
+          <div className={pcss.row}><span>Net worth</span><span>{p.netWorth}</span></div>
+          <div className={pcss.props}>
+            {state.tiles.filter(t=>t.property && t.property.owner===p.id).map(t=> (
+              <div key={t.i} className={pcss.prop}>
+                <div className={pcss.pname}>{t.name}</div>
+                <div className={pcss.pmeta}>Lv {t.property!.upgrades} {t.property!.mortgaged?"(M)":""}</div>
+                {p.id===me.id && (
+                  <div className={pcss.actions}>
+                    <button onClick={()=>build(t.i)} disabled={t.property!.upgrades>=5}>Build</button>
+                    <button onClick={()=>mortgage(t.i)}>{t.property!.mortgaged?"Unmortgage":"Mortgage"}</button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/WT4Q/src/components/metrotrade/Tile.tsx
+++ b/WT4Q/src/components/metrotrade/Tile.tsx
@@ -1,0 +1,30 @@
+"use client";
+import type { Tile as T } from "@/lib/metrotrade/types";
+import { useMetroStore } from "@/hooks/useMetroStore";
+import ui from "@/styles/metrotrade/board.module.css";
+
+export default function Tile({ tile }: { tile: T }){
+  const state = useMetroStore(s=>s.state);
+  const me = state.players[state.turn];
+  const isHere = me.pos === tile.i;
+  const classes = [ui[`t_${tile.type.toLowerCase()}`]];
+  return (
+    <div className={classes.join(" ")}> 
+      <div className={ui.name}>{tile.name}</div>
+      {tile.property && (
+        <div className={ui.prop}>
+          <div>Cost: {tile.property.cost}</div>
+          <div>Lv: {tile.property.upgrades}</div>
+          <div>Own: {tile.property.owner===null?"—": state.players[tile.property.owner].name}</div>
+          {tile.property.mortgaged && <div className={ui.badge}>M</div>}
+        </div>
+      )}
+      <div className={ui.pawns}>
+        {state.players.map(p=> (
+          <span key={p.id} className={ui.pawn} style={{ opacity: p.pos===tile.i?1:0.15 }}>{p.id+1}</span>
+        ))}
+      </div>
+      {isHere && <div className={ui.here} />}
+    </div>
+  );
+}

--- a/WT4Q/src/components/metrotrade/index.ts
+++ b/WT4Q/src/components/metrotrade/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MetroTradeGame';

--- a/WT4Q/src/hooks/useMetroStore.ts
+++ b/WT4Q/src/hooks/useMetroStore.ts
@@ -1,0 +1,29 @@
+"use client";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type { GameState, InitOptions } from "@/lib/metrotrade/types";
+import { initGame, rollAndAdvance, resolveLanding, endTurn, buyCurrent, buildOnOwned, toggleMortgage } from "@/lib/metrotrade/engine";
+
+interface Store {
+  state: GameState;
+  init: (opts: InitOptions) => void;
+  roll: () => void;
+  resolve: () => void;
+  end: () => void;
+  buy: () => void;
+  build: (tileIndex: number) => void;
+  mortgage: (tileIndex: number) => void;
+  reset: (opts?: InitOptions) => void;
+}
+
+export const useMetroStore = create<Store>()(immer((set) => ({
+  state: initGame({ players: 2, humans: 1 }),
+  init: (opts) => set(draft => { draft.state = initGame(opts); }),
+  reset: (opts) => set(draft => { draft.state = initGame(opts || { players: 2, humans: 1 }); }),
+  roll: () => set(draft => { draft.state = rollAndAdvance(draft.state); }),
+  resolve: () => set(draft => { draft.state = resolveLanding(draft.state); }),
+  end: () => set(draft => { draft.state = endTurn(draft.state); }),
+  buy: () => set(draft => { draft.state = buyCurrent(draft.state); }),
+  build: (tileIndex) => set(draft => { draft.state = buildOnOwned(draft.state, tileIndex); }),
+  mortgage: (tileIndex) => set(draft => { draft.state = toggleMortgage(draft.state, tileIndex); }),
+})));

--- a/WT4Q/src/styles/metrotrade/board.module.css
+++ b/WT4Q/src/styles/metrotrade/board.module.css
@@ -1,0 +1,70 @@
+.grid { 
+  --size: min(80vh, 80vw);
+  width: var(--size);
+  height: var(--size);
+  display: grid;
+  grid-template-columns: repeat(11, 1fr);
+  grid-template-rows: repeat(11, 1fr);
+  background: #0a0f18; border: 2px solid #223; border-radius: 8px; position: relative; overflow: hidden;
+}
+.tile { border: 1px solid #1e2735; padding: 4px; font-size: 11px; position: relative; color: #d7e2f2; }
+.name { font-weight: 600; margin-bottom: 2px; }
+.prop { font-size: 10px; opacity: 0.9; }
+.badge { position:absolute; top:4px; right:4px; background:#b33; color:#fff; font-size:9px; padding:2px 4px; border-radius:4px; }
+.pawns { position:absolute; bottom:4px; right:4px; display:flex; gap:2px; }
+.pawn { width:14px; height:14px; border-radius:50%; background:#6aa3ff; color:#000; font-weight:700; display:grid; place-items:center; }
+.here { position:absolute; inset:2px; border:2px dashed #58d68d; border-radius:6px; pointer-events:none; }
+
+/* Tile type accents */
+.t_go { background: linear-gradient(180deg, rgba(40,180,120,0.1), rgba(0,0,0,0)); }
+.t_property { background: linear-gradient(180deg, rgba(100,150,250,0.06), rgba(0,0,0,0)); }
+.t_transit { background: linear-gradient(180deg, rgba(250,200,50,0.06), rgba(0,0,0,0)); }
+.t_utility { background: linear-gradient(180deg, rgba(250,100,50,0.06), rgba(0,0,0,0)); }
+.t_jail, .t_visit { background: rgba(200,80,80,0.08); }
+.t_parking { background: rgba(80,200,140,0.08); }
+.t_go_to_jail { background: rgba(200,80,120,0.08); }
+.t_event, .t_fund { background: rgba(140,120,240,0.08); }
+.t_tax { background: rgba(255,120,60,0.08); }
+
+/* Position tiles around edges (11x11).
+   NOTE: We wrap each Tile in Board.tsx with .tile, so nth-child maps to BOARD order. */
+.tile:nth-child(1) { grid-area: 11 / 11 / 12 / 12; }
+.tile:nth-child(2) { grid-area: 11 / 10 / 12 / 11; }
+.tile:nth-child(3) { grid-area: 11 / 9 / 12 / 10; }
+.tile:nth-child(4) { grid-area: 11 / 8 / 12 / 9; }
+.tile:nth-child(5) { grid-area: 11 / 7 / 12 / 8; }
+.tile:nth-child(6) { grid-area: 11 / 6 / 12 / 7; }
+.tile:nth-child(7) { grid-area: 11 / 5 / 12 / 6; }
+.tile:nth-child(8) { grid-area: 11 / 4 / 12 / 5; }
+.tile:nth-child(9) { grid-area: 11 / 3 / 12 / 4; }
+.tile:nth-child(10){ grid-area: 11 / 2 / 12 / 3; }
+.tile:nth-child(11){ grid-area: 11 / 1 / 12 / 2; }
+.tile:nth-child(12){ grid-area: 10 / 1 / 11 / 2; }
+.tile:nth-child(13){ grid-area: 9 / 1 / 10 / 2; }
+.tile:nth-child(14){ grid-area: 8 / 1 / 9 / 2; }
+.tile:nth-child(15){ grid-area: 7 / 1 / 8 / 2; }
+.tile:nth-child(16){ grid-area: 6 / 1 / 7 / 2; }
+.tile:nth-child(17){ grid-area: 5 / 1 / 6 / 2; }
+.tile:nth-child(18){ grid-area: 4 / 1 / 5 / 2; }
+.tile:nth-child(19){ grid-area: 3 / 1 / 4 / 2; }
+.tile:nth-child(20){ grid-area: 2 / 1 / 3 / 2; }
+.tile:nth-child(21){ grid-area: 1 / 1 / 2 / 2; }
+.tile:nth-child(22){ grid-area: 1 / 2 / 2 / 3; }
+.tile:nth-child(23){ grid-area: 1 / 3 / 2 / 4; }
+.tile:nth-child(24){ grid-area: 1 / 4 / 2 / 5; }
+.tile:nth-child(25){ grid-area: 1 / 5 / 2 / 6; }
+.tile:nth-child(26){ grid-area: 1 / 6 / 2 / 7; }
+.tile:nth-child(27){ grid-area: 1 / 7 / 2 / 8; }
+.tile:nth-child(28){ grid-area: 1 / 8 / 2 / 9; }
+.tile:nth-child(29){ grid-area: 1 / 9 / 2 / 10; }
+.tile:nth-child(30){ grid-area: 1 / 10 / 2 / 11; }
+.tile:nth-child(31){ grid-area: 1 / 11 / 2 / 12; }
+.tile:nth-child(32){ grid-area: 2 / 11 / 3 / 12; }
+.tile:nth-child(33){ grid-area: 3 / 11 / 4 / 12; }
+.tile:nth-child(34){ grid-area: 4 / 11 / 5 / 12; }
+.tile:nth-child(35){ grid-area: 5 / 11 / 6 / 12; }
+.tile:nth-child(36){ grid-area: 6 / 11 / 7 / 12; }
+.tile:nth-child(37){ grid-area: 7 / 11 / 8 / 12; }
+.tile:nth-child(38){ grid-area: 8 / 11 / 9 / 12; }
+.tile:nth-child(39){ grid-area: 9 / 11 / 10 / 12; }
+.tile:nth-child(40){ grid-area: 10 / 11 / 11 / 12; }

--- a/WT4Q/src/styles/metrotrade/panels.module.css
+++ b/WT4Q/src/styles/metrotrade/panels.module.css
@@ -1,0 +1,12 @@
+.wrap { display:flex; flex-direction:column; gap:8px; }
+.card { background:#0f1828; border:1px solid #26334b; border-radius:8px; padding:10px; }
+.card[data-active="true"]{ outline:2px solid #25c2a0; }
+.header { display:flex; align-items:center; gap:8px; font-weight:700; margin-bottom:6px; }
+.badge { background:#6aa3ff; color:#001; width:18px; height:18px; display:grid; place-items:center; border-radius:50%; font-weight:800; }
+.row { display:flex; justify-content:space-between; font-size:13px; padding:2px 0; }
+.props { display:flex; flex-direction:column; gap:6px; max-height:220px; overflow:auto; }
+.prop { background:#0b1322; border:1px solid #21304a; border-radius:6px; padding:6px; }
+.pname { font-size:13px; font-weight:700; }
+.pmeta { font-size:11px; opacity:0.8; }
+.actions { display:flex; gap:6px; margin-top:6px; }
+.actions button { padding:4px 6px; background:#162138; color:#dbe8ff; border:1px solid #2a3a55; border-radius:6px; cursor:pointer; }

--- a/WT4Q/src/styles/metrotrade/ui.module.css
+++ b/WT4Q/src/styles/metrotrade/ui.module.css
@@ -1,0 +1,24 @@
+.container { display:flex; flex-direction:column; gap:16px; padding:16px; color:#e9f1fb; background:#0b1220; }
+.topBar { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.brand { font-weight:800; font-size:20px; letter-spacing:0.5px; }
+.controls { display:flex; gap:8px; align-items:center; }
+.controls input { width:60px; margin-left:6px; }
+.primary { background:#25c2a0; color:#081018; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
+.layout { display:grid; grid-template-columns: 1fr 320px; gap:16px; }
+.boardWrap { display:grid; place-items:center; }
+.side { display:flex; flex-direction:column; gap:12px; }
+.hud { background:#101826; border:1px solid #223047; border-radius:8px; padding:12px; }
+.turnRow { display:flex; justify-content:space-between; margin-bottom:8px; }
+.buttons { display:flex; gap:8px; flex-wrap:wrap; }
+.buttons button { padding:6px 10px; background:#1a2334; color:#e6f0ff; border:1px solid #2a3a55; border-radius:6px; cursor:pointer; }
+.buttons button:disabled{ opacity:0.5; cursor:not-allowed; }
+.log { margin-top:8px; height:140px; overflow:auto; font-size:12px; background:#0c1320; padding:8px; border-radius:6px; border:1px solid #1d2940; }
+.logLine { opacity:0.9; }
+.overlay { position:fixed; inset:0; backdrop-filter: blur(4px); display:grid; place-items:center; }
+.modal { background:#0d1626; border:1px solid #2a3a55; border-radius:10px; padding:16px; min-width:280px; }
+
+
+@media (max-width: 900px){
+.layout { grid-template-columns: 1fr; }
+.side { order:-1; }
+}

--- a/WT4Q/tests/engine.test.ts
+++ b/WT4Q/tests/engine.test.ts
@@ -1,0 +1,45 @@
+// To run: npm i -D vitest @types/node tsx && npx vitest run
+import { describe, it, expect } from "vitest";
+import { initGame, rollAndAdvance, resolveLanding, buyCurrent } from "../lib/metrotrade/engine";
+
+// Helper to force a known dice outcome by setting rngSeed
+function setSeed(g:any, seed:number){ g.rngSeed = seed >>> 0; return g; }
+
+describe("engine basics", () => {
+  it("initializes with requested players", () => {
+    const g = initGame({ players: 5, humans: 2 });
+    expect(g.players.length).toBe(5);
+    expect(g.players.filter(p=>p.isHuman).length).toBe(2);
+  });
+
+  it("rolls and advances position", () => {
+    let g = initGame({ players: 2, humans: 1 });
+    setSeed(g, 123456);
+    const old = g.players[g.turn].pos;
+    g = rollAndAdvance(g);
+    expect(g.players[g.turn].pos).not.toBe(old);
+  });
+
+  it("allows buying unowned property", () => {
+    let g = initGame({ players: 2, humans: 1 });
+    // Teleport to a known property tile
+    g.players[g.turn].pos = 1; // Lime Street
+    g = resolveLanding(g);
+    expect(g.prompts.canBuy).toBe(true);
+    const cashBefore = g.players[g.turn].cash;
+    g = buyCurrent(g);
+    expect(g.players[g.turn].cash).toBeLessThan(cashBefore);
+    expect(g.tiles[1].property!.owner).toBe(g.players[g.turn].id);
+  });
+
+  it("pays rent when landing on opponent property", () => {
+    let g = initGame({ players: 2, humans: 2 });
+    // Player 0 buys tile 1
+    g.players[0].pos = 1; g = resolveLanding(g); g = buyCurrent(g);
+    // Switch to player 1 and land on tile 1
+    g.turn = 1; g.players[1].pos = 1; const cashBefore = g.players[1].cash; const ownerBefore = g.players[0].cash;
+    g = resolveLanding(g);
+    expect(g.players[1].cash).toBeLessThan(cashBefore);
+    expect(g.players[0].cash).toBeGreaterThan(ownerBefore);
+  });
+});

--- a/WT4Q/tsconfig.json
+++ b/WT4Q/tsconfig.json
@@ -25,6 +25,7 @@
       "@/lib/*": ["./lib/*"],
       "@/app/*": ["./src/app/*"],
       "@/styles/*": ["./src/styles/*"],
+      "@/services/*": ["./services/*"],
     },
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.ts"],

--- a/WT4Q/vitest.config.ts
+++ b/WT4Q/vitest.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig } from 'vitest/config';
-
+import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
-    environment: 'jsdom',
-    setupFiles: [],
+    environment: "happy-dom",
+    include: ["tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- implement full MetroTrade board game with zustand store, board rendering, and player HUD
- add learning AI agent, engine logic, and Vitest suite
- include styling, config updates, and new dependencies

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a45e9bc62c83279261b44e6ca3269f