### PR TITLE
Refine crime feed and category inference

### DIFF
--- a/Northeast/Services/CategoryHeuristics.cs
+++ b/Northeast/Services/CategoryHeuristics.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using Northeast.Models;
+
+namespace Northeast.Services;
+
+internal static class CategoryHeuristics
+{
+    private static readonly string[] CrimeKeywords =
+    {
+        "crime", "police", "arrest", "investigation", "shooting", "stabbing", "homicide", "murder", "assault", "kidnapping", "fraud", "trafficking"
+    };
+
+    private static readonly string[] PoliticsKeywords =
+    {
+        "election", "president", "senate", "congress", "parliament", "minister", "government", "policy", "politic", "vote", "campaign", "candidate"
+    };
+
+    public static Category Guess(string? title, string? summary, string? content)
+    {
+        var text = string.Join(' ', title ?? string.Empty, summary ?? string.Empty, content ?? string.Empty)
+            .ToLowerInvariant();
+
+        if (CrimeKeywords.Any(k => text.Contains(k))) return Category.Crime;
+        if (PoliticsKeywords.Any(k => text.Contains(k))) return Category.Politics;
+
+        return Category.Info;
+    }
+}


### PR DESCRIPTION
## Summary
- expand crime RSS query with additional English keywords
- keep AI categories and apply heuristic when Info is requested
- rotate global editions for top stories

## Testing
- `dotnet build Northeast/Northeast.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aa173e3ffc832788eeef38a08f2f26