### PR TITLE
Fix undefined setLoggedIn in profile page

### DIFF
--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './Profile.module.css';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { setLoggedIn } from '@/lib/auth';
 import VisitorMap from '@/components/VisitorMap';
 
 interface User {


### PR DESCRIPTION
## Summary
- import setLoggedIn from auth utilities in profile page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aba4780dc08327910dc282a389146f