### PR TITLE
feat: replace AiNewsServices with Google News pipeline

### DIFF
--- a/Northeast/Models/Category.cs
+++ b/Northeast/Models/Category.cs
@@ -9,6 +9,7 @@
         Health,
         Lifestyle,
         Technology,
+        Science,
         Sports,
         Info
     }

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -114,7 +114,6 @@ builder.Services.AddAiNews(o =>
     o.MinWordCount = 150;            // still decent length
     o.PreInsertMinWordCount = 80;    // forgiving first gate
     o.FillMissingHtml = true;
-    o.AcceptStaleAsAnalysis = true;  // turns “too old” into analysis (non-breaking)
     o.UseExternalImages = false;     // keep things simple/stable
 });
 

--- a/Northeast/Services/AiFallbacks.cs
+++ b/Northeast/Services/AiFallbacks.cs
@@ -27,6 +27,6 @@ internal static class AiFallbacks
 <p>We’ll watch for official updates and add confirmed information.</p>
 {kws}
 </div>";
-        return ArticleMapping.EnsureHtmlDiv(html, minWords);
+        return HtmlText.EnsureHtmlDivWithStructure(html, minWords);
     }
 }

--- a/Northeast/Services/AiNewsServices.cs
+++ b/Northeast/Services/AiNewsServices.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using Northeast.Data;
 using Northeast.DTOs;
 using Northeast.Models;
-using Northeast.Utilities;
 using Polly.Timeout;                      // ✅ Polly timeout type
 using System.Collections.Generic;
 using System.Linq;
@@ -19,36 +18,46 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;                    // SemaphoreSlim + Timeout.InfiniteTimeSpan
 using System.Threading.RateLimiting;       // fixed-window limiter
+using System.Xml.Linq;
 
 namespace Northeast.Services;
 
 #region Options
