### PR TITLE
Use article slugs for SEO-friendly routes

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -75,7 +75,56 @@ namespace Northeast.Controllers
             return Ok(articles);
         }
 
-        [HttpGet("{id}")]
+        [HttpGet("{slug}")]
+        public async Task<IActionResult> GetBySlug(string slug)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                return BadRequest(new { message = "Please enter a title" });
+            }
+
+            var article = await articleUpload.GetArticleBySlug(slug);
+            if (article == null)
+            {
+                return NotFound(new { message = "Sorry, no article found with this title" });
+            }
+
+            return Ok(article);
+        }
+
+        [HttpGet("{slug}/recommendations")]
+        public async Task<IActionResult> GetRecommendations(string slug, [FromQuery] int count = 5)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                return BadRequest(new { message = "Please enter a title" });
+            }
+
+            var article = await articleUpload.GetArticleBySlug(slug);
+            if (article == null)
+            {
+                return NotFound(new { message = "Sorry, no article found with this title" });
+            }
+
+            var results = await _recommendations.GetRecommendationsAsync(article.Id, count);
+            if (!results.Any())
+            {
+                return NotFound(new { message = "No related articles found" });
+            }
+
+            var dto = results.Select(a => new ArticleRecommendationDto
+            {
+                Id = a.Id,
+                Title = a.Title,
+                Slug = a.Slug,
+                Category = a.Category,
+                ArticleType = a.ArticleType
+            });
+
+            return Ok(dto);
+        }
+
+        [HttpGet("id/{id:guid}")]
         public async Task<IActionResult> GetById(Guid id)
         {
             if (id == Guid.Empty)
@@ -90,31 +139,6 @@ namespace Northeast.Controllers
             }
 
             return Ok(article);
-        }
-
-        [HttpGet("{id}/recommendations")]
-        public async Task<IActionResult> GetRecommendations(Guid id, [FromQuery] int count = 5)
-        {
-            if (id == Guid.Empty)
-            {
-                return BadRequest(new { message = "Please enter an Id" });
-            }
-
-            var results = await _recommendations.GetRecommendationsAsync(id, count);
-            if (!results.Any())
-            {
-                return NotFound(new { message = "No related articles found" });
-            }
-
-            var dto = results.Select(a => new ArticleRecommendationDto
-            {
-                Id = a.Id,
-                Title = a.Title,
-                Category = a.Category,
-                ArticleType = a.ArticleType
-            });
-
-            return Ok(dto);
         }
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]

