### PR TITLE
Hide notifications and user checks when logged out

### DIFF
--- a/WT4Q/lib/auth.ts
+++ b/WT4Q/lib/auth.ts
@@ -1,0 +1,4 @@
+export const isLoggedIn = (): boolean => {
+  if (typeof document === 'undefined') return false;
+  return document.cookie.split(';').some((cookie) => cookie.trim().startsWith('JwtToken='));
+};

--- a/WT4Q/src/app/contact/page.tsx
+++ b/WT4Q/src/app/contact/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState, FormEvent } from "react";
 import { useSearchParams } from "next/navigation";
 import { API_ROUTES } from "@/lib/api";
+import { isLoggedIn } from "@/lib/auth";
 
 function ContactForm() {
   const [email, setEmail] = useState("");
@@ -12,15 +13,17 @@ function ContactForm() {
   const params = useSearchParams();
 
   useEffect(() => {
-    fetch(API_ROUTES.USERS.ME, { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((user) => {
-        if (user && user.email) {
-          setEmail(user.email);
-          setConnected(true);
-        }
-      })
-      .catch(() => {});
+    if (isLoggedIn()) {
+      fetch(API_ROUTES.USERS.ME, { credentials: "include" })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((user) => {
+          if (user && user.email) {
+            setEmail(user.email);
+            setConnected(true);
+          }
+        })
+        .catch(() => {});
+    }
     if (params.get("type") === "problem") {
       setMessage("I would like to report a problem: ");
     }

--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import styles from './Profile.module.css';
 import { API_ROUTES } from '@/lib/api';
 import VisitorMap from '@/components/VisitorMap';
+import { isLoggedIn } from '@/lib/auth';
 
 interface User {
   userName: string;
@@ -38,6 +39,7 @@ export default function Profile() {
   const router = useRouter();
 
   useEffect(() => {
+    if (!isLoggedIn()) return;
     fetch(API_ROUTES.USERS.ME, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setUser(data))

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -3,6 +3,7 @@
 import { useState, FormEvent, useEffect } from 'react';
 import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES } from '@/lib/api';
+import { isLoggedIn } from '@/lib/auth';
 import styles from './CommentsSection.module.css';
 
 export interface Comment {
@@ -30,9 +31,9 @@ export default function CommentsSection({
   const [loginHref, setLoginHref] = useState('/login');
 
   useEffect(() => {
-    fetch(API_ROUTES.USERS.ME, { credentials: 'include' })
-      .then((res) => setLoggedIn(res.ok))
-      .catch(() => setLoggedIn(false));
+    if (isLoggedIn()) {
+      setLoggedIn(true);
+    }
     setLoginHref(
       `/login?returnUrl=${encodeURIComponent(window.location.href + '#comments')}`
     );

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -10,6 +10,7 @@ import WeatherWidget from './WeatherWidget';
 import MenuIcon from './MenuIcon';
 import NotificationBell from './NotificationBell';
 import styles from './Header.module.css';
+import { isLoggedIn } from '@/lib/auth';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -49,7 +50,7 @@ export default function Header() {
           >
             <MenuIcon className={styles.menuIcon} />
           </button>
-          <NotificationBell />
+          {isLoggedIn() && <NotificationBell />}
           <div className={styles.userMenu}>
             <UserMenu />
           </div>

--- a/WT4Q/src/components/NotificationBell.tsx
+++ b/WT4Q/src/components/NotificationBell.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import PrefetchLink from "@/components/PrefetchLink";
 import { API_ROUTES } from "@/lib/api";
+import { isLoggedIn } from "@/lib/auth";
 import styles from "./NotificationBell.module.css";
 
 interface Notification {
@@ -12,8 +13,10 @@ interface Notification {
 
 export default function NotificationBell() {
   const [unread, setUnread] = useState(0);
+  const loggedIn = isLoggedIn();
 
   useEffect(() => {
+    if (!loggedIn) return;
     fetch(API_ROUTES.NOTIFICATIONS.GET, { credentials: "include" })
       .then((res) => (res.ok ? res.json() : []))
       .then((data: Notification[]) => {
@@ -21,7 +24,9 @@ export default function NotificationBell() {
         setUnread(count);
       })
       .catch(() => {});
-  }, []);
+  }, [loggedIn]);
+
+  if (!loggedIn) return null;
 
   return (
     <PrefetchLink href="/notifications" className={styles.bell} aria-label="Notifications">

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -5,6 +5,7 @@ import PrefetchLink from '@/components/PrefetchLink';
 import { useRouter } from 'next/navigation';
 import styles from './UserMenu.module.css';
 import { API_ROUTES } from '@/lib/api';
+import { isLoggedIn } from '@/lib/auth';
 
 interface User {
   id: string;
@@ -18,6 +19,7 @@ export default function UserMenu() {
   const router = useRouter();
 
   useEffect(() => {
+    if (!isLoggedIn()) return;
     fetch(API_ROUTES.USERS.ME, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setUser(data))


### PR DESCRIPTION
## Summary
- Add `isLoggedIn` helper to detect auth cookie
- Render notification bell only for logged-in users
- Skip `api/User/me` calls when unauthenticated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab660a5f1083278cdd005a892afa9a