+/// <summary>
+/// Options for Google News RSS powered pipeline. This replaces the purely-AI writers.
+/// - CategoryRotationInterval: fetch a category feed every 10 minutes (default)
+/// - TopStoriesInterval: fetch global "Top stories" every 30 minutes
+/// - LocalTopStoriesInterval: pick a random country from Data/Countries.json and fetch its Top stories every 15 minutes
+/// Other options (MinWordCount, etc.) are reused.
+/// </summary>
 public sealed class AiNewsOptions
 {
-    public string ApiKey { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;                 // Gemini key for paraphrasing/expansion
     public string Model { get; set; } = "gemini-2.5-flash";
 
-    public TimeSpan TrendingInterval { get; set; } = TimeSpan.FromMinutes(15);
-    public TimeSpan RandomInterval { get; set; } = TimeSpan.FromMinutes(15);
-    public TimeSpan TrueCrimeInterval { get; set; } = TimeSpan.FromMinutes(30);
+    // NEW intervals for RSS-based writers
+    public TimeSpan CategoryRotationInterval { get; set; } = TimeSpan.FromMinutes(10);
+    public TimeSpan TopStoriesInterval { get; set; } = TimeSpan.FromMinutes(30);
+    public TimeSpan LocalTopStoriesInterval { get; set; } = TimeSpan.FromMinutes(15);
 
-    public int MaxTrendingPerTick { get; set; } = 3;
+    // Output & behavior
     public double Creativity { get; set; } = 0.9;
     public int MinWordCount { get; set; } = 150;
     public int PreInsertMinWordCount { get; set; } = 80;      // low bar before mapping/padding
     public bool FillMissingHtml { get; set; } = true;          // auto-build HTML if AI omits it
-    public bool AcceptStaleAsAnalysis { get; set; } = true;    // coerce stale items into analysis
-    public int MaxAgeHours { get; set; } = 24;
-    public int MaxAgeDays { get; set; } = 3;
-    public int BreakingWindowHours { get; set; } = 24;
+    public int BreakingWindowHours { get; set; } = 24;         // what counts as breaking
+
+    // Locale defaults for Google News (used when not selecting a specific country)
+    public string DefaultLang { get; set; } = "fr";           // UI language, e.g., fr, en-US
+    public string DefaultCountry { get; set; } = "FR";        // Edition country code, e.g., FR, US
+
+    // Images (kept off by default)
     public bool UseExternalImages { get; set; } = false;
-    public int TrueCrimeMinWordCount { get; set; } = 250;
-    public bool UseExternalNews { get; set; } = false; // back-compat
 }
 #endregion
 
 #region Cross-service single-flight gate
-/// <summary>Ensures only one AI job runs at a time across all hosted services.</summary>
+/// <summary>Ensures only one job runs at a time across all hosted services.</summary>
 public sealed class AiWorkGate
 {
     private static readonly SemaphoreSlim _sem = new(1, 1);
@@ -66,70 +75,7 @@ public sealed class AiWorkGate
 }
 #endregion
 
-#region Image filtering helper
-internal static class AiImageFilter
-{
-    public static List<ArticleImage>? SelectRelevantImages(AiArticleDraft draft)
-    {
-        if (draft.Images is null || draft.Images.Count == 0) return null;
-
-        var subject = draft.Title ?? string.Empty;
-        var splitIndex = subject.IndexOfAny(new[] { ':', '-' });
-        if (splitIndex > 0) subject = subject[..splitIndex];
-
-        var subjectWords = subject
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Select(w => w.Trim().ToLowerInvariant())
-            .Where(w => !StopWords.Contains(w))
-            .ToList();
-
-        var filtered = draft.Images
-            .AsEnumerable()
-            .Reverse()
-            .Where(i => ImageMatches(i, subjectWords))
-            .Take(2)
-            .Select(i => new ArticleImage
-            {
-                PhotoLink = i.PhotoLink,
-                AltText = string.IsNullOrWhiteSpace(i.AltText) ? draft.Title : i.AltText,
-                Caption = string.IsNullOrWhiteSpace(i.Caption) ? draft.Title : i.Caption
-            })
-            .ToList();
-
-        return filtered.Count > 0 ? filtered : null;
-    }
-
-    private static readonly HashSet<string> StopWords = new(StringComparer.OrdinalIgnoreCase)
-    { "the","a","an","of","in","to","for","and" };
-
-    private static readonly string[] AllowedHosts =
-    {
-        "images.unsplash.com", "unsplash.com",
-        "pexels.com", "images.pexels.com",
-        "pixabay.com",
-        "upload.wikimedia.org", "commons.wikimedia.org", "wikimedia.org", "wikipedia.org"
-    };
-
-    private static bool ImageMatches(AiImage img, List<string> subjectWords)
-    {
-        if (img is null) return false;
-
-        var text = ((img.AltText ?? string.Empty) + " " + (img.Caption ?? string.Empty)).ToLowerInvariant();
-        var hits = subjectWords.Count(w => Regex.IsMatch(text, $@"\b{Regex.Escape(w)}\b", RegexOptions.IgnoreCase));
-        if (hits < Math.Min(2, Math.Max(1, subjectWords.Count / 2))) return false;
-
-        if (!IsValidHttpUrl(img.PhotoLink)) return false;
-        var host = new Uri(img.PhotoLink!).Host.Replace("www.", "");
-        return AllowedHosts.Any(h => host.EndsWith(h, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static bool IsValidHttpUrl(string? url)
-        => Uri.TryCreate(url, UriKind.Absolute, out var u) &&
-           (u.Scheme == Uri.UriSchemeHttp || u.Scheme == Uri.UriSchemeHttps);
-}
-#endregion
-
-#region DTOs for AI JSON
+#region DTOs (shared)
 public sealed class AiArticleDraft
 {
     [JsonPropertyName("title")] public string Title { get; set; } = string.Empty;
@@ -141,7 +87,6 @@ public sealed class AiArticleDraft
     [JsonPropertyName("images")] public List<AiImage>? Images { get; set; }
     [JsonPropertyName("eventDateUtc")] public DateTimeOffset? EventDateUtc { get; set; }
     [JsonPropertyName("isBreaking")] public bool? IsBreaking { get; set; }
- 
 }
 
 public sealed class AiImage
@@ -157,7 +102,158 @@ public sealed class AiArticleDraftBatch
 }
 #endregion
 
-#region Gemini REST client (queued limiter + 31s spacing)
+#region Minimal HTML/Text helpers (self-contained)
+internal static class HtmlText
+{
+    public static int CountWords(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return 0;
+        var text = Regex.Replace(html, "<[^>]+>", " ");
+        return Regex.Matches(text, @"\b\w+\b").Count;
+    }
+
+    public static string EnsureHtmlDivWithStructure(string html, int minWords)
+    {
+        var t = html?.Trim() ?? string.Empty;
+        if (!t.StartsWith("<div", StringComparison.OrdinalIgnoreCase))
+            t = $"<div>\n{t}\n</div>";
+
+        // Ensure some h2/h3 structure and paragraphization
+        if (!Regex.IsMatch(t, @"<h2>|<h3>", RegexOptions.IgnoreCase))
+            t = t.Replace("<div>", "<div>\n<h2>Key points</h2>", StringComparison.OrdinalIgnoreCase);
+
+        // Split long text blocks into paragraphs for readability
+        t = Paragraphize(t);
+
+        if (!Regex.IsMatch(t, @"What happens next", RegexOptions.IgnoreCase))
+            t += "\n<h2>What happens next</h2><p>We will keep tracking this story and update as officials or primary sources provide new, verified details.</p>";
+
+        // pad if very short
+        if (CountWords(t) < minWords)
+            t += $"\n<!-- padded to reach ≥{minWords} words -->";
+
+        return t;
+    }
+
+    private static string Paragraphize(string html)
+    {
+        // Add <p> around loose text lines (simple heuristic)
+        var inner = Regex.Replace(html, @"<div>([\s\S]*?)</div>", m =>
+        {
+            var body = m.Groups[1].Value;
+            // Already has <p>? keep. Otherwise wrap plain lines into <p>.
+            if (!body.Contains("<p>"))
+            {
+                var chunks = Regex.Split(body, @"\r\n|\r|\n").Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+                if (chunks.Length > 0)
+                    body = string.Join("\n", chunks.Select(c => c.Trim().StartsWith("<") ? c : $"<p>{WebUtility.HtmlEncode(c.Trim())}</p>"));
+            }
+            return $"<div>\n{body}\n</div>";
+        }, RegexOptions.IgnoreCase);
+        return inner;
+    }
+}
+#endregion
+
+#region Google News RSS utilities
+internal static class GoogleNews
+{
+    // Fixed Google News topic codes
+    public static readonly Dictionary<Category, string> TopicCodes = new()
+    {
+        { Category.Business,       "BUSINESS" },
+        { Category.Technology,     "TECHNOLOGY" },
+        { Category.Entertainment,  "ENTERTAINMENT" },
+        { Category.Science,        "SCIENCE" },
+        { Category.Sports,         "SPORTS" },
+        { Category.Health,         "HEALTH" },
+        { Category.Politics,       "NATION" }, // closest fit for domestic/national politics
+        { Category.Info,           "WORLD" },  // fallback: world
+        { Category.Crime,          "NATION" }, // mapped but overridden by search feed
+        { Category.Lifestyle,      "WORLD" },  // map to world/general
+    };
+
+    public static string BuildTopStoriesUrl(string lang, string country)
+        => $"https://news.google.com/rss?hl={Uri.EscapeDataString(lang)}&gl={Uri.EscapeDataString(country)}&ceid={Uri.EscapeDataString(country)}:{Uri.EscapeDataString(lang)}";
+
+    public static string BuildCategoryUrl(Category category, string lang, string country)
+    {
+        if (category == Category.Crime)
+            return BuildCrimeUrl(lang, country);
+
+        var code = TopicCodes.TryGetValue(category, out var c) ? c : "WORLD";
+        return $"https://news.google.com/rss/headlines/section/topic/{code}?hl={Uri.EscapeDataString(lang)}&gl={Uri.EscapeDataString(country)}&ceid={Uri.EscapeDataString(country)}:{Uri.EscapeDataString(lang)}";
+    }
+
+    public static string BuildCrimeUrl(string lang, string country)
+        => $"https://news.google.com/rss/search?q={Uri.EscapeDataString("crime OR police OR arrest OR investigation")}&hl={Uri.EscapeDataString(lang)}&gl={Uri.EscapeDataString(country)}&ceid={Uri.EscapeDataString(country)}:{Uri.EscapeDataString(lang)}";
+
+    /// <summary>Basic RSS parser that supports Google News Atom/RSS variants.</summary>
+    public static async Task<List<RssItem>> FetchAsync(HttpClient http, string url, CancellationToken ct)
+    {
+        using var res = await http.GetAsync(url, ct);
+        res.EnsureSuccessStatusCode();
+        await using var s = await res.Content.ReadAsStreamAsync(ct);
+        var doc = await XDocument.LoadAsync(s, LoadOptions.None, ct);
+
+        // Try Atom <entry>
+        XNamespace atom = "http://www.w3.org/2005/Atom";
+        var entries = doc.Root?.Descendants(atom + "entry").ToList();
+        if (entries != null && entries.Count > 0)
+        {
+            return entries.Select(e => new RssItem
+            {
+                Title = e.Element(atom + "title")?.Value?.Trim() ?? string.Empty,
+                Link = e.Element(atom + "link")?.Attribute("href")?.Value ??
+                       e.Descendants(atom + "link").FirstOrDefault()?.Attribute("href")?.Value ?? string.Empty,
+                Published = ParseDate(e.Element(atom + "updated")?.Value) ?? ParseDate(e.Element(atom + "published")?.Value),
+                Summary = (e.Element(atom + "summary")?.Value ?? string.Empty).Trim(),
+                Content = (e.Element(atom + "content")?.Value ?? string.Empty).Trim(),
+                Source = e.Element(atom + "source")?.Value?.Trim()
+            })
+            .Where(i => !string.IsNullOrWhiteSpace(i.Title) && !string.IsNullOrWhiteSpace(i.Link))
+            .ToList();
+        }
+
+        // Try RSS 2.0 <item>
+        var channel = doc.Root?.Element("channel");
+        if (channel != null)
+        {
+            return channel.Elements("item").Select(it => new RssItem
+            {
+                Title = it.Element("title")?.Value?.Trim() ?? string.Empty,
+                Link = it.Element("link")?.Value?.Trim() ?? string.Empty,
+                Published = ParseDate(it.Element("pubDate")?.Value),
+                Summary = (it.Element("description")?.Value ?? string.Empty).Trim(),
+                Content = (it.Element("content")?.Value ?? string.Empty).Trim(),
+                Source = it.Element("source")?.Value?.Trim()
+            })
+            .Where(i => !string.IsNullOrWhiteSpace(i.Title) && !string.IsNullOrWhiteSpace(i.Link))
+            .ToList();
+        }
+
+        return new List<RssItem>();
+    }
+
+    private static DateTimeOffset? ParseDate(string? s)
+    {
+        if (DateTimeOffset.TryParse(s, out var dt)) return dt;
+        return null;
+    }
+}
+
+internal sealed class RssItem
+{
+    public string Title { get; set; } = string.Empty;
+    public string Link { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty; // may be empty
+    public string? Source { get; set; }
+    public DateTimeOffset? Published { get; set; }
+}
+#endregion
+
+#region Gemini REST client (for paraphrasing/expansion)
 public interface IGenerativeTextClient
 {
     Task<string> GenerateJsonAsync(string model, string systemInstruction, string userPrompt, double temperature, CancellationToken ct);
@@ -179,15 +275,13 @@ public sealed class GeminiRestClient : IGenerativeTextClient
             AutoReplenishment = true
         });
 
-    // Extra safety: ensure >= 31s between sends across process
+    // Extra safety: ensure ≥ 31s between sends across process
     private static readonly SemaphoreSlim _slotLock = new(1, 1);
     private static DateTimeOffset _nextSlotUtc = DateTimeOffset.MinValue;
     private static readonly TimeSpan _minSpacing = TimeSpan.FromSeconds(31);
 
     public GeminiRestClient(HttpClient http, IOptions<AiNewsOptions> opts, ILogger<GeminiRestClient> log)
-    {
-        _http = http; _log = log; _opts = opts.Value;
-    }
+    { _http = http; _log = log; _opts = opts.Value; }
 
     public async Task<string> GenerateJsonAsync(string model, string systemInstruction, string userPrompt, double temperature, CancellationToken ct)
     {
@@ -196,24 +290,17 @@ public sealed class GeminiRestClient : IGenerativeTextClient
         var text = ok1 ? Extract(body1!) : null;
         if (!string.IsNullOrWhiteSpace(text) && text != "{}") return text!;
 
-        // Strategy 2: Plain text, but force JSON in prompt
-        var forced = userPrompt + "\n\nReturn ONLY valid JSON for the described schema in the 'items' array. No prose outside JSON.";
+        // Strategy 2: plain text forcing JSON
+        var forced = userPrompt + "\n\nReturn ONLY valid JSON per schema in 'items'. No prose outside JSON.";
         var (ok2, body2) = await CallAsync(model, systemInstruction, forced, temperature, jsonMode: false, ct);
         text = ok2 ? Extract(body2!) : null;
         if (!string.IsNullOrWhiteSpace(text) && text != "{}") return text!;
 
-        // Strategy 3: flash JSON mode
-        var (ok3, body3) = await CallAsync("gemini-2.5-flash", systemInstruction, userPrompt, temperature, jsonMode: true, ct);
-        text = ok3 ? Extract(body3!) : null;
-        if (!string.IsNullOrWhiteSpace(text) && text != "{}") return text!;
-
-        _log.LogWarning("Gemini returned no usable JSON after all strategies.");
+        _log.LogWarning("Gemini returned no usable JSON after retries.");
         return "{}";
     }
 
-    private async Task<(bool ok, string? body)> CallAsync(
-        string model, string sys, string prompt, double temperature,
-        bool jsonMode, CancellationToken ct)
+    private async Task<(bool ok, string? body)> CallAsync(string model, string sys, string prompt, double temperature, bool jsonMode, CancellationToken ct)
     {
         var gen = new Dictionary<string, object?>
         {
@@ -241,14 +328,10 @@ public sealed class GeminiRestClient : IGenerativeTextClient
             if (_nextSlotUtc > now)
             {
                 var wait = _nextSlotUtc - now;
-                _log.LogInformation("Gemini: waiting {ms} ms to respect spacing", (int)wait.TotalMilliseconds);
                 await Task.Delay(wait, ct);
             }
         }
-        finally
-        {
-            _slotLock.Release();
-        }
+        finally { _slotLock.Release(); }
 
         var attempt = 0;
         var maxAttempts = 3;
@@ -257,15 +340,11 @@ public sealed class GeminiRestClient : IGenerativeTextClient
         while (true)
         {
             attempt++;
-
             using var lease = await _limiter.AcquireAsync(1, ct);
-            if (!lease.IsAcquired)
-                throw new Exception("Local Gemini rate limit exceeded (queue full)");
+            if (!lease.IsAcquired) throw new Exception("Local Gemini rate limit exceeded (queue full)");
 
             using var req = new HttpRequestMessage(HttpMethod.Post, uri)
-            {
-                Content = new StringContent(json, Encoding.UTF8, "application/json")
-            };
+            { Content = new StringContent(json, Encoding.UTF8, "application/json") };
             req.Headers.TryAddWithoutValidation("x-goog-api-key", _opts.ApiKey);
 
             var start = DateTimeOffset.UtcNow;
@@ -275,12 +354,9 @@ public sealed class GeminiRestClient : IGenerativeTextClient
 
             if (res.IsSuccessStatusCode)
             {
-                _log.LogInformation("Gemini {Model} 200 OK in {Ms} ms", model, (int)took.TotalMilliseconds);
-
                 await _slotLock.WaitAsync(ct);
                 try { _nextSlotUtc = DateTimeOffset.UtcNow + _minSpacing; }
                 finally { _slotLock.Release(); }
-
                 return (true, body);
             }
 
@@ -289,58 +365,27 @@ public sealed class GeminiRestClient : IGenerativeTextClient
             {
                 var delay = res.Headers.RetryAfter?.Delta ??
                             TimeSpan.FromMilliseconds(300 * Math.Pow(2, attempt) + rnd.Next(0, 200));
-                _log.LogWarning("Gemini HTTP {Status}. Retrying in {Delay}ms (attempt {Attempt}/{Max}). Body: {Body}",
-                    code, (int)delay.TotalMilliseconds, attempt, maxAttempts, Trunc(body, 600));
                 await Task.Delay(delay, ct);
                 continue;
             }
-
-            _log.LogWarning("Gemini HTTP {Status}. Body: {Body}", code, Trunc(body, 800));
             return (false, body);
         }
-
-        static string Trunc(string s, int max) => s.Length <= max ? s : s[..max] + "…";
     }
 
     private static string? Extract(string body)
     {
         using var doc = JsonDocument.Parse(body);
         var root = doc.RootElement;
-
-        if (!root.TryGetProperty("candidates", out var cands) ||
-            cands.ValueKind != JsonValueKind.Array || cands.GetArrayLength() == 0)
+        if (!root.TryGetProperty("candidates", out var cands) || cands.ValueKind != JsonValueKind.Array || cands.GetArrayLength() == 0)
             return null;
-
-        var c0 = cands[0];
-        if (!c0.TryGetProperty("content", out var content)) return null;
-        if (!content.TryGetProperty("parts", out var parts) ||
-            parts.ValueKind != JsonValueKind.Array || parts.GetArrayLength() == 0)
-            return null;
-
+        var content = cands[0].GetProperty("content");
+        var parts = content.GetProperty("parts");
         foreach (var p in parts.EnumerateArray())
         {
-            if (p.TryGetProperty("text", out var textNode))
+            if (p.TryGetProperty("text", out var t))
             {
-                var text = textNode.GetString();
-                if (!string.IsNullOrWhiteSpace(text)) return text!;
-            }
-
-            if (p.TryGetProperty("inlineData", out var inlineData) &&
-                inlineData.TryGetProperty("mimeType", out var mime) &&
-                string.Equals(mime.GetString(), "application/json", StringComparison.OrdinalIgnoreCase) &&
-                inlineData.TryGetProperty("data", out var dataNode))
-            {
-                try
-                {
-                    var b64 = dataNode.GetString();
-                    if (!string.IsNullOrEmpty(b64))
-                    {
-                        var bytes = Convert.FromBase64String(b64);
-                        var json = Encoding.UTF8.GetString(bytes);
-                        if (!string.IsNullOrWhiteSpace(json)) return json;
-                    }
-                }
-                catch { }
+                var s = t.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) return s;
             }
         }
         return null;
@@ -348,58 +393,50 @@ public sealed class GeminiRestClient : IGenerativeTextClient
 }
 #endregion
 
-#region Prompt builder
-public static class AiNewsPrompt
+#region Prompt builder for PARAPHRASING only (no invention)
+internal static class ParaphrasePrompt
 {
-    public static string BuildSystem(AiNewsOptions o, IEnumerable<string> recentTitles) => $@"
-You are a senior human news editor. Write like a calm, clear journalist with simple words.
+    public static string BuildSystem(AiNewsOptions o) => $@"
+You are a senior news editor. Paraphrase and expand using simple, neutral language.
 Hard rules:
 - Output STRICT JSON only (UTF-8). No prose outside JSON.
-- Each item: ≥ {o.MinWordCount} words, one <div> root, use <h2>/<h3> sub-headings, END with sub heading 'What happens next'.
-- Sound human (no AI clichés). Paraphrase; do not copy lines verbatim.
-- If global, set ""countryName"": null and ""countryCode"": null.
-- Provide 5–12 lowercase, unique keywords.
-- DO NOT repeat topics already covered recently.
-- Recency: eventDateUtc MUST be within the last {o.MaxAgeHours} hours (≤ 30 hours).
+- Each item: ≥ {o.MinWordCount} words. ONE <div> root. Use <h2>/<h3> sub-headings. Multiple short <p> paragraphs for readability. END with sub heading 'What happens next'.
+- No fabricated quotes or numbers. Use only the feed info provided plus widely-known, non-controversial background.
+- Country fields: null if global. If the country is provided, set both name and 2-letter code.
+- Provide 5–12 lowercase keywords.
+- eventDateUtc = feed publish date (or now if missing). isBreaking = true if within last {o.BreakingWindowHours} hours.
+";
 
-Recent titles to avoid: {string.Join("; ", recentTitles.Take(50))}";
-
-    public static string BuildTrendingUser(AiNewsOptions o, int count) => $@"
-Return JSON:
+    public static string BuildUser(string title, string? summary, string? content, string category, string? countryName, string? countryCode)
+    {
+        // The model must return AiArticleDraftBatch JSON with one item.
+        return $@"
+Return JSON shape:
 {{
   ""items"": [
     {{
-      ""title"": ""specific, unique headline"",
-      ""category"": ""Politics|Crime|Entertainment|Business|Health|Lifestyle|Technology|Sports|Info"",
-      ""articleHtml"": ""<div>...subheads...summary...</div>"",
-      ""countryName"": null | ""France"" | ""United States"" | ...,
-      ""countryCode"": null | ""FR"" | ""US"" | ...,
-      ""keywords"": [""kw1"",""kw2"",...],
+      ""title"": ""unique, specific headline"",
+      ""category"": ""{category}"",
+      ""articleHtml"": ""<div>..."",
+      ""countryName"": {(countryName != null ? $"""{Escape(countryName)}""" : "null")},
+      ""countryCode"": {(countryCode != null ? $"""{Escape(countryCode)}""" : "null")},
+      ""keywords"": [""news""],
       ""images"": [],
-      ""eventDateUtc"": ""YYYY-MM-DDTHH:mm:ssZ"",
-      ""isBreaking"": true|false
+      ""eventDateUtc"": ""<will be set by caller>"",
+      ""isBreaking"": false
     }}
   ]
 }}
-Constraints:
-- PRIORITIZE stories from the LAST 60 MINUTES.
-- If not enough last-hour stories exist, you MAY include items (up to {o.MaxAgeDays} days old) for NON-POLITICS categories, but label them as context/non-breaking.
-- DO NOT include items older than 60 minutes for the Politics category.
-- Return up to {count} items (include fewer if necessary).
-- Add depth to article
-- If necessary add stats or available datas in the article. 
-- If details are thin, write a 'what we know so far' with verified context to reach ≥ {o.MinWordCount} words.";
 
-    public static string BuildRandomUser(AiNewsOptions o, Category category) => $@"
-Write ONE fresh analysis piece in category '{category}' that follows the same structural rules. Return the same JSON shape with a single item in 'items'. Title must be unique vs the recent list.";
+Source snippet to paraphrase and deepen (do NOT copy lines verbatim):
+TITLE: {Escape(title)}
+SUMMARY: {Escape(summary ?? string.Empty)}
+CONTENT: {Escape(content ?? string.Empty)}
+";
+    }
 
-    public static string BuildTrueCrimeUser(AiNewsOptions o) => $@"
-Write ONE non-graphic TRUE CRIME article in the 'Crime' category.
-Requirements:
-- Focus on a real murder/crime cases , recent or historic;.
-- ≥ {Math.Max(o.MinWordCount, o.TrueCrimeMinWordCount)} words, make it thriller and without palgiarism and properly worded, in depth stories.
-- Structure: one <div> with clear <h2> sections, and end with 'What happened next' if there is proper else give concludion or warning for people to take care against similar incident .
-- Output the same JSON 'items' shape as other prompts with some crrections for trum crime part no what happen next but 'what happened next 'like public reactions, outcomes,etc";
+    private static string Escape(string s)
+        => s.Replace("\\", "\\\\").Replace("\"", "\\\"");
 }
 #endregion
 
@@ -412,40 +449,23 @@ internal static class ArticleMapping
         return s.Trim().ToLowerInvariant() switch
         {
             "politics" => Category.Politics,
-            "crime" => Category.Crime,
+            "crime" => Category.Crime,              // not used here, but kept
             "entertainment" => Category.Entertainment,
             "business" => Category.Business,
             "health" => Category.Health,
             "lifestyle" => Category.Lifestyle,
             "technology" => Category.Technology,
+            "science" => Category.Science,
             "sports" => Category.Sports,
             "info" => Category.Info,
             _ => Category.Info
         };
     }
 
-    public static string EnsureHtmlDiv(string html, int minWords)
-    {
-        var t = html?.Trim() ?? string.Empty;
-        if (!t.StartsWith("<div", StringComparison.OrdinalIgnoreCase))
-            t = $"<div>\n{t}\n</div>";
-
-        var words = Regex.Split(Regex.Replace(t, "<.*?>", " "), @"\s+")
-                         .Where(w => !string.IsNullOrWhiteSpace(w)).ToArray();
-        if (words.Length < minWords)
-            t += $"\n<!-- padded to meet minimum word count {minWords} -->";
-        if (!Regex.IsMatch(t, @"<h2>|<h3>", RegexOptions.IgnoreCase))
-            t = t.Replace("<div>", "<div>\n<h2>Update</h2>\n", StringComparison.OrdinalIgnoreCase);
-        if (!Regex.IsMatch(t, @"What happens next", RegexOptions.IgnoreCase))
-            t += "\n<h2>What happens next</h2><p>We will monitor developments and update when officials share more verified details.</p>";
-        return t;
-    }
-
     public static Article MapToArticle(
         AiArticleDraft d,
         ArticleType type,
         Guid authorId,
-        IEnumerable<ArticleImage>? pickedImages,
         AiNewsOptions opts,
         DateTimeOffset nowUtc)
     {
@@ -463,19 +483,10 @@ internal static class ArticleMapping
 
         string? countryName = d.CountryName;
         string? countryCode = d.CountryCode;
-        if (string.IsNullOrWhiteSpace(countryName) ||
-            countryName.Equals("global", StringComparison.OrdinalIgnoreCase))
-        {
-            countryName = null;
-            countryCode = null;
-        }
+        if (string.IsNullOrWhiteSpace(countryName) || countryName.Equals("global", StringComparison.OrdinalIgnoreCase))
+        { countryName = null; countryCode = null; }
 
-        var imagesList = pickedImages?.Where(i => !string.IsNullOrWhiteSpace(i.PhotoLink)).ToList();
-        if (imagesList is { Count: 0 }) imagesList = null;
-
-        var minWords = type == ArticleType.Article && opts.TrueCrimeMinWordCount > opts.MinWordCount
-            ? opts.TrueCrimeMinWordCount
-            : opts.MinWordCount;
+        var html = HtmlText.EnsureHtmlDivWithStructure(d.ArticleHtml ?? string.Empty, opts.MinWordCount);
 
         return new Article
         {
@@ -484,210 +495,124 @@ internal static class ArticleMapping
             Category = ParseCategoryStrict(d.Category),
             Title = (d.Title ?? string.Empty).Trim(),
             CreatedDate = DateTime.UtcNow,
-            Content = EnsureHtmlDiv(d.ArticleHtml, minWords),
+            Content = html,
             IsBreakingNews = isBreaking,
             CountryName = countryName,
             CountryCode = countryCode,
             Keywords = keywords,
-            Images = imagesList
+            Images = null // images intentionally omitted
         };
     }
 
     public static ArticleDto MapToDto(Article article)
-    {
-        return new ArticleDto
+        => new()
         {
             Title = article.Title,
             Category = article.Category,
             ArticleType = article.ArticleType,
             Content = article.Content,
             IsBreakingNews = article.IsBreakingNews,
-            Images = article.Images?.Select(i => new ArticleImageDto
-            {
-                Photo = i.Photo,
-                PhotoLink = i.PhotoLink,
-                AltText = i.AltText,
-                Caption = i.Caption
-            }).ToList(),
+            Images = null,
             CountryName = article.CountryName,
             CountryCode = article.CountryCode,
             Keyword = article.Keywords
         };
+}
+#endregion
+
+#region Countries.json loader
+internal sealed class CountryEntry
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;  // e.g., "France"
+    [JsonPropertyName("code")] public string Code { get; set; } = string.Empty;  // e.g., "FR"
+    [JsonPropertyName("lang")] public string? Lang { get; set; }                // e.g., "fr" (optional)
+}
+
+internal static class CountriesFile
+{
+    public static List<CountryEntry> Load(IServiceProvider sp, ILogger log)
+    {
+        try
+        {
+            var env = sp.GetService<IHostEnvironment>();
+            var baseDir = env?.ContentRootPath ?? AppContext.BaseDirectory;
+            var path = System.IO.Path.Combine(baseDir, "Data", "Countries.json");
+            if (!System.IO.File.Exists(path))
+            {
+                log.LogWarning("Countries.json not found at {Path}. Local country top stories will be skipped.", path);
+                return new();
+            }
+            var json = System.IO.File.ReadAllText(path, Encoding.UTF8);
+            var list = JsonSerializer.Deserialize<List<CountryEntry>>(json) ?? new();
+            return list.Where(c => !string.IsNullOrWhiteSpace(c.Code)).ToList();
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Failed to load Countries.json. Local country top stories will be skipped.");
+            return new();
+        }
     }
 }
 #endregion
 
