### PR TITLE
Add slug-based cocktail lookup

### DIFF
--- a/Northeast/Controllers/CocktailController.cs
+++ b/Northeast/Controllers/CocktailController.cs
@@ -31,10 +31,18 @@ namespace Northeast.Controllers
             return Ok(items);
         }
 
-        [HttpGet("{id}")]
+        [HttpGet("id/{id}")]
         public async Task<IActionResult> GetById(int id)
         {
             var item = await _service.GetById(id);
+            if (item == null) return NotFound();
+            return Ok(item);
+        }
+
+        [HttpGet("{slug}")]
+        public async Task<IActionResult> GetBySlug(string slug)
+        {
+            var item = await _service.GetBySlug(slug);
             if (item == null) return NotFound();
             return Ok(item);
         }

--- a/Northeast/Models/Cocktail.cs
+++ b/Northeast/Models/Cocktail.cs
@@ -1,13 +1,20 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace Northeast.Models
 {
+    [Index(nameof(Slug), IsUnique = true)]
     public class Cocktail
     {
         public int Id { get; set; }
 
+        [Required]
         public string Name { get; set; }
+
+        [Required]
+        public string Slug { get; set; } = string.Empty;
+
         public string Content { get; set; }
 
         public List<Ingridient> Ingridients { get; set; } = new List<Ingridient>();
@@ -15,15 +22,16 @@ namespace Northeast.Models
         public List<IngridientQuantity> IngredientQuantities { get; set; } = new List<IngridientQuantity>();
     }
 
-    public class Ingridient { 
+    public class Ingridient
+    {
         public int Id { get; set; }
         public string Name { get; set; }
     }
+
     public class IngridientQuantity
     {
         [Key]
         public int Id { get; set; }
-
 
         public string Quantity { get; set; }
 
@@ -35,6 +43,7 @@ namespace Northeast.Models
         public Cocktail Cocktail { get; set; }
 
         [ForeignKey(nameof(Cocktail))]
-        public int CocktailID { get; set;}
+        public int CocktailID { get; set; }
     }
 }
+

--- a/Northeast/Repository/CocktailRepository.cs
+++ b/Northeast/Repository/CocktailRepository.cs
@@ -12,6 +12,9 @@ namespace Northeast.Repository
             _context = context;
         }
 
+        public Task<Cocktail?> GetBySlug(string slug) =>
+            _context.Cocktails.AsNoTracking().FirstOrDefaultAsync(c => c.Slug == slug);
+
         public async Task<IEnumerable<Cocktail>> Search(string query)
         {
             if (string.IsNullOrWhiteSpace(query))
@@ -20,7 +23,10 @@ namespace Northeast.Repository
             }
             query = query.ToLower();
             return await _context.Cocktails.AsNoTracking()
-                .Where(c => c.Name.ToLower().Contains(query) || c.Content.ToLower().Contains(query))
+                .Where(c =>
+                    c.Name.ToLower().Contains(query) ||
+                    c.Content.ToLower().Contains(query) ||
+                    c.Slug.ToLower().Contains(query))
                 .ToListAsync();
         }
     }

--- a/Northeast/Services/CocktailService.cs
+++ b/Northeast/Services/CocktailService.cs
@@ -1,6 +1,7 @@
 using Northeast.DTOs;
 using Northeast.Models;
 using Northeast.Repository;
+using Northeast.Utilities;
 using System.Linq;
 
 namespace Northeast.Services
@@ -19,6 +20,7 @@ namespace Northeast.Services
             var cocktail = new Cocktail
             {
                 Name = dto.Name,
+                Slug = HtmlText.Slug(dto.Name),
                 Content = dto.Content,
                 Ingridients = dto.Ingredients.Select(i => new Ingridient { Name = i.Name }).ToList(),
                 IngredientQuantities = dto.Ingredients.Select(i => new IngridientQuantity
@@ -35,6 +37,8 @@ namespace Northeast.Services
 
         public async Task<Cocktail> GetById(int id) => await _repository.GetById(id);
 
+        public async Task<Cocktail?> GetBySlug(string slug) => await _repository.GetBySlug(slug);
+
         public async Task<IEnumerable<Cocktail>> Search(string query) => await _repository.Search(query);
 
         public async Task Update(int id, CocktailDto dto)
@@ -43,6 +47,7 @@ namespace Northeast.Services
             if (cocktail == null) return;
 
             cocktail.Name = dto.Name;
+            cocktail.Slug = HtmlText.Slug(dto.Name);
             cocktail.Content = dto.Content;
             cocktail.Ingridients = dto.Ingredients.Select(i => new Ingridient { Name = i.Name }).ToList();
             cocktail.IngredientQuantities = dto.Ingredients.Select(i => new IngridientQuantity

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -49,7 +49,8 @@ export const API_ROUTES = {
   COCKTAIL: {
     CREATE: `${API_BASE_URL}/api/Cocktail`,
     GET_ALL: `${API_BASE_URL}/api/Cocktail`,
-    GET_BY_ID: (id: string) => `${API_BASE_URL}/api/Cocktail/${id}`,
+    GET_BY_ID: (id: string) => `${API_BASE_URL}/api/Cocktail/id/${id}`,
+    GET_BY_SLUG: (slug: string) => `${API_BASE_URL}/api/Cocktail/${slug}`,
     UPDATE: (id: string) => `${API_BASE_URL}/api/Cocktail/${id}`,
     DELETE: (id: string) => `${API_BASE_URL}/api/Cocktail/${id}`,
     SEARCH: (query: string) =>

--- a/WT4Q/src/app/bar/page.tsx
+++ b/WT4Q/src/app/bar/page.tsx
@@ -7,6 +7,7 @@ import styles from './bar.module.css';
 interface Cocktail {
   id: number;
   name: string;
+  slug: string;
   content: string;
 }
 


### PR DESCRIPTION
## Summary
- add unique slug field to cocktails and populate from name
- support fetching cocktails by slug and searching slug
- expose slug in frontend API routes and cocktail list

## Testing
- `npm test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ab09f393b48327b14205fdc1574fbe