### PR TITLE
Enforce article category and persist enums as strings

### DIFF
--- a/Northeast/Data/AppDbContext.cs
+++ b/Northeast/Data/AppDbContext.cs
@@ -34,23 +34,32 @@ namespace Northeast.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Article>()
-                .HasOne(a => a.Author)
-                .WithMany(u => u.Articles)
-                .HasForeignKey(a => a.AuthorId);
+            base.OnModelCreating(modelBuilder);
 
-            modelBuilder.Entity<Article>()
-                .HasMany(a => a.Images)
-                .WithOne(i => i.Article)
-                .HasForeignKey(i => i.ArticleId);
+            modelBuilder.Entity<Article>(b =>
+            {
+                b.HasOne(a => a.Author)
+                    .WithMany(u => u.Articles)
+                    .HasForeignKey(a => a.AuthorId);
 
-            modelBuilder.Entity<Article>()
-                .HasIndex(a => a.Title)
-                .IsUnique();
+                b.HasMany(a => a.Images)
+                    .WithOne(i => i.Article)
+                    .HasForeignKey(i => i.ArticleId);
 
-            modelBuilder.Entity<Article>()
-                .Navigation(a => a.Images)
-                .AutoInclude();
+                b.HasIndex(a => a.Title)
+                    .IsUnique();
+
+                b.Navigation(a => a.Images)
+                    .AutoInclude();
+
+                b.Property(a => a.Category)
+                    .HasConversion<string>()
+                    .HasMaxLength(32);
+
+                b.Property(a => a.ArticleType)
+                    .HasConversion<string>()
+                    .HasMaxLength(32);
+            });
 
             modelBuilder.Entity<Comment>()
                 .HasOne(c => c.ParentComment)

--- a/Northeast/Migrations/20250823144700_StoreEnumsAsString.Designer.cs
+++ b/Northeast/Migrations/20250823144700_StoreEnumsAsString.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Northeast.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Northeast.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250823144700_StoreEnumsAsString")]
+    partial class StoreEnumsAsString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Northeast/Migrations/20250823144700_StoreEnumsAsString.cs
+++ b/Northeast/Migrations/20250823144700_StoreEnumsAsString.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Northeast.Migrations
+{
+    /// <inheritdoc />
+    public partial class StoreEnumsAsString : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Category",
+                table: "Articles",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ArticleType",
+                table: "Articles",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Category",
+                table: "Articles",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ArticleType",
+                table: "Articles",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32);
+        }
+    }
+}

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddControllers().AddJsonOptions(options =>
     options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
     options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/Northeast/Services/AiNewsServices.cs
+++ b/Northeast/Services/AiNewsServices.cs
@@ -464,6 +464,7 @@ internal static class ArticleMapping
 
     public static Article MapToArticle(
         AiArticleDraft d,
+        Category enforcedCategory,
         ArticleType type,
         Guid authorId,
         AiNewsOptions opts,
@@ -492,7 +493,7 @@ internal static class ArticleMapping
         {
             AuthorId = authorId,
             ArticleType = type,
-            Category = ParseCategoryStrict(d.Category),
+            Category = enforcedCategory,
             Title = (d.Title ?? string.Empty).Trim(),
             CreatedDate = DateTime.UtcNow,
             Content = html,
@@ -602,7 +603,7 @@ internal static class RssIngest
             d.ArticleHtml = $"<div><h2>Summary</h2><p>{safe}</p></div>";
         }
 
-        var article = ArticleMapping.MapToArticle(d, ArticleType.News,
+        var article = ArticleMapping.MapToArticle(d, category, ArticleType.News,
             authorId: await ResolveAdminIdAsync(db, ct), opts, now);
         return article;
     }

--- a/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
+++ b/WT4Q/src/app/admin/dashboard/DashboardClient.tsx
@@ -112,8 +112,8 @@ export default function DashboardClient() {
 
         const body = {
           title,
-          category: category ? UPLOADCATEGORIES.indexOf(category) + 1 : 0,
-          articleType: type ? ARTICLE_TYPES.indexOf(type) : 0,
+          category: category || undefined,
+          articleType: type || undefined,
           createdDate: new Date().toISOString(),
           content,
           images: imagesPayload,

--- a/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
@@ -14,8 +14,8 @@ interface ArticleDetails {
   title: string;
   content: string;
   createdDate: string;
-  articleType: number;
-  category: number;
+  articleType: string;
+  category: string;
   images?: ArticleImage[];
   embededCode?: string;
   countryName?: string;
@@ -52,8 +52,8 @@ export default function EditArticleClient({ id }: { id: string }) {
         const data: ArticleDetails = await res.json();
         setTitle(data.title);
         setContent(data.content);
-        setType(ARTICLE_TYPES[data.articleType] ?? '');
-        setCategory(CATEGORIES[data.category - 1] ?? '');
+        setType(data.articleType || '');
+        setCategory(data.category || '');
         setCreatedDate(data.createdDate.slice(0, 16));
         setEmbededCode(data.embededCode || '');
         setImages(
@@ -124,8 +124,8 @@ export default function EditArticleClient({ id }: { id: string }) {
 
         const body = {
           title,
-          category: category ? CATEGORIES.indexOf(category) + 1 : 0,
-          articleType: type ? ARTICLE_TYPES.indexOf(type) : 0,
+          category: category || undefined,
+          articleType: type || undefined,
           createdDate: new Date(createdDate).toISOString(),
           content,
           images: imagesPayload,


### PR DESCRIPTION
## Summary
- Pass the chosen category into `ArticleMapping.MapToArticle` and use it directly in the mapped entity.
- Configure EF Core to store `Category` and `ArticleType` enums as strings and add a migration.

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d3d754b483279bdec5f0a42092ba