-#region Service: AI Trending News
-public sealed class AiTrendingNewsPollingService : BackgroundService
+#region Core ingest & publish logic (shared by services)
+internal static class RssIngest
 {
-    private readonly ILogger<AiTrendingNewsPollingService> _log;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly AiNewsOptions _opts;
-    private readonly IGenerativeTextClient _ai;
-
-    public AiTrendingNewsPollingService(
-        ILogger<AiTrendingNewsPollingService> log,
-        IServiceScopeFactory scopeFactory,
-        IOptions<AiNewsOptions> opts,
-        IGenerativeTextClient ai)
+    public static async Task<Article?> ProcessOneAsync(
+        IServiceProvider scopeSp,
+        AiNewsOptions opts,
+        IGenerativeTextClient ai,
+        RssItem item,
+        Category category,
+        string? countryName,
+        string? countryCode,
+        CancellationToken ct)
     {
-        _log = log; _scopeFactory = scopeFactory; _opts = opts.Value; _ai = ai;
-    }
-
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        await Task.Delay(TimeSpan.Zero, stoppingToken); // 0s for Trending
-
-        _log.LogInformation("AiTrendingNewsPollingService started (interval {Interval}).", _opts.TrendingInterval);
-        var timer = new PeriodicTimer(_opts.TrendingInterval);
-        try
-        {
-            while (await timer.WaitForNextTickAsync(stoppingToken))
-            {
-                try { await TickAsync(stoppingToken); }
-                catch (OperationCanceledException) { }
-                catch (Exception ex) { _log.LogError(ex, "AI trending tick failed."); }
-            }
-        }
-        catch (OperationCanceledException) { }
-        finally
-        {
-            timer.Dispose();
-            _log.LogInformation("AiTrendingNewsPollingService stopping.");
-        }
-    }
-
-    private async Task TickAsync(CancellationToken ct)
-    {
-        using var gate = await AiWorkGate.EnterAsync();
-
-        using var scope = _scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-
-        var recent = await db.Set<Article>()
-            .OrderByDescending(a => a.CreatedDate)
-            .Select(a => a.Title)
-            .Take(300)
-            .ToListAsync(ct);
-
-        var system = AiNewsPrompt.BuildSystem(_opts, recent);
-        var user = AiNewsPrompt.BuildTrendingUser(_opts, Math.Max(1, _opts.MaxTrendingPerTick));
-
-        var json = await _ai.GenerateJsonAsync(_opts.Model, system, user, _opts.Creativity, ct);
-        var batch = DeserializeSafe(json);
-        if (batch.Items.Count == 0) { _log.LogInformation("AI returned no items this tick."); return; }
-
-        var admin = await db.Users
-            .FirstOrDefaultAsync(u => u.Role == Role.SuperAdmin || u.Role == Role.Admin, ct);
-        if (admin is null) { _log.LogWarning("No Admin or SuperAdmin found."); return; }
-        var adminId = admin.Id;
-
+        var db = scopeSp.GetRequiredService<AppDbContext>();
         var now = DateTimeOffset.UtcNow;
-        var lastHour = TimeSpan.FromHours(1);
-        var maxAge = TimeSpan.FromDays(_opts.MaxAgeDays);
 
-        var toAdd = new List<Article>();
-        foreach (var d0 in batch.Items)
+        // Basic duplicate guard by title
+        var exists = await db.Set<Article>().AnyAsync(a => a.Title.ToLower() == item.Title.Trim().ToLower(), ct);
+        if (exists) return null;
+
+        var system = ParaphrasePrompt.BuildSystem(opts);
+        var user = ParaphrasePrompt.BuildUser(
+            title: item.Title,
+            summary: item.Summary,
+            content: string.IsNullOrWhiteSpace(item.Content) ? item.Summary : item.Content,
+            category: category.ToString(),
+            countryName: countryName,
+            countryCode: countryCode);
+
+        var json = await ai.GenerateJsonAsync(opts.Model, system, user, opts.Creativity, ct);
+        var batch = DeserializeSafe(json);
+        if (batch.Items.Count == 0) return null;
+        var d = batch.Items[0];
+
+        // Ensure critical fields
+        d.Category = category.ToString();
+        d.EventDateUtc ??= item.Published ?? now;
+        d.IsBreaking ??= (now - (d.EventDateUtc ?? now)) <= TimeSpan.FromHours(opts.BreakingWindowHours);
+        d.CountryName = countryName;
+        d.CountryCode = countryCode;
+
+        if (string.IsNullOrWhiteSpace(d.ArticleHtml) && opts.FillMissingHtml)
         {
-            var d = d0;
-
-            if (string.IsNullOrWhiteSpace(d.Title))
-            { Info("missing title", d); continue; }
-
-            if (d.EventDateUtc is null) d.EventDateUtc = now;
-
-            var age = now - d.EventDateUtc.Value;
-            var cat = ArticleMapping.ParseCategoryStrict(d.Category);
-            var acceptingStale = false;
-
-            // Fresh vs stale logic
-            if (age > lastHour)
-            {
-                if (cat == Category.Politics)
-                {
-                    Info($"politics item older than last hour ({(int)age.TotalMinutes} min)", d);
-                    continue;
-                }
-
-                // Accept stale (non-Politics) as analysis, within MaxAgeDays
-                if (age <= maxAge)
-                {
-                    acceptingStale = true;
-                    d.IsBreaking = false;
-                    // Normalize to 'now' so it doesn't look outdated in feeds
-                    d.EventDateUtc = now;
-                }
-                else
-                {
-                    Info("too old (beyond MaxAgeDays)", d);
-                    continue;
-                }
-            }
-
-            // Ensure HTML exists
-            if (string.IsNullOrWhiteSpace(d.ArticleHtml) && _opts.FillMissingHtml)
-                d.ArticleHtml = AiFallbacks.MakeArticleHtml(d, _opts.MinWordCount, now, editorsNote: acceptingStale);
-
-            // Try to expand to >= MinWordCount if short
-            if (HtmlText.CountWords(d.ArticleHtml) < _opts.MinWordCount)
-            {
-                var expanded = await AiElaboration.ExpandToMinWordsAsync(_ai, _opts, d, recent, now, ct);
-                if (HtmlText.CountWords(expanded.ArticleHtml) >= _opts.MinWordCount)
-                    d = expanded;
-            }
-
-            // Hard fallback: enforce minimum length
-            if (HtmlText.CountWords(d.ArticleHtml) < _opts.MinWordCount)
-            {
-                d.ArticleHtml = AiFallbacks.MakeArticleHtml(d, _opts.MinWordCount, now, editorsNote: acceptingStale);
-            }
-
-            List<ArticleImage>? images = null; // images intentionally omitted
-            var articleType = acceptingStale ? ArticleType.Article : ArticleType.News;
-
-            var article = ArticleMapping.MapToArticle(d, articleType, adminId, images, _opts, now);
-
-            // Duplicate handling: uniquify instead of drop
-            var exists = await db.Set<Article>()
-                .AnyAsync(a => a.Title.ToLower() == article.Title.ToLower(), ct);
-            if (exists)
-            {
-                var fallbackTitle = $"{article.Title} — update {now:HH:mm}";
-                var exists2 = await db.Set<Article>()
-                    .AnyAsync(a => a.Title.ToLower() == fallbackTitle.ToLower(), ct);
-
-                if (!exists2)
-                {
-                    article.Title = fallbackTitle;
-                }
-                else
-                {
-                    Info("DB duplicate title (even with update suffix)", d);
-                    continue;
-                }
-            }
-
-            toAdd.Add(article);
+            var safe = WebUtility.HtmlEncode(item.Summary ?? d.Title);
+            d.ArticleHtml = $"<div><h2>Summary</h2><p>{safe}</p></div>";
         }
 
-        if (toAdd.Count == 0) { _log.LogInformation("No new AI last-hour or accepted-stale news to insert."); return; }
-
-        var articleService = scope.ServiceProvider.GetRequiredService<ArticleServices>();
-        try
-        {
-            foreach (var article in toAdd)
-                await articleService.Publish(ArticleMapping.MapToDto(article), adminId);
-
-            _log.LogInformation("Inserted {Count} AI trending item(s) (fresh + accepted stale).", toAdd.Count);
-        }
-        catch (DbUpdateException ex)
-        {
-            _log.LogError(ex, "Failed to insert AI trending item(s); no articles were saved.");
-        }
+        var article = ArticleMapping.MapToArticle(d, ArticleType.News,
+            authorId: await ResolveAdminIdAsync(db, ct), opts, now);
+        return article;
     }
 
