### PR TITLE
Gracefully handle world clock API failures

### DIFF
--- a/WT4Q/src/app/tools/world-clock/page.tsx
+++ b/WT4Q/src/app/tools/world-clock/page.tsx
@@ -15,22 +15,34 @@ export const metadata: Metadata = {
 };
 
 async function fetchCity(city: WorldCity): Promise<CityWeather> {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&current_weather=true&timezone=${encodeURIComponent(city.timezone)}`;
-  const res = await fetch(url);
-  const data = await res.json();
   const now = new Intl.DateTimeFormat('en-GB', {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
     timeZone: city.timezone,
   }).format(new Date());
-  return {
-    ...city,
-    time: now,
-    temperature: data.current_weather?.temperature ?? 0,
-    weathercode: data.current_weather?.weathercode ?? 0,
-    is_day: data.current_weather?.is_day ?? 1,
-  };
+
+  try {
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&current_weather=true&timezone=${encodeURIComponent(city.timezone)}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Failed to fetch');
+    const data = await res.json();
+    return {
+      ...city,
+      time: now,
+      temperature: data.current_weather?.temperature ?? 0,
+      weathercode: data.current_weather?.weathercode ?? 0,
+      is_day: data.current_weather?.is_day ?? 1,
+    };
+  } catch {
+    return {
+      ...city,
+      time: now,
+      temperature: 0,
+      weathercode: 0,
+      is_day: 1,
+    };
+  }
 }
 
 export default async function WorldClockPage() {


### PR DESCRIPTION
## Summary
- protect world clock build step from network errors by wrapping API fetches in try/catch and providing default values

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aba5ad61408327b2f2aaf0fd7fdcd5