### PR TITLE
Ensure login status derived from cookie

### DIFF
--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -3,7 +3,7 @@
 import { useState, FormEvent, useEffect } from 'react';
 import PrefetchLink from '@/components/PrefetchLink';
 import { API_ROUTES, apiFetch } from '@/lib/api';
-import { isLoggedIn as authLoggedIn, setLoggedIn as setAuthLoggedIn } from '@/lib/auth';
+import { setLoggedIn as setAuthLoggedIn } from '@/lib/auth';
 import styles from './CommentsSection.module.css';
 
 export interface Comment {
@@ -31,24 +31,20 @@ export default function CommentsSection({
   const [loginHref, setLoginHref] = useState('/login');
 
   useEffect(() => {
-    if (authLoggedIn()) {
-      apiFetch(API_ROUTES.USERS.ME)
-        .then((res) => {
-          if (res.ok) {
-            setLoggedInState(true);
-            setAuthLoggedIn(true);
-          } else {
-            setLoggedInState(false);
-            setAuthLoggedIn(false);
-          }
-        })
-        .catch(() => {
+    apiFetch(API_ROUTES.USERS.ME)
+      .then((res) => {
+        if (res.ok) {
+          setLoggedInState(true);
+          setAuthLoggedIn(true);
+        } else {
           setLoggedInState(false);
           setAuthLoggedIn(false);
-        });
-    } else {
-      setLoggedInState(false);
-    }
+        }
+      })
+      .catch(() => {
+        setLoggedInState(false);
+        setAuthLoggedIn(false);
+      });
     setLoginHref(
       `/login?returnUrl=${encodeURIComponent(window.location.href + '#comments')}`
     );

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -5,7 +5,7 @@ import PrefetchLink from '@/components/PrefetchLink';
 import { useRouter } from 'next/navigation';
 import styles from './UserMenu.module.css';
 import { API_ROUTES, apiFetch } from '@/lib/api';
-import { isLoggedIn, setLoggedIn } from '@/lib/auth';
+import { setLoggedIn } from '@/lib/auth';
 
 interface User {
   id: string;
@@ -19,12 +19,12 @@ export default function UserMenu() {
   const router = useRouter();
 
   useEffect(() => {
-    if (!isLoggedIn()) return;
     apiFetch(API_ROUTES.USERS.ME)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data) {
           setUser(data);
+          setLoggedIn(true);
         } else {
           setLoggedIn(false);
         }


### PR DESCRIPTION
## Summary
- Check `/users/me` without relying on localStorage in the user menu
- Fetch current user in comments section to sync login state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab82e426708327b89405892c7940f4