### PR TITLE
feat: accept stale trending news

### DIFF
--- a/Northeast/Services/AiElaboration.cs
+++ b/Northeast/Services/AiElaboration.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Northeast.Services;
+
+internal static class AiElaboration
+{
+    public static Task<AiArticleDraft> ExpandToMinWordsAsync(
+        IGenerativeTextClient ai,
+        AiNewsOptions opts,
+        AiArticleDraft d,
+        IEnumerable<string> recent,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        // Placeholder: return draft unchanged
+        return Task.FromResult(d);
+    }
+}


### PR DESCRIPTION
## Summary
- prioritize last-hour stories but allow contextual stale items in trending prompt
- accept non-politics items up to MaxAgeDays old and uniquify titles in trending polling service
- add placeholder AiElaboration helper

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c477be1c832787106c68633577dc