### PR TITLE
fix: clean tetris styles

### DIFF
--- a/WT4Q/src/app/games/tetris/TetrisGame.tsx
+++ b/WT4Q/src/app/games/tetris/TetrisGame.tsx
@@ -153,8 +153,8 @@ export default function TetrisGame() {
       return `rgba(${r},${g},${b},${a})`;
     }
 
-    function seededRandom(seed?: number) {
-      let x = seed | 0 || 123456789;
+    function seededRandom(seed: number = 123456789) {
+      let x = seed | 0;
       return () => {
         x ^= x << 13;
         x ^= x >>> 17;
@@ -622,19 +622,17 @@ export default function TetrisGame() {
     }
     soundBtn.addEventListener('click', () => {
       ensureAudio();
-      audioCtx?.resume?.();
+      audioCtx?.resume();
       soundBtn.textContent = '🔊 Sound on';
     });
     document.addEventListener('keydown', () => {
-      if (!audioCtx) {
-        ensureAudio();
-        audioCtx?.resume?.();
-        soundBtn.textContent = '🔊 Sound on';
-      }
+      ensureAudio();
+      audioCtx?.resume();
+      soundBtn.textContent = '🔊 Sound on';
     });
     function unlockAudioOnGesture() {
       ensureAudio();
-      audioCtx?.resume?.();
+      audioCtx?.resume();
       soundBtn.textContent = '🔊 Sound on';
       window.removeEventListener('touchstart', unlockAudioOnGesture);
       window.removeEventListener('pointerdown', unlockAudioOnGesture);
@@ -905,7 +903,7 @@ export default function TetrisGame() {
 
     // --- Best score (localStorage) ------------------------------------------
     const bestEl = document.getElementById('best')!;
-    let best = +localStorage.getItem('tetrisBest') || 0;
+    let best = Number(localStorage.getItem('tetrisBest') ?? 0);
     bestEl.textContent = best.toString();
     function updateBest() {
       if (player.score > best) {

--- a/WT4Q/src/app/games/tetris/tetris.module.css
+++ b/WT4Q/src/app/games/tetris/tetris.module.css
@@ -1,10 +1,3 @@
-:global(:root){
-  --bg1:#2b0a86;
-  --bg2:#130242;
-  --panel: rgba(255,255,255,0.08);
-  --panel-border: rgba(255,255,255,0.18);
-}
-
 .container{
   display:grid;
   grid-template-columns:auto 300px;

--- a/WT4Q/src/app/globals.css
+++ b/WT4Q/src/app/globals.css
@@ -26,6 +26,12 @@
   --error-red: #e63946;
   --metal-gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
 
+  /* Tetris game colors */
+  --bg1: #2b0a86;
+  --bg2: #130242;
+  --panel: rgba(255,255,255,0.08);
+  --panel-border: rgba(255,255,255,0.18);
+
   /* Layout scale */
   --content-max: 1200px;
   --radius: 14px;


### PR DESCRIPTION
## Summary
- move Tetris CSS variables into global stylesheet
- tidy Tetris game TypeScript for build compatibility

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Could not find a declaration file for module 'qrcode'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6711656f88327be93dd3c22fc1786