### PR TITLE
fix: align login page search param types

### DIFF
--- a/WT4Q/src/app/login/page.tsx
+++ b/WT4Q/src/app/login/page.tsx
@@ -5,10 +5,13 @@ export const metadata = {
   description: 'Sign in to your WT4Q account',
 };
 
-export default function LoginPage({
+type LoginSearchParams = { from?: string };
+
+export default async function LoginPage({
   searchParams,
 }: {
-  searchParams?: { from?: string };
+  searchParams?: Promise<LoginSearchParams>;
 }) {
-  return <LoginClient from={searchParams?.from} />;
+  const params = await searchParams;
+  return <LoginClient from={params?.from} />;
 }


### PR DESCRIPTION
## Summary
- align login page with project-wide PageProps by awaiting `searchParams`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ff206ac8327a8a98fc836f7e108