### PR TITLE
feat: add hover preview for article card

### DIFF
--- a/WT4Q/src/components/ArticleCard.module.css
+++ b/WT4Q/src/components/ArticleCard.module.css
@@ -12,6 +12,7 @@
   transform-style: preserve-3d;
   text-decoration: none;
   color: inherit;
+  position: relative;
 }
 
 .card:hover {
@@ -43,6 +44,27 @@
   font-size: 0.75rem;
   color: var(--accent);
   text-decoration: underline;
+}
+
+.preview {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  max-width: calc(100vw - 2rem);
+  background: var(--background, #fff);
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  z-index: 10;
+  max-height: 50vh;
+  overflow: auto;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.preview::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
 }
 @media(max-width: 1000px){
   .card{


### PR DESCRIPTION
## Summary
- show article summary preview after 2-second hover or long press
- overlay styling prevents layout shifts and adds a read-more link
- mark article card as client component so React hooks run correctly
- render preview HTML with `dangerouslySetInnerHTML`
- ensure overlay covers the card title and hide preview scrollbars

## Testing
- `npm --prefix WT4Q test`
- `npm --prefix WT4Q run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e6c71008327aa7350413b84e814