### PR TITLE
Avoid unauthorized API calls when not logged in

### DIFF
--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -14,6 +14,7 @@ export const API_ROUTES = {
     REGISTER: `${API_BASE_URL}/api/UserRegistration`,
     LOGOUT: `${API_BASE_URL}/api/auth/logout`,
     REFRESH: `${API_BASE_URL}/api/auth/refresh`,
+    SESSION: `${API_BASE_URL}/api/auth/session`,
   },
 
   USERS: {

--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -39,25 +39,32 @@ export default function Profile() {
   const router = useRouter();
 
   useEffect(() => {
-    apiFetch(API_ROUTES.USERS.ME)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) {
-          setUser(data);
-          setLoggedIn(true);
-        } else {
-          setLoggedIn(false);
+    apiFetch(API_ROUTES.AUTH.SESSION, { method: 'GET' })
+      .then((res) => res.json())
+      .then(
+        async (sess: { authenticated: boolean; user?: User }) => {
+          if (sess.authenticated && sess.user) {
+            setUser(sess.user);
+            setLoggedIn(true);
+            try {
+              const activityRes = await apiFetch(API_ROUTES.USERS.ACTIVITY);
+              const act = activityRes.ok ? await activityRes.json() : null;
+              setActivity(act);
+            } catch {
+              setActivity(null);
+            }
+          } else {
+            setUser(null);
+            setLoggedIn(false);
+            setActivity(null);
+          }
         }
-      })
+      )
       .catch(() => {
         setUser(null);
         setLoggedIn(false);
+        setActivity(null);
       });
-
-    apiFetch(API_ROUTES.USERS.ACTIVITY)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => setActivity(data))
-      .catch(() => setActivity(null));
   }, []);
 
   const handleSubmit = async (e: FormEvent) => {

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -30,8 +30,11 @@ export default function CommentsSection({
   const [loginHref, setLoginHref] = useState('/login');
 
   useEffect(() => {
-    apiFetch(API_ROUTES.USERS.ME)
-      .then((res) => setLoggedInState(res.ok))
+    apiFetch(API_ROUTES.AUTH.SESSION, { method: 'GET' })
+      .then((res) => res.json())
+      .then((sess: { authenticated: boolean }) =>
+        setLoggedInState(sess.authenticated)
+      )
       .catch(() => setLoggedInState(false));
 
     setLoginHref(

--- a/WT4Q/src/components/UserMenu.tsx
+++ b/WT4Q/src/components/UserMenu.tsx
@@ -19,20 +19,29 @@ export default function UserMenu() {
   const router = useRouter();
 
   useEffect(() => {
-    apiFetch(API_ROUTES.USERS.ME)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) {
-          setUser(data);
+    let mounted = true;
+
+    apiFetch(API_ROUTES.AUTH.SESSION, { method: 'GET' })
+      .then((res) => res.json())
+      .then((sess: { authenticated: boolean; user?: User }) => {
+        if (!mounted) return;
+        if (sess.authenticated && sess.user) {
+          setUser(sess.user);
           setLoggedIn(true);
         } else {
+          setUser(null);
           setLoggedIn(false);
         }
       })
       .catch(() => {
+        if (!mounted) return;
         setUser(null);
         setLoggedIn(false);
       });
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const initials = user?.userName


### PR DESCRIPTION
## Summary
- Add `/api/auth/session` endpoint that reports cookie-based authentication status without 401s
- Use new session endpoint in UserMenu, profile page, and comments to determine login state
- Register session route in shared API constants

## Testing
- `npm test`
- `npm run lint`
- `dotnet build Northeast/Northeast.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ac3d8fd160832787cd0b791deefa4c