-    private void Info(string reason, AiArticleDraft d) =>
-        _log.LogInformation("drop: {Reason} | title='{Title}'", reason, d.Title);
+    private static async Task<Guid> ResolveAdminIdAsync(AppDbContext db, CancellationToken ct)
+    {
+        var admin = await db.Users.FirstOrDefaultAsync(u => u.Role == Role.SuperAdmin || u.Role == Role.Admin, ct);
+        if (admin is null) throw new InvalidOperationException("No Admin or SuperAdmin found.");
+        return admin.Id;
+    }
 
     internal static AiArticleDraftBatch DeserializeSafe(string json)
     {
@@ -718,259 +643,240 @@ public sealed class AiTrendingNewsPollingService : BackgroundService
 }
 #endregion
 
-#region Service: Random AI article
-public sealed class AiRandomArticleWriterService : BackgroundService
+#region Service: Category rotation (every 10 minutes)
+public sealed class GoogleNewsCategoryRotationService : BackgroundService
 {
-    private readonly ILogger<AiRandomArticleWriterService> _log;
+    private readonly ILogger<GoogleNewsCategoryRotationService> _log;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly AiNewsOptions _opts;
     private readonly IGenerativeTextClient _ai;
-    private readonly Random _rng = new();
+    private readonly HttpClient _http;
+    private int _categoryIndex = 0;
 
-    public AiRandomArticleWriterService(
-        ILogger<AiRandomArticleWriterService> log,
+    private static readonly Category[] Order = new[]
+    {
+        Category.Technology, Category.Business, Category.Sports,
+        Category.Health, Category.Entertainment, Category.Science,
+        Category.Crime, Category.Politics, Category.Info
+    };
+
+    public GoogleNewsCategoryRotationService(
+        ILogger<GoogleNewsCategoryRotationService> log,
         IServiceScopeFactory scopeFactory,
         IOptions<AiNewsOptions> opts,
-        IGenerativeTextClient ai)
+        IGenerativeTextClient ai,
+        IHttpClientFactory httpFactory)
     {
         _log = log; _scopeFactory = scopeFactory; _opts = opts.Value; _ai = ai;
+        _http = httpFactory.CreateClient("gn");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await Task.Delay(TimeSpan.FromSeconds(20), stoppingToken); // stagger
-
-        _log.LogInformation("AiRandomArticleWriterService started (interval {Interval}).", _opts.RandomInterval);
-        var timer = new PeriodicTimer(_opts.RandomInterval);
+        _log.LogInformation("GoogleNewsCategoryRotationService started (interval {Interval}).", _opts.CategoryRotationInterval);
+        var timer = new PeriodicTimer(_opts.CategoryRotationInterval);
         try
         {
             while (await timer.WaitForNextTickAsync(stoppingToken))
             {
                 try { await TickAsync(stoppingToken); }
                 catch (OperationCanceledException) { }
-                catch (Exception ex) { _log.LogError(ex, "AI random writer tick failed."); }
+                catch (Exception ex) { _log.LogError(ex, "Category rotation tick failed."); }
             }
         }
         catch (OperationCanceledException) { }
-        finally
-        {
-            timer.Dispose();
-            _log.LogInformation("AiRandomArticleWriterService stopping.");
-        }
+        finally { timer.Dispose(); _log.LogInformation("Category rotation stopping."); }
     }
 
     private async Task TickAsync(CancellationToken ct)
     {
         using var gate = await AiWorkGate.EnterAsync();
-
         using var scope = _scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var sp = scope.ServiceProvider;
 
-        var cats = Enum.GetValues(typeof(Category)).Cast<Category>().ToArray();
-        var category = cats[_rng.Next(cats.Length)];
+        var cat = Order[_categoryIndex % Order.Length];
+        _categoryIndex++;
 
-        var recent = await db.Set<Article>()
-            .OrderByDescending(a => a.CreatedDate)
-            .Select(a => a.Title)
-            .Take(300)
-            .ToListAsync(ct);
+        var url = GoogleNews.BuildCategoryUrl(cat, _opts.DefaultLang, _opts.DefaultCountry);
+        var items = await GoogleNews.FetchAsync(_http, url, ct);
+        if (items.Count == 0) { _log.LogInformation("No RSS items for {Category}", cat); return; }
 
-        var system = AiNewsPrompt.BuildSystem(_opts, recent);
-        var user = AiNewsPrompt.BuildRandomUser(_opts, category);
+        // Prefer the first few (more likely trending), but pick one at random among top 10
+        var rnd = new Random();
+        var pick = items.Take(10).OrderBy(_ => rnd.Next()).First();
 
-        var json = await _ai.GenerateJsonAsync(_opts.Model, system, user, _opts.Creativity, ct);
-        var batch = AiTrendingNewsPollingService.DeserializeSafe(json);
-        if (batch.Items.Count == 0) { _log.LogInformation("AI returned no items this tick."); return; }
-
-        var admin = await db.Users
-            .FirstOrDefaultAsync(u => u.Role == Role.SuperAdmin || u.Role == Role.Admin, ct);
-        if (admin is null) { _log.LogWarning("No Admin or SuperAdmin found."); return; }
-        var adminId = admin.Id;
-
-        var now = DateTimeOffset.UtcNow;
-        var maxAge = TimeSpan.FromHours(_opts.MaxAgeHours);
-
-        var toAdd = new List<Article>();
-        foreach (var d in batch.Items)
+        try
         {
-            if (string.IsNullOrWhiteSpace(d.Title))
-                { Info("missing title", d); continue; }
-            if (string.IsNullOrWhiteSpace(d.ArticleHtml) && _opts.FillMissingHtml)
-                d.ArticleHtml = AiFallbacks.MakeArticleHtml(d, _opts.MinWordCount, now);
-            if (d.EventDateUtc is null) d.EventDateUtc = now;
-            if (now - d.EventDateUtc.Value > maxAge)
-                { Info("too old", d); continue; }
-            if (HtmlText.CountWords(d.ArticleHtml) < _opts.PreInsertMinWordCount)
-                { Info($"too short (<{_opts.PreInsertMinWordCount} words)", d); continue; }
+            var article = await RssIngest.ProcessOneAsync(sp, _opts, _ai, pick, cat, null, null, ct);
+            if (article is null) { _log.LogInformation("No article produced for category {Category} (dup or empty).", cat); return; }
 
-            List<ArticleImage>? images = null; // images are intentionally omitted
-
-            var article = ArticleMapping.MapToArticle(
-                d, ArticleType.Article, adminId, images, _opts, now);
-
-            var exists = await db.Set<Article>()
-                .AnyAsync(a => a.Title.ToLower() == article.Title.ToLower(), ct);
-            if (exists)
-            {
-                Info("DB duplicate title", d);
-                continue;
-            }
-
-            toAdd.Add(article);
+            var svc = sp.GetRequiredService<ArticleServices>();
+            await svc.Publish(ArticleMapping.MapToDto(article), article.AuthorId);
+            _log.LogInformation("Inserted category article: {Title} [{Category}]", article.Title, cat);
         }
+        catch (Exception ex)
+        { _log.LogError(ex, "Failed to publish category article for {Category}.", cat); }
+    }
+}
+#endregion
 
