### PR TITLE
feat: add science category to frontend

### DIFF
--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -6,6 +6,7 @@ export const UPLOADCATEGORIES = [
   'Health',
   'Lifestyle',
   'Technology',
+  'Science',
   'Sports',
   'Info'
 ];
@@ -15,12 +16,14 @@ export const CATEGORIES = [
   'Crime',
   'Entertainment',
   'Business',
-    'Health',
-    'Lifestyle',
+  'Health',
+  'Lifestyle',
   'Technology',
+  'Science',
   'Sports',
   'Info'
 ];
+
 /*namespace Northeast.Models
 {
     public enum Category
@@ -32,6 +35,7 @@ export const CATEGORIES = [
         Health,
         Lifestyle,
         Technology,
+        Science,
         Sports,
         Info
     }


### PR DESCRIPTION
## Summary
- align frontend category lists with backend Category enum

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba75e0a08327b5201583387022d6