### PR TITLE
Add responsive MetroTrade game styles

### DIFF
--- a/WT4Q/src/components/metrotrade/MetroTradeGame.tsx
+++ b/WT4Q/src/components/metrotrade/MetroTradeGame.tsx
@@ -5,6 +5,7 @@ import Board from "./Board";
 import HUD from "./HUD";
 import PlayerPanel from "./PlayerPanel";
 import styles from "@/styles/metrotrade/ui.module.css";
+import responsive from "@/styles/metrotrade/responsive.module.css";
 
 export default function MetroTradeGame(){
   const [players, setPlayers] = useState(2);
@@ -18,10 +19,10 @@ export default function MetroTradeGame(){
   const gameOver = bankruptCount >= state.players.length-1;
 
   return (
-    <div className={styles.container}>
-      <div className={styles.topBar}>
+    <div className={`${styles.container} ${responsive.container}`}>
+      <div className={`${styles.topBar} ${responsive.topBar}`}>
         <div className={styles.brand}>MetroTrade</div>
-        <div className={styles.controls}>
+        <div className={`${styles.controls} ${responsive.controls}`}>
           <label>Players
             <input type="number" min={2} max={5} value={players} onChange={e=>setPlayers(parseInt(e.target.value||"2"))}/>
           </label>
@@ -31,9 +32,9 @@ export default function MetroTradeGame(){
           <button onClick={onStart} className={styles.primary}>Start</button>
         </div>
       </div>
-      <div className={styles.layout}>
-        <div className={styles.boardWrap}><Board/></div>
-        <div className={styles.side}>
+      <div className={`${styles.layout} ${responsive.layout}`}>
+        <div className={`${styles.boardWrap} ${responsive.boardWrap}`}><Board/></div>
+        <div className={`${styles.side} ${responsive.side}`}>
           <HUD/>
           <PlayerPanel/>
         </div>

--- a/WT4Q/src/styles/metrotrade/board.module.css
+++ b/WT4Q/src/styles/metrotrade/board.module.css
@@ -19,6 +19,22 @@
 .pawn { width:14px; height:14px; border-radius:50%; background:#6aa3ff; color:#000; font-weight:700; display:grid; place-items:center; }
 .here { position:absolute; inset:2px; border:2px dashed #58d68d; border-radius:6px; pointer-events:none; }
 
+@media (max-width: 600px) {
+  .grid {
+    --size: min(70vh, 95vw);
+    min-width: 260px;
+    min-height: 260px;
+  }
+}
+
+@media (max-width: 400px) {
+  .grid {
+    --size: min(60vh, 90vw);
+    min-width: 220px;
+    min-height: 220px;
+  }
+}
+
 /* Tile type accents */
 .t_go { background: linear-gradient(180deg, rgba(40,180,120,0.1), rgba(0,0,0,0)); }
 .t_property { background: linear-gradient(180deg, rgba(100,150,250,0.06), rgba(0,0,0,0)); }

--- a/WT4Q/src/styles/metrotrade/responsive.module.css
+++ b/WT4Q/src/styles/metrotrade/responsive.module.css
@@ -1,0 +1,25 @@
+.container {}
+.topBar {}
+.controls {}
+.layout {}
+.boardWrap {}
+.side {}
+
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  .side { order: -1; }
+}
+
+@media (max-width: 600px) {
+  .topBar { flex-direction: column; align-items: flex-start; }
+  .controls { width: 100%; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; width: 100%; }
+  .controls input { width: 100%; margin-left: 0; margin-top: 4px; }
+  .layout { gap: 12px; }
+}
+
+@media (max-width: 480px) {
+  .container { padding: 8px; }
+  .controls { gap: 6px; }
+  .layout { gap: 8px; }
+}

--- a/WT4Q/src/styles/metrotrade/ui.module.css
+++ b/WT4Q/src/styles/metrotrade/ui.module.css
@@ -16,9 +16,3 @@
 .logLine { opacity:0.9; }
 .overlay { position:fixed; inset:0; backdrop-filter: blur(4px); display:grid; place-items:center; }
 .modal { background:#0d1626; border:1px solid #2a3a55; border-radius:10px; padding:16px; min-width:280px; }
-
-
-@media (max-width: 900px){
-.layout { grid-template-columns: 1fr; }
-.side { order:-1; }
-}


### PR DESCRIPTION
## Summary
- add dedicated responsive CSS for MetroTrade to support small and medium screens
- update MetroTradeGame component to use responsive classes
- adjust board grid sizing for narrow viewports

## Testing
- `npm test`
- `npm run lint` *(warnings: react-hooks/exhaustive-deps, @next/next/no-img-element)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f0a419c8327a2e293f438660dff