### PR TITLE
Link homepage categories to dedicated pages

### DIFF
--- a/WT4Q/src/app/page.module.css
+++ b/WT4Q/src/app/page.module.css
@@ -145,6 +145,8 @@
 }
 .kicker {
   font-variant: small-caps;
+  text-decoration: none;
+  color: inherit;
 }
 
 /* Articles inside a column: first one prominent, others compact */
@@ -267,7 +269,6 @@
 
 /* re-use column/article styles you already had */
 .columnGrid { display: grid; grid-template-columns: 1fr; gap: 1rem; }
-.kicker { font-variant: small-caps; }
 
 /* Responsive: stack columns on small screens */
 @media (max-width: 1100px) {

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -2,6 +2,7 @@
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import BreakingCenterpiece from '@/components/BreakingCenterpiece';
 import type { BreakingArticle } from '@/components/BreakingNewsSlider';
+import PrefetchLink from '@/components/PrefetchLink';
 import type { ArticleImage } from '@/lib/models';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
@@ -105,7 +106,12 @@ export default async function Home() {
           {leftRail.map(({ category, articles }) => (
             <section key={category} className={styles.section}>
               <h2 className={styles.heading}>
-                <span className={styles.kicker}>{category}</span>
+                <PrefetchLink
+                  href={`/category/${encodeURIComponent(category)}`}
+                  className={styles.kicker}
+                >
+                  {category}
+                </PrefetchLink>
               </h2>
               <div className={styles.columnGrid}>
                 {articles.slice(0, 5).map((a) => (
@@ -124,9 +130,14 @@ export default async function Home() {
           {rightRail.map(({ category, articles }) => (
             <section key={category} className={styles.section}>
               <h2 className={styles.heading}>
-                <span className={styles.kicker}>{category}</span>
+                <PrefetchLink
+                  href={`/category/${encodeURIComponent(category)}`}
+                  className={styles.kicker}
+                >
+                  {category}
+                </PrefetchLink>
               </h2>
-              
+
               <div className={styles.columnGrid}>
                 {articles.slice(0, 5).map((a) => (
                   <ArticleCard key={a.id} article={a} />
@@ -145,7 +156,12 @@ export default async function Home() {
           {row.map(({ category, articles }) => (
             <section key={category} className={`${styles.section} ${styles.column}`}>
               <h2 className={styles.heading}>
-                <span className={styles.kicker}>{category}</span>
+                <PrefetchLink
+                  href={`/category/${encodeURIComponent(category)}`}
+                  className={styles.kicker}
+                >
+                  {category}
+                </PrefetchLink>
               </h2>
               <div className={styles.columnGrid}>
                 {articles.slice(0, 5).map((a) => (


### PR DESCRIPTION
## Summary
- Turn homepage category headers into links to their respective category pages
- Ensure category links inherit existing newspaper styling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0b28c56483278d4588a68ee6c661