### PR TITLE
Set auth cookies as SameSite=None

### DIFF
--- a/Northeast/Controllers/AdminController.cs
+++ b/Northeast/Controllers/AdminController.cs
@@ -53,7 +53,7 @@ namespace Northeast.Controllers
             {
                 HttpOnly = true,
                 Secure = true,
-                SameSite = SameSiteMode.Lax,
+                SameSite = SameSiteMode.None,
                 Path = "/",
                 Expires = DateTime.UtcNow.AddMinutes(Convert.ToInt32(_configuration["Jwt:ExpireMinutes"]))
             };
@@ -73,7 +73,7 @@ namespace Northeast.Controllers
                 {
                     HttpOnly = true,
                     Secure = true,
-                    SameSite = SameSiteMode.Lax,
+                    SameSite = SameSiteMode.None,
                     Path = "/"
                 });
             }

--- a/Northeast/Controllers/GoogleSignInController.cs
+++ b/Northeast/Controllers/GoogleSignInController.cs
@@ -93,7 +93,7 @@ namespace Northeast.Controllers
             {
                 HttpOnly = true,
                 Secure = true,
-                SameSite = SameSiteMode.Lax,
+                SameSite = SameSiteMode.None,
                 Path = "/",
                 Expires = DateTime.UtcNow.AddMinutes(
                     Convert.ToInt32(_configuration["Jwt:ExpireMinutes"]))

--- a/Northeast/Controllers/UserAuthController.cs
+++ b/Northeast/Controllers/UserAuthController.cs
@@ -98,7 +98,7 @@ namespace Northeast.Controllers
                 {
                     HttpOnly = true,
                     Secure = secure,
-                    SameSite = SameSiteMode.Lax,
+                    SameSite = SameSiteMode.None,
                     Path = "/",
                     Expires = accessExp
                 };
@@ -106,7 +106,7 @@ namespace Northeast.Controllers
                 {
                     HttpOnly = true,
                     Secure = secure,
-                    SameSite = SameSiteMode.Lax,
+                    SameSite = SameSiteMode.None,
                     Path = "/",
                     Expires = refreshExp
                 };
@@ -153,7 +153,7 @@ namespace Northeast.Controllers
                 HttpOnly = true,
                 Secure = secure,
 
-                SameSite = SameSiteMode.Lax,
+                SameSite = SameSiteMode.None,
                 Path = "/"
             };
             Response.Cookies.Delete("JwtToken", opts);
@@ -211,7 +211,7 @@ namespace Northeast.Controllers
                 HttpOnly = true,
                 Secure = secure,
 
-                SameSite = SameSiteMode.Lax,
+                SameSite = SameSiteMode.None,
                 Path = "/",
                 Expires = idToken.ExpiryDate
             };
@@ -221,7 +221,7 @@ namespace Northeast.Controllers
 
                 Secure = secure,
 
-                SameSite = SameSiteMode.Lax,
+                SameSite = SameSiteMode.None,
                 Path = "/",
                 Expires = newRt.ExpiresAtUtc
             };


### PR DESCRIPTION
## Summary
- ensure auth cookies use `SameSite=None` so tokens are sent with cross-site requests

## Testing
- `dotnet build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abaf7de17c8327a7b2e84809ce6131