### PR TITLE
Add QR code scanner tool and navigation links

### DIFF
--- a/WT4Q/package-lock.json
+++ b/WT4Q/package-lock.json
@@ -15,6 +15,7 @@
         "lint": "^0.8.19",
         "lucide-react": "^0.469.0",
         "next": "^15.4.2",
+        "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-dropzone": "^14.2.3",
@@ -2842,7 +2843,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2852,7 +2852,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3536,7 +3535,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3549,7 +3547,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -3938,6 +3935,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6163,7 +6166,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7695,7 +7697,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7767,6 +7768,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7895,6 +7905,135 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -8890,7 +9029,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8904,8 +9042,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -9025,7 +9162,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },

--- a/WT4Q/package.json
+++ b/WT4Q/package.json
@@ -17,6 +17,7 @@
     "lint": "^0.8.19",
     "lucide-react": "^0.469.0",
     "next": "^15.4.2",
+    "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",

--- a/WT4Q/src/app/tools/page.tsx
+++ b/WT4Q/src/app/tools/page.tsx
@@ -5,7 +5,7 @@ import styles from './Tools.module.css';
 export const metadata: Metadata = {
   title: 'Tools',
   description:
-    'Handy utilities including a meme generator and a world clock.',
+    'Handy utilities including a meme generator, a world clock, and a free QR code scanner.',
 };
 
 export default function ToolsPage() {
@@ -27,6 +27,14 @@ export default function ToolsPage() {
             title="MemeMaker – create custom memes"
           >
             Mememaker
+          </PrefetchLink>
+        </li>
+        <li className={styles.item}>
+          <PrefetchLink
+            href="/tools/qr-code-scanner"
+            title="QR Code Scanner – free online tool, no sign up or login required"
+          >
+            QR Code Scanner
           </PrefetchLink>
         </li>
       </ul>

--- a/WT4Q/src/app/tools/qr-code-scanner/page.module.css
+++ b/WT4Q/src/app/tools/qr-code-scanner/page.module.css
@@ -1,0 +1,13 @@
+.main {
+  padding: 1rem;
+}
+
+.heading {
+  text-transform: uppercase;
+  border-bottom: 2px solid #000;
+  margin-bottom: 1rem;
+}
+
+.back {
+  margin-top: 1rem;
+}

--- a/WT4Q/src/app/tools/qr-code-scanner/page.tsx
+++ b/WT4Q/src/app/tools/qr-code-scanner/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import PrefetchLink from '@/components/PrefetchLink';
+import QrMaker from '@/components/QrMaker';
+import styles from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'QR Code Scanner Online - Free Tool, No Sign Up',
+  description: 'QR code scanner online no sign up or login required. Free to use.',
+};
+
+export default function QrCodeScannerPage() {
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.heading}>QR Code Scanner</h1>
+      <QrMaker />
+      <p className={styles.back}>
+        <PrefetchLink href="/tools">Back to Tools</PrefetchLink>
+      </p>
+    </main>
+  );
+}

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -44,6 +44,13 @@ export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
           >
             Mememaker
           </PrefetchLink>
+          <PrefetchLink
+            href="/tools/qr-code-scanner"
+            className={styles.link}
+            onClick={onNavigate}
+          >
+            QR Code Scanner
+          </PrefetchLink>
 
         </div>
       </div>

