### PR TITLE
feat: add hover preview for article card

### DIFF
--- a/WT4Q/src/components/ArticleCard.module.css
+++ b/WT4Q/src/components/ArticleCard.module.css
@@ -12,6 +12,7 @@
   transform-style: preserve-3d;
   text-decoration: none;
   color: inherit;
+  position: relative;
 }
 
 .card:hover {
@@ -43,6 +44,21 @@
   font-size: 0.75rem;
   color: var(--accent);
   text-decoration: underline;
+}
+
+.preview {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-width: calc(100vw - 2rem);
+  background: var(--background, #fff);
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  z-index: 10;
+  max-height: 50vh;
+  overflow: auto;
 }
 @media(max-width: 1000px){
   .card{

--- a/WT4Q/src/components/ArticleCard.tsx
+++ b/WT4Q/src/components/ArticleCard.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import PrefetchLink from '@/components/PrefetchLink';
 import styles from './ArticleCard.module.css';
 import { truncateWords } from '@/lib/text';
@@ -12,17 +13,50 @@ export interface Article {
 }
 
 export default function ArticleCard({ article }: { article: Article }) {
-  const snippet = truncateWords(article.summary);
+  const [showPreview, setShowPreview] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const snippet = truncateWords(article.summary, 50);
+
+  function startPreview() {
+    timerRef.current = setTimeout(() => setShowPreview(true), 2000);
+  }
+
+  function stopPreview() {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    setShowPreview(false);
+  }
+
   return (
-    <PrefetchLink href={`/articles/${article.slug}`} className={styles.card}>
+    <div
+      className={styles.card}
+      onMouseEnter={startPreview}
+      onMouseLeave={stopPreview}
+      onTouchStart={(e) => {
+        e.preventDefault();
+        startPreview();
+      }}
+      onTouchEnd={stopPreview}
+      onTouchCancel={stopPreview}
+    >
       <h2 className={styles.title}>{article.title}</h2>
-      <p className={styles.summary}>{snippet}</p>
       {typeof article.views === 'number' && (
         <p className={styles.views}>
           {article.views.toLocaleString()} views
         </p>
       )}
-      <span className={styles.readMore}>Read more</span>
-    </PrefetchLink>
+      {showPreview && (
+        <div className={styles.preview}>
+          <p className={styles.summary}>{snippet}</p>
+          <PrefetchLink
+            href={`/articles/${article.slug}`}
+            className={styles.readMore}
+          >
+            Read more
+          </PrefetchLink>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- show article summary preview after 2-second hover or long press
- overlay styling prevents layout shifts and adds a read-more link

## Testing
- `npm --prefix WT4Q test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e6c71008327aa7350413b84e814