--- a/Northeast/DTOs/ArticleRecommendationDto.cs
+++ b/Northeast/DTOs/ArticleRecommendationDto.cs
@@ -7,6 +7,7 @@ namespace Northeast.DTOs
     {
         public Guid Id { get; set; }
         public string Title { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
         public Category Category { get; set; }
         public ArticleType ArticleType { get; set; }
     }

--- a/Northeast/Models/Article.cs
+++ b/Northeast/Models/Article.cs
@@ -1,9 +1,11 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace Northeast.Models
 {
+    [Index(nameof(Slug), IsUnique = true)]
     public class Article
     {
         [Key]
@@ -17,6 +19,9 @@ namespace Northeast.Models
         public Category Category { get; set; }
         [Required]
         public string Title { get; set; }
+
+        [Required]
+        public string Slug { get; set; } = string.Empty;
         [Required]
         public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
         [Required]

--- a/Northeast/Repository/ArticleRepository.cs
+++ b/Northeast/Repository/ArticleRepository.cs
@@ -17,6 +17,9 @@ namespace Northeast.Repository
         public Task<Article?> GetByIdAsync(Guid id) =>
             _context.Articles.AsNoTracking().FirstOrDefaultAsync(a => a.Id == id);
 
+        public Task<Article?> GetBySlugAsync(string slug) =>
+            _context.Articles.AsNoTracking().FirstOrDefaultAsync(a => a.Slug == slug);
+
         public Task<List<Article>> GetAllExceptAsync(Guid excludeId) =>
             _context.Articles.AsNoTracking().Where(a => a.Id != excludeId).ToListAsync();
         public async Task<IEnumerable<Article>> GetAllByCategory(Category category) {

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -42,7 +42,7 @@ namespace Northeast.Services
         {
             if (article != null)
             {
-                article.Views = await _pageVisitRepository.CountVisitsAsync($"/articles/{article.Id}");
+                article.Views = await _pageVisitRepository.CountVisitsAsync($"/articles/{article.Slug}");
             }
         }
 
@@ -76,6 +76,7 @@ namespace Northeast.Services
             {
                 AuthorId = authorId,
                 Title = articleDto.Title,
+                Slug = Northeast.Utilities.HtmlText.Slug(articleDto.Title),
                 Category = articleDto.Category,
                 CreatedDate = DateTime.UtcNow,
                 ArticleType = articleDto.ArticleType,
@@ -111,6 +112,17 @@ namespace Northeast.Services
                 .Include(a => a.Like)
                 .Include(a => a.Comments)
                 .FirstOrDefaultAsync(a => a.Id == Id);
+            await SetViewsAsync(article);
+            return article;
+        }
+
+        public async Task<Article?> GetArticleBySlug(string slug)
+        {
+            var article = await _appDbContext.Articles
+                .AsNoTracking()
+                .Include(a => a.Like)
+                .Include(a => a.Comments)
+                .FirstOrDefaultAsync(a => a.Slug == slug);
             await SetViewsAsync(article);
             return article;
         }
@@ -195,6 +207,7 @@ namespace Northeast.Services
             }
 
             article.Title = articleDto.Title;
+            article.Slug = Northeast.Utilities.HtmlText.Slug(articleDto.Title);
             article.Category = articleDto.Category;
             article.ArticleType = articleDto.ArticleType;
             article.Content = articleDto.Content;

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -28,9 +28,10 @@ export const API_ROUTES = {
   ARTICLE: {
     CREATE: `${API_BASE_URL}/api/Article`,
     GET_ALL: `${API_BASE_URL}/api/Article`,
-    GET_BY_ID: (id: string) => `${API_BASE_URL}/api/Article/${id}`,
-    GET_RECOMMENDATIONS: (id: string, count = 5) =>
-      `${API_BASE_URL}/api/Article/${id}/recommendations?count=${count}`,
+    GET_BY_SLUG: (slug: string) => `${API_BASE_URL}/api/Article/${slug}`,
+    GET_BY_ID: (id: string) => `${API_BASE_URL}/api/Article/id/${id}`,
+    GET_RECOMMENDATIONS: (slug: string, count = 5) =>
+      `${API_BASE_URL}/api/Article/${slug}/recommendations?count=${count}`,
     SEARCH: (query: string) =>
       `${API_BASE_URL}/api/ArticleSearch?query=${encodeURIComponent(query)}`,
     SEARCH_ADVANCED: `${API_BASE_URL}/api/ArticleSearch/advanced`,

--- a/WT4Q/lib/text.ts
+++ b/WT4Q/lib/text.ts
@@ -9,3 +9,10 @@ export function truncateWords(text = '', count = 50): string {
 export function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '');
 }
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+}

--- a/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { API_ROUTES } from '@/lib/api';
 import { ARTICLE_TYPES } from '@/lib/articleTypes';
 import { CATEGORIES } from '@/lib/categories';
+import { slugify } from '@/lib/text';
 import countries from '../../../../../public/datas/Countries.json';
 import styles from '../../dashboard/dashboard.module.css';
 import type { ArticleImage } from '@/lib/models';
@@ -148,7 +149,7 @@ export default function EditArticleClient({ id }: { id: string }) {
           if (!res.ok) {
             throw new Error(data.message || 'Failed to update');
           }
-          router.push(`/articles/${id}`);
+          router.push(`/articles/${slugify(title)}`);
         } catch (err) {
           if (err instanceof Error) setError(err.message);
           else setError('Failed to update');

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -49,6 +49,7 @@ async function fetchBreakingNews(): Promise<BreakingArticle[]> {
       )
       .map((a) => ({
         id: a.id,
+        slug: a.slug,
         title: a.title,
         content: a.content,
         images: a.images as ArticleImage[],

--- a/WT4Q/src/app/sitemap.ts
+++ b/WT4Q/src/app/sitemap.ts
@@ -8,8 +8,8 @@ async function fetchArticlePaths(): Promise<string[]> {
   try {
     const res = await fetch(API_ROUTES.ARTICLE.GET_ALL, { cache: 'no-store' });
     if (!res.ok) return [];
-    const articles: { id: string }[] = await res.json();
-    return articles.map(a => `/articles/${a.id}`);
+    const articles: { slug: string }[] = await res.json();
+    return articles.map(a => `/articles/${a.slug}`);
   } catch {
     return [];
   }

--- a/WT4Q/src/components/ArticleCard.tsx
+++ b/WT4Q/src/components/ArticleCard.tsx
@@ -4,6 +4,7 @@ import { truncateWords } from '@/lib/text';
 
 export interface Article {
   id: string;
+  slug: string;
   title: string;
   summary: string;
   createdDate?: string;
@@ -13,7 +14,7 @@ export interface Article {
 export default function ArticleCard({ article }: { article: Article }) {
   const snippet = truncateWords(article.summary);
   return (
-    <PrefetchLink href={`/articles/${article.id}`} className={styles.card}>
+    <PrefetchLink href={`/articles/${article.slug}`} className={styles.card}>
       <h2 className={styles.title}>{article.title}</h2>
       <p className={styles.summary}>{snippet}</p>
       {typeof article.views === 'number' && (

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -8,6 +8,7 @@ import { API_ROUTES } from '@/lib/api';
 
 export interface BreakingArticle {
   id: string;
+  slug: string;
   title: string;
   content?: string;
   images?: ArticleImage[];
@@ -83,7 +84,7 @@ export default function BreakingNewsSlider({
         // don’t silently loop on 4xx/5xx
         throw new Error(`HTTP ${res.status}`);
       }
-      const data: { id: string; title: string; createdDate?: string }[] = await res.json();
+      const data: { id: string; slug: string; title: string; createdDate?: string }[] = await res.json();
       setArticles(
         data
           .sort(
@@ -92,7 +93,7 @@ export default function BreakingNewsSlider({
               new Date(a.createdDate ?? 0).getTime(),
           )
           .slice(0, 20)
-          .map((a) => ({ id: a.id, title: a.title, createdDate: a.createdDate })),
+          .map((a) => ({ id: a.id, slug: a.slug, title: a.title, createdDate: a.createdDate })),
       );
       setIndex(0);
     })().catch((err: unknown) => {
@@ -180,7 +181,7 @@ export default function BreakingNewsSlider({
           )}
           <h3 className={styles.detailTitle}>{current.title}</h3>
           {snippet && <p className={styles.snippet}>{snippet}</p>}
-          <PrefetchLink href={`/articles/${current.id}`} className={styles.readMore}>
+          <PrefetchLink href={`/articles/${current.slug}`} className={styles.readMore}>
             Read more
           </PrefetchLink>
         </div>
@@ -190,7 +191,7 @@ export default function BreakingNewsSlider({
             direction === 'next' ? styles.slideLeft : styles.slideRight
           }`}
         >
-          <PrefetchLink href={`/articles/${current.id}`} className={styles.item}>
+          <PrefetchLink href={`/articles/${current.slug}`} className={styles.item}>
             <span ref={textRef}>{current.title}</span>
           </PrefetchLink>
         </div>


### PR DESCRIPTION
## Summary
- replace article ID routes with slug-based paths for better SEO
- expose slug-based article endpoints and recommendations in backend
- rename frontend article pages and links to use slugs and update sitemap

## Testing
- `npm test`
- `npm run lint`
- `dotnet build Northeast/Northeast.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aa52d3be44832796f63b50ddf0234f