--- a/WT4Q/src/components/QrMaker.module.css
+++ b/WT4Q/src/components/QrMaker.module.css
@@ -1,0 +1,93 @@
+.wrapper {
+  padding: 1rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.controls,
+.preview {
+  background: #fff;
+  padding: 1rem;
+  border: 4px double #4b5563;
+}
+
+.field {
+  margin-bottom: 0.75rem;
+}
+
+.label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.textarea {
+  width: 100%;
+  padding: 0.5rem;
+}
+
+.range {
+  width: 100%;
+}
+
+.select {
+  width: 100%;
+  padding: 0.25rem;
+}
+
+.colorInput {
+  width: 100%;
+}
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.buttonPrimary {
+  background: #000;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border: none;
+  cursor: pointer;
+}
+
+.buttonSecondary {
+  border: 1px solid #000;
+  padding: 0.5rem 1rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+.previewBox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+}
+
+.tip {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}

--- a/WT4Q/src/components/QrMaker.tsx
+++ b/WT4Q/src/components/QrMaker.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import QRCode from 'qrcode';
+import styles from './QrMaker.module.css';
+
+export default function QrMaker() {
+  const [text, setText] = useState('https://example.com');
+  const [size, setSize] = useState(256);
+  const [margin, setMargin] = useState(2);
+  const [level, setLevel] = useState<'L' | 'M' | 'Q' | 'H'>('M');
+  const [bgColor, setBgColor] = useState('#ffffff');
+  const [fgColor, setFgColor] = useState('#000000');
+  const [renderAs, setRenderAs] = useState<'canvas' | 'svg'>('canvas');
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  const options = useMemo(() => ({
+    errorCorrectionLevel: level,
+    margin,
+    color: {
+      dark: fgColor,
+      light: bgColor,
+    },
+    width: size,
+    scale: undefined as number | undefined,
+  }), [level, margin, fgColor, bgColor, size]);
+
+  useEffect(() => {
+    let isCancelled = false;
+    async function draw() {
+      try {
+        if (renderAs === 'canvas' && canvasRef.current) {
+          await QRCode.toCanvas(canvasRef.current, text || ' ', options);
+        } else if (renderAs === 'svg' && svgRef.current) {
+          const svgStr = await QRCode.toString(text || ' ', { ...options, type: 'svg', width: size });
+          if (!isCancelled && svgRef.current) {
+            svgRef.current.innerHTML = svgStr;
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    draw();
+    return () => {
+      isCancelled = true;
+    };
+  }, [text, options, renderAs, size]);
+
+  const handleDownload = () => {
+    const filenameBase = `qr_${Date.now()}`;
+    if (renderAs === 'canvas' && canvasRef.current) {
+      const url = canvasRef.current.toDataURL('image/png');
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${filenameBase}.png`;
+      a.click();
+    } else if (renderAs === 'svg' && svgRef.current) {
+      const svgContainer = svgRef.current;
+      const innerSvg = svgContainer.querySelector('svg') || svgContainer;
+      const serializer = new XMLSerializer();
+      const source = serializer.serializeToString(innerSvg);
+      const blob = new Blob([source], { type: 'image/svg+xml;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${filenameBase}.svg`;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const handleCopyPng = async () => {
+    if (!canvasRef.current) return;
+    try {
+      canvasRef.current.toBlob(async (blob) => {
+        if (!blob) return;
+        // @ts-expect-error ClipboardItem may not exist in some browsers
+        await navigator.clipboard.write([
+          new window.ClipboardItem({ 'image/png': blob }),
+        ]);
+        alert('Copied PNG to clipboard!');
+      });
+    } catch {
+      alert('Copy failed. Your browser may not support image clipboard yet.');
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <header className={styles.header}>
+        <h1>QR Code Generator</h1>
+        <a href="https://www.npmjs.com/package/qrcode" target="_blank" rel="noreferrer">
+          Powered by <code>qrcode</code>
+        </a>
+      </header>
+      <div className={styles.grid}>
+        <section className={styles.controls}>
+          <div className={styles.field}>
+            <label className={styles.label}>Text / URL</label>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={4}
+              className={styles.textarea}
+              placeholder="Enter text or URL"
+            />
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label}>Size: {size}px</label>
+            <input
+              type="range"
+              min={128}
+              max={1024}
+              value={size}
+              onChange={(e) => setSize(parseInt(e.target.value))}
+              className={styles.range}
+            />
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label}>Margin: {margin}</label>
+            <input
+              type="range"
+              min={0}
+              max={8}
+              value={margin}
+              onChange={(e) => setMargin(parseInt(e.target.value))}
+              className={styles.range}
+            />
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label}>Error Correction</label>
+            <select
+              value={level}
+              onChange={(e) =>
+                setLevel(e.target.value as 'L' | 'M' | 'Q' | 'H')
+              }
+              className={styles.select}
+            >
+              <option value="L">L (7%)</option>
+              <option value="M">M (15%)</option>
+              <option value="Q">Q (25%)</option>
+              <option value="H">H (30%)</option>
+            </select>
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label}>Foreground</label>
+            <input
+              type="color"
+              value={fgColor}
+              onChange={(e) => setFgColor(e.target.value)}
+              className={styles.colorInput}
+            />
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label}>Background</label>
+            <input
+              type="color"
+              value={bgColor}
+              onChange={(e) => setBgColor(e.target.value)}
+              className={styles.colorInput}
+            />
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label}>Render As</label>
+            <div>
+              <label>
+                <input
+                  type="radio"
+                  checked={renderAs === 'canvas'}
+                  onChange={() => setRenderAs('canvas')}
+                />{' '}
+                Canvas (PNG)
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  checked={renderAs === 'svg'}
+                  onChange={() => setRenderAs('svg')}
+                />{' '}
+                SVG
+              </label>
+            </div>
+          </div>
+          <div className={styles.buttonRow}>
+            <button onClick={handleDownload} className={styles.buttonPrimary}>
+              Download {renderAs === 'canvas' ? 'PNG' : 'SVG'}
+            </button>
+            {renderAs === 'canvas' && (
+              <button onClick={handleCopyPng} className={styles.buttonSecondary}>
+                Copy PNG to Clipboard
+              </button>
+            )}
+          </div>
+        </section>
+        <section className={styles.preview}>
+          <h2 className={styles.label}>Preview</h2>
+          <div className={styles.previewBox}>
+            {renderAs === 'canvas' ? (
+              <canvas ref={canvasRef} width={size} height={size} />
+            ) : (
+              <div>
+                <svg ref={svgRef} />
+              </div>
+            )}
+          </div>
+          <p className={styles.tip}>
+            Tip: Higher error correction (Q/H) makes the code more robust but slightly denser.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add QR code scanner tool with generation and download options
- expose scanner in Tools index and header dropdown
- include qrcode dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a662c80be0832795b6201c79f2077f