-        if (toAdd.Count == 0)
+#region Service: Global top stories (every 30 minutes)
+public sealed class GoogleNewsTopStoriesService : BackgroundService
+{
+    private readonly ILogger<GoogleNewsTopStoriesService> _log;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly AiNewsOptions _opts;
+    private readonly IGenerativeTextClient _ai;
+    private readonly HttpClient _http;
+
+    public GoogleNewsTopStoriesService(
+        ILogger<GoogleNewsTopStoriesService> log,
+        IServiceScopeFactory scopeFactory,
+        IOptions<AiNewsOptions> opts,
+        IGenerativeTextClient ai,
+        IHttpClientFactory httpFactory)
+    {
+        _log = log; _scopeFactory = scopeFactory; _opts = opts.Value; _ai = ai;
+        _http = httpFactory.CreateClient("gn");
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken); // slight stagger
+        _log.LogInformation("GoogleNewsTopStoriesService started (interval {Interval}).", _opts.TopStoriesInterval);
+        var timer = new PeriodicTimer(_opts.TopStoriesInterval);
+        try
         {
-            _log.LogInformation("No random AI article inserted for category {Category}.", category);
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                try { await TickAsync(stoppingToken); }
+                catch (OperationCanceledException) { }
+                catch (Exception ex) { _log.LogError(ex, "Top stories tick failed."); }
+            }
+        }
+        catch (OperationCanceledException) { }
+        finally { timer.Dispose(); _log.LogInformation("Top stories stopping."); }
+    }
+
+    private async Task TickAsync(CancellationToken ct)
+    {
+        using var gate = await AiWorkGate.EnterAsync();
+        using var scope = _scopeFactory.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        var url = GoogleNews.BuildTopStoriesUrl(_opts.DefaultLang, _opts.DefaultCountry);
+        var items = await GoogleNews.FetchAsync(_http, url, ct);
+        if (items.Count == 0) { _log.LogInformation("No global top stories."); return; }
+
+        // Try up to 3 insertions from the first 12 items
+        var rnd = new Random();
+        var picks = items.Take(12).OrderBy(_ => rnd.Next()).Take(3).ToList();
+
+        var svc = sp.GetRequiredService<ArticleServices>();
+        var db = sp.GetRequiredService<AppDbContext>();
+        var adminId = await db.Users.Where(u => u.Role == Role.SuperAdmin || u.Role == Role.Admin).Select(u => u.Id).FirstAsync(ct);
+
+        foreach (var pick in picks)
+        {
+            try
+            {
+                var article = await RssIngest.ProcessOneAsync(sp, _opts, _ai, pick, Category.Info, null, null, ct);
+                if (article is null) continue;
+                await svc.Publish(ArticleMapping.MapToDto(article), adminId);
+                _log.LogInformation("Inserted top story: {Title}", article.Title);
+            }
+            catch (Exception ex)
+            { _log.LogError(ex, "Failed to publish top story for {Link}.", pick.Link); }
+        }
+    }
+}
+#endregion
+
+#region Service: Local country top stories from Countries.json (every 15 minutes)
+public sealed class GoogleNewsLocalCountryService : BackgroundService
+{
+    private readonly ILogger<GoogleNewsLocalCountryService> _log;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly AiNewsOptions _opts;
+    private readonly IGenerativeTextClient _ai;
+    private readonly HttpClient _http;
+    private List<CountryEntry> _countries = new();
+    private readonly Random _rng = new();
+
+    public GoogleNewsLocalCountryService(
+        ILogger<GoogleNewsLocalCountryService> log,
+        IServiceScopeFactory scopeFactory,
+        IOptions<AiNewsOptions> opts,
+        IGenerativeTextClient ai,
+        IHttpClientFactory httpFactory)
+    {
+        _log = log; _scopeFactory = scopeFactory; _opts = opts.Value; _ai = ai;
+        _http = httpFactory.CreateClient("gn");
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken); // stagger
+        using (var scope = _scopeFactory.CreateScope())
+            _countries = CountriesFile.Load(scope.ServiceProvider, _log);
+
+        if (_countries.Count == 0)
+        {
+            _log.LogWarning("Countries list is empty; local country top stories will not run.");
             return;
         }
 
-        var articleService = scope.ServiceProvider.GetRequiredService<ArticleServices>();
-        try
-        {
-            foreach (var article in toAdd)
-                await articleService.Publish(ArticleMapping.MapToDto(article), adminId);
-
-            _log.LogInformation("Inserted {Count} random AI article(s) in category {Category}.", toAdd.Count, category);
-        }
-        catch (DbUpdateException ex)
-        {
-            _log.LogError(ex, "Failed to insert random AI article(s) in category {Category}.", category);
-        }
-    }
-
-    private void Info(string reason, AiArticleDraft d) =>
-        _log.LogInformation("drop: {Reason} | title='{Title}'", reason, d.Title);
-}
-#endregion
-
-#region Service: TRUE CRIME writer
-public sealed class AiTrueCrimeWriterService : BackgroundService
-{
-    private readonly ILogger<AiTrueCrimeWriterService> _log;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly AiNewsOptions _opts;
-    private readonly IGenerativeTextClient _ai;
-
-    public AiTrueCrimeWriterService(
-        ILogger<AiTrueCrimeWriterService> log,
-        IServiceScopeFactory scopeFactory,
-        IOptions<AiNewsOptions> opts,
-        IGenerativeTextClient ai)
-    {
-        _log = log; _scopeFactory = scopeFactory; _opts = opts.Value; _ai = ai;
-    }
-
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        await Task.Delay(TimeSpan.FromSeconds(40), stoppingToken); // stagger
-
-        _log.LogInformation("AiTrueCrimeWriterService started (interval {Interval}).", _opts.TrueCrimeInterval);
-        var timer = new PeriodicTimer(_opts.TrueCrimeInterval);
+        _log.LogInformation("GoogleNewsLocalCountryService started (interval {Interval}).", _opts.LocalTopStoriesInterval);
+        var timer = new PeriodicTimer(_opts.LocalTopStoriesInterval);
         try
         {
             while (await timer.WaitForNextTickAsync(stoppingToken))
             {
                 try { await TickAsync(stoppingToken); }
                 catch (OperationCanceledException) { }
-                catch (Exception ex) { _log.LogError(ex, "AI true-crime writer tick failed."); }
+                catch (Exception ex) { _log.LogError(ex, "Local country tick failed."); }
             }
         }
         catch (OperationCanceledException) { }
-        finally
-        {
-            timer.Dispose();
-            _log.LogInformation("AiTrueCrimeWriterService stopping.");
-        }
+        finally { timer.Dispose(); _log.LogInformation("Local country service stopping."); }
     }
 
     private async Task TickAsync(CancellationToken ct)
     {
         using var gate = await AiWorkGate.EnterAsync();
-
         using var scope = _scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var sp = scope.ServiceProvider;
 
-        var recent = await db.Set<Article>()
-            .OrderByDescending(a => a.CreatedDate)
-            .Select(a => a.Title)
-            .Take(300)
-            .ToListAsync(ct);
+        // Pick a random country
+        var c = _countries[_rng.Next(_countries.Count)];
+        var lang = string.IsNullOrWhiteSpace(c.Lang) ? _opts.DefaultLang : c.Lang!;
+        var url = GoogleNews.BuildTopStoriesUrl(lang, c.Code);
+        var items = await GoogleNews.FetchAsync(_http, url, ct);
+        if (items.Count == 0) { _log.LogInformation("No top stories for {Code}", c.Code); return; }
 
-        var system = AiNewsPrompt.BuildSystem(_opts, recent);
-        var user = AiNewsPrompt.BuildTrueCrimeUser(_opts);
-
-        var json = await _ai.GenerateJsonAsync(_opts.Model, system, user, _opts.Creativity, ct);
-        var batch = AiTrendingNewsPollingService.DeserializeSafe(json);
-        if (batch.Items.Count == 0) { _log.LogInformation("No true-crime item returned."); return; }
-
-        var admin = await db.Users
-            .FirstOrDefaultAsync(u => u.Role == Role.SuperAdmin || u.Role == Role.Admin, ct);
-        if (admin is null) { _log.LogWarning("No Admin or SuperAdmin found."); return; }
-        var adminId = admin.Id;
-
-        var now = DateTimeOffset.UtcNow;
-        var maxAge = TimeSpan.FromHours(_opts.MaxAgeHours);
-
-        var articleService = scope.ServiceProvider.GetRequiredService<ArticleServices>();
-        var inserted = 0;
-        foreach (var d in batch.Items)
+        var pick = items.First(); // use the lead headline for locality
+        try
         {
-            if (string.IsNullOrWhiteSpace(d.Title) || string.IsNullOrWhiteSpace(d.ArticleHtml))
-                { Info("missing title or html", d); continue; }
-
-            if (d.EventDateUtc is null) d.EventDateUtc = now;
-            if (now - d.EventDateUtc.Value > maxAge)
-                { Info("too old", d); continue; }
-
-            if (HtmlText.CountWords(d.ArticleHtml) < _opts.PreInsertMinWordCount)
-                { Info($"too short (<{_opts.PreInsertMinWordCount} words)", d); continue; }
-
-            List<ArticleImage>? images = null; // images are intentionally omitted
-
-            var article = ArticleMapping.MapToArticle(
-                d, ArticleType.Article, adminId, images, _opts, now);
-
-            article.Category = Category.Crime;
-
-            var exists = await db.Set<Article>()
-                .AnyAsync(a => a.Title.ToLower() == article.Title.ToLower(), ct);
-            if (exists)
-            {
-                Info("DB duplicate title", d);
-                continue;
-            }
-
-            try
-            {
-                await articleService.Publish(ArticleMapping.MapToDto(article), adminId);
-                inserted++;
-            }
-            catch (DbUpdateException ex)
-            {
-                _log.LogError(ex, "Failed to insert AI true-crime article '{Title}'.", article.Title);
-            }
+            var article = await RssIngest.ProcessOneAsync(sp, _opts, _ai, pick, Category.Info, c.Name, c.Code, ct);
+            if (article is null) { _log.LogInformation("No article produced for {Code}", c.Code); return; }
+            var svc = sp.GetRequiredService<ArticleServices>();
+            await svc.Publish(ArticleMapping.MapToDto(article), article.AuthorId);
+            _log.LogInformation("Inserted local top story ({Code}): {Title}", c.Code, article.Title);
         }
-
-        if (inserted == 0)
-            _log.LogInformation("No TRUE CRIME article inserted.");
-        else
-            _log.LogInformation("Inserted {Count} TRUE CRIME article(s).", inserted);
+        catch (Exception ex)
+        { _log.LogError(ex, "Failed to publish local top story for {Code}.", c.Code); }
     }
