### PR TITLE
fix: import setLoggedIn in login client

### DIFF
--- a/WT4Q/src/app/login/LoginClient.tsx
+++ b/WT4Q/src/app/login/LoginClient.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import styles from './Login.module.css';
 import Button from '@/components/Button';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { setLoggedIn } from '@/lib/auth';
 
 interface LoginRequest {
   email: string;


### PR DESCRIPTION
## Summary
- add missing setLoggedIn import in login client to resolve build error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab9f037e2483279768789f53fe9dc3