### PR TITLE
feat: add keywords metadata

### DIFF
--- a/WT4Q/src/app/articles/[id]/page.tsx
+++ b/WT4Q/src/app/articles/[id]/page.tsx
@@ -25,6 +25,7 @@ interface ArticleDetails {
   comments?: Comment[];
   like?: { id: number; type: number }[];
   views?: number;
+  keywords?: string[];
 }
 
 interface RelatedArticle {
@@ -110,6 +111,7 @@ export async function generateMetadata(
   return {
     title: article.title,
     description,
+    keywords: article.keywords,
     alternates: { canonical: url },
     openGraph: {
       title: article.title,


### PR DESCRIPTION
## Summary
- include article keywords in type definitions
- expose article keywords in page metadata for SEO

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c98a4e808327a47e7258c470851e