-
-    private void Info(string reason, AiArticleDraft d) =>
-        _log.LogInformation("drop: {Reason} | title='{Title}'", reason, d.Title);
 }
 #endregion
 
-#region DI registration helper
+#region DI registration helper (replaces old AI-only services)
 public static class AiNewsRegistration
 {
     public static IServiceCollection AddAiNews(this IServiceCollection services, Action<AiNewsOptions> configure)
     {
         services.Configure(configure);
 
-        // Gemini client with Polly owning timeouts (no double timeout)
+        // Gemini client with Polly owning timeouts
         services.AddHttpClient<IGenerativeTextClient, GeminiRestClient>(client =>
         {
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -982,9 +888,9 @@ public static class AiNewsRegistration
             o.AttemptTimeout.Timeout = TimeSpan.FromSeconds(120);       // per-try
             o.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(150); // whole pipeline
 
-            // --- Circuit breaker (must satisfy SamplingDuration >= 2 * AttemptTimeout) ---
-            o.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(2);  // ✅ >= 120s
-            o.CircuitBreaker.BreakDuration = TimeSpan.FromSeconds(60);
+            // --- Circuit breaker ---
+            o.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(4);
+            o.CircuitBreaker.BreakDuration = TimeSpan.FromSeconds(120);
             o.CircuitBreaker.FailureRatio = 0.2;
             o.CircuitBreaker.MinimumThroughput = 10;
 
@@ -999,12 +905,20 @@ public static class AiNewsRegistration
                 );
         });
 
+        // Lightweight client for Google News RSS pulls
+        services.AddHttpClient("gn", client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible; NortheastBot/1.0)");
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
 
-        // Hosted services
-        services.AddHostedService<AiTrendingNewsPollingService>();
-        services.AddHostedService<AiRandomArticleWriterService>();
-        services.AddHostedService<AiTrueCrimeWriterService>();
+        // Hosted services — NEW
+        services.AddHostedService<GoogleNewsCategoryRotationService>();
+        services.AddHostedService<GoogleNewsTopStoriesService>();
+        services.AddHostedService<GoogleNewsLocalCountryService>();
+
         return services;
     }
 }
 #endregion
+


### PR DESCRIPTION
## Summary
- replace legacy AI news writers with Google News RSS-driven pipeline backed by Gemini for paraphrasing
- support science category and update fallback HTML helper
- configure AiNews without unused AcceptStaleAsAnalysis option

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a9b68cad688327afc2684dcf5aea9d