### PR TITLE
fix unused state setter in CommentsSection

### DIFF
--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -31,9 +31,8 @@ export default function CommentsSection({
 
   useEffect(() => {
     apiFetch(API_ROUTES.USERS.ME)
-
-      .then((res) => setLoggedIn(res.ok))
-      .catch(() => setLoggedIn(false));
+      .then((res) => setLoggedInState(res.ok))
+      .catch(() => setLoggedInState(false));
 
     setLoginHref(
       `/login?returnUrl=${encodeURIComponent(window.location.href + '#comments')}`


### PR DESCRIPTION
## Summary
- fix login state setter in CommentsSection to resolve unused variable lint error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab9cb395e8832782cbe76a55635708