### PR TITLE
fix: ensure metro board visible

### DIFF
--- a/WT4Q/src/styles/metrotrade/board.module.css
+++ b/WT4Q/src/styles/metrotrade/board.module.css
@@ -1,8 +1,11 @@
 
-.grid { 
+.grid {
   --size: min(80vh, 80vw);
   width: var(--size);
   height: var(--size);
+  /* ensure the board is visible even if viewport units resolve to zero */
+  min-width: 320px;
+  min-height: 320px;
   display: grid;
   grid-template-columns: repeat(11, 1fr);
   grid-template-rows: repeat(11, 1fr);


### PR DESCRIPTION
## Summary
- guarantee MetroTrade board has minimum size so it doesn't collapse when viewport units are unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46af707488327ac046b6b7c7c92d7