### PR TITLE
fix login state handling in CommentsSection and UserMenu

### DIFF
--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -31,9 +31,8 @@ export default function CommentsSection({
 
   useEffect(() => {
     apiFetch(API_ROUTES.USERS.ME)
-
-      .then((res) => setLoggedIn(res.ok))
-      .catch(() => setLoggedIn(false));
+      .then((res) => setLoggedInState(res.ok))
+      .catch(() => setLoggedInState(false));
 
     setLoginHref(
       `/login?returnUrl=${encodeURIComponent(window.location.href + '#comments')}`

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -5,6 +5,7 @@ import PrefetchLink from '@/components/PrefetchLink';
 import { useRouter } from 'next/navigation';
 import styles from './UserMenu.module.css';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { setLoggedIn } from '@/lib/auth';
 
 interface User {
   id: string;


### PR DESCRIPTION
## Summary
- fix login state setter in CommentsSection to resolve unused variable lint error
- import missing setLoggedIn helper in UserMenu to prevent runtime ReferenceError

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab9cb395e8832782cbe76a55635708