### PR TITLE
Avoid API calls when logged out

### DIFF
--- a/WT4Q/lib/auth.ts
+++ b/WT4Q/lib/auth.ts
@@ -1,0 +1,12 @@
+export function isLoggedIn(): boolean {
+  return typeof window !== 'undefined' && localStorage.getItem('wt4q_logged_in') === 'true';
+}
+
+export function setLoggedIn(value: boolean) {
+  if (typeof window === 'undefined') return;
+  if (value) {
+    localStorage.setItem('wt4q_logged_in', 'true');
+  } else {
+    localStorage.removeItem('wt4q_logged_in');
+  }
+}

--- a/WT4Q/src/app/contact/page.tsx
+++ b/WT4Q/src/app/contact/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState, FormEvent } from "react";
 import { useSearchParams } from "next/navigation";
 import { API_ROUTES } from "@/lib/api";
+import { isLoggedIn, setLoggedIn } from "@/lib/auth";
 
 function ContactForm() {
   const [email, setEmail] = useState("");
@@ -12,15 +13,20 @@ function ContactForm() {
   const params = useSearchParams();
 
   useEffect(() => {
-    fetch(API_ROUTES.USERS.ME, { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((user) => {
-        if (user && user.email) {
-          setEmail(user.email);
-          setConnected(true);
-        }
-      })
-      .catch(() => {});
+    if (isLoggedIn()) {
+      fetch(API_ROUTES.USERS.ME, { credentials: "include" })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((user) => {
+          if (user && user.email) {
+            setEmail(user.email);
+            setConnected(true);
+            setLoggedIn(true);
+          } else {
+            setLoggedIn(false);
+          }
+        })
+        .catch(() => setLoggedIn(false));
+    }
     if (params.get("type") === "problem") {
       setMessage("I would like to report a problem: ");
     }

--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import styles from './Login.module.css';
 import Button from '@/components/Button';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { setLoggedIn } from '@/lib/auth';
 
 interface LoginRequest {
   email: string;
@@ -58,6 +59,7 @@ const LoginClient: FC<Props> = ({ from }) => {
           throw new Error(data.message || 'Login failed');
         }
 
+        setLoggedIn(true);
         router.replace('/');
       } catch (err) {
         if (err instanceof Error) {

--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './Profile.module.css';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { isLoggedIn, setLoggedIn } from '@/lib/auth';
 import VisitorMap from '@/components/VisitorMap';
 
 interface User {
@@ -38,10 +39,21 @@ export default function Profile() {
   const router = useRouter();
 
   useEffect(() => {
+    if (!isLoggedIn()) return;
     apiFetch(API_ROUTES.USERS.ME)
       .then((res) => (res.ok ? res.json() : null))
-      .then((data) => setUser(data))
-      .catch(() => setUser(null));
+      .then((data) => {
+        if (data) {
+          setUser(data);
+          setLoggedIn(true);
+        } else {
+          setLoggedIn(false);
+        }
+      })
+      .catch(() => {
+        setUser(null);
+        setLoggedIn(false);
+      });
 
     apiFetch(API_ROUTES.USERS.ACTIVITY)
       .then((res) => (res.ok ? res.json() : null))

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -3,6 +3,7 @@
 import { useState, FormEvent, useEffect } from 'react';
 import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { isLoggedIn as authLoggedIn, setLoggedIn as setAuthLoggedIn } from '@/lib/auth';
 import styles from './CommentsSection.module.css';
 
 export interface Comment {
@@ -26,13 +27,28 @@ export default function CommentsSection({
   const [error, setError] = useState<string | null>(null);
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [reported, setReported] = useState<Record<string, boolean>>({});
-  const [loggedIn, setLoggedIn] = useState(false);
+  const [loggedIn, setLoggedInState] = useState(false);
   const [loginHref, setLoginHref] = useState('/login');
 
   useEffect(() => {
-    apiFetch(API_ROUTES.USERS.ME)
-      .then((res) => setLoggedIn(res.ok))
-      .catch(() => setLoggedIn(false));
+    if (authLoggedIn()) {
+      apiFetch(API_ROUTES.USERS.ME)
+        .then((res) => {
+          if (res.ok) {
+            setLoggedInState(true);
+            setAuthLoggedIn(true);
+          } else {
+            setLoggedInState(false);
+            setAuthLoggedIn(false);
+          }
+        })
+        .catch(() => {
+          setLoggedInState(false);
+          setAuthLoggedIn(false);
+        });
+    } else {
+      setLoggedInState(false);
+    }
     setLoginHref(
       `/login?returnUrl=${encodeURIComponent(window.location.href + '#comments')}`
     );

--- a/WT4Q/src/components/NotificationBell.tsx
+++ b/WT4Q/src/components/NotificationBell.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import PrefetchLink from "@/components/PrefetchLink";
-import { API_ROUTES } from "@/lib/api";
+import { API_ROUTES, apiFetch } from "@/lib/api";
+import { isLoggedIn, setLoggedIn } from "@/lib/auth";
 import styles from "./NotificationBell.module.css";
 
 interface Notification {
@@ -12,16 +13,24 @@ interface Notification {
 
 export default function NotificationBell() {
   const [unread, setUnread] = useState(0);
+  const [show, setShow] = useState(false);
 
   useEffect(() => {
-    fetch(API_ROUTES.NOTIFICATIONS.GET, { credentials: "include" })
+    if (!isLoggedIn()) return;
+    setShow(true);
+    apiFetch(API_ROUTES.NOTIFICATIONS.GET)
       .then((res) => (res.ok ? res.json() : []))
       .then((data: Notification[]) => {
         const count = data.filter((n) => !n.isRead).length;
         setUnread(count);
       })
-      .catch(() => {});
+      .catch(() => {
+        setShow(false);
+        setLoggedIn(false);
+      });
   }, []);
+
+  if (!show) return null;
 
   return (
     <PrefetchLink href="/notifications" className={styles.bell} aria-label="Notifications">

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -5,6 +5,7 @@ import PrefetchLink from '@/components/PrefetchLink';
 import { useRouter } from 'next/navigation';
 import styles from './UserMenu.module.css';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { isLoggedIn, setLoggedIn } from '@/lib/auth';
 
 interface User {
   id: string;
@@ -18,10 +19,20 @@ export default function UserMenu() {
   const router = useRouter();
 
   useEffect(() => {
+    if (!isLoggedIn()) return;
     apiFetch(API_ROUTES.USERS.ME)
       .then((res) => (res.ok ? res.json() : null))
-      .then((data) => setUser(data))
-      .catch(() => setUser(null));
+      .then((data) => {
+        if (data) {
+          setUser(data);
+        } else {
+          setLoggedIn(false);
+        }
+      })
+      .catch(() => {
+        setUser(null);
+        setLoggedIn(false);
+      });
   }, []);
 
   const initials = user?.userName
@@ -38,6 +49,7 @@ export default function UserMenu() {
       method: 'POST',
     });
     setUser(null);
+    setLoggedIn(false);
     router.refresh();
   };
 


### PR DESCRIPTION
## Summary
- track login state in localStorage via auth helpers
- hide notifications and skip user lookups when not authenticated
- prevent anonymous pages from calling `/api/User/me`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab68887ebc8327b82bdb5f891a7dce