### PR TITLE
Add local news slideshow with hover navigation

### DIFF
--- a/WT4Q/src/components/LocalArticleSection.module.css
+++ b/WT4Q/src/components/LocalArticleSection.module.css
@@ -6,3 +6,34 @@
   font-size: 1.25rem;
   margin-bottom: 0.5rem;
 }
+
+.slider {
+  position: relative;
+}
+
+.arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.3s;
+  padding: 0 0.25rem;
+  z-index: 1;
+}
+
+.slider:hover .arrow {
+  opacity: 1;
+}
+
+.left {
+  left: 0.25rem;
+}
+
+.right {
+  right: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- Show up to five location-based articles in a rotating slideshow
- Add hover-revealed arrows to navigate between local news items

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a9b05e1bbc8327af9799dad36b008b