### PR TITLE
Fix article reactions and add comment controls

### DIFF
--- a/WT4Q/src/components/CommentsSection.module.css
+++ b/WT4Q/src/components/CommentsSection.module.css
@@ -47,6 +47,54 @@
   gap: 0.5rem;
 }
 
+.menuWrapper {
+  position: relative;
+}
+
+.menuButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  color: var(--ink);
+}
+
+.menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #fff;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+}
+
+.menuItem {
+  display: block;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.menuItem:hover {
+  background: #f0f0f0;
+}
+
+.editForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.editActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .replyButton {
   background: none;
   border: none;

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -28,13 +28,18 @@ export default function CommentsSection({
   const [reported, setReported] = useState<Record<string, boolean>>({});
   const [loggedIn, setLoggedInState] = useState(false);
   const [loginHref, setLoginHref] = useState('/login');
+  const [currentUser, setCurrentUser] = useState<string | null>(null);
+  const [menuOpen, setMenuOpen] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingText, setEditingText] = useState('');
 
   useEffect(() => {
-    apiFetch(API_ROUTES.AUTH.SESSION, { method: 'GET' })
-      .then((res) => res.json())
-      .then((sess: { authenticated: boolean }) =>
-        setLoggedInState(sess.authenticated)
-      )
+    apiFetch(API_ROUTES.USERS.ME, { method: 'GET' })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((user: { userName?: string }) => {
+        setLoggedInState(true);
+        setCurrentUser(user.userName || null);
+      })
       .catch(() => setLoggedInState(false));
 
     setLoginHref(
@@ -101,6 +106,51 @@ export default function CommentsSection({
     }
   };
 
+  const handleEditStart = (c: Comment) => {
+    setEditingId(c.id);
+    setEditingText(c.content);
+    setMenuOpen(null);
+  };
+
+  const handleEditSubmit = async (
+    e: FormEvent<HTMLFormElement>,
+    id: string
+  ) => {
+    e.preventDefault();
+    const trimmed = editingText.trim();
+    if (!trimmed) return;
+    try {
+      const res = await apiFetch(
+        `${API_ROUTES.ARTICLE.MODIFY_COMMENT}?CommentId=${id}&Comment=${encodeURIComponent(trimmed)}`,
+        { method: 'PUT' }
+      );
+      if (res.ok) {
+        setComments((prev) =>
+          prev.map((c) => (c.id === id ? { ...c, content: trimmed } : c))
+        );
+        setEditingId(null);
+        setEditingText('');
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const res = await apiFetch(
+        `${API_ROUTES.ARTICLE.MODIFY_COMMENT}?CommentId=${id}`,
+        { method: 'DELETE' }
+      );
+      if (res.ok) {
+        setComments((prev) => prev.filter((c) => c.id !== id));
+      }
+    } catch {
+      // ignore
+    }
+    setMenuOpen(null);
+  };
+
   return (
     <section id="comments" className={styles.section}>
       <h2 className={styles.heading}>Comments</h2>
@@ -111,9 +161,81 @@ export default function CommentsSection({
           {comments.map((c) => (
             <li key={c.id} className={styles.comment}>
               <span className={styles.commentAuthor}>{c.writer?.userName || 'Anonymous'}:</span>
-              <p className={styles.commentContent}>{c.content}</p>
+              {editingId === c.id ? (
+                <form
+                  onSubmit={(e) => handleEditSubmit(e, c.id)}
+                  className={styles.editForm}
+                >
+                  <textarea
+                    value={editingText}
+                    onChange={(e) => setEditingText(e.target.value)}
+                    rows={3}
+                    required
+                    className={styles.textarea}
+                  />
+                  <div className={styles.editActions}>
+                    <button type="submit" className={styles.button}>
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.button}
+                      onClick={() => {
+                        setEditingId(null);
+                        setEditingText('');
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <p className={styles.commentContent}>{c.content}</p>
+              )}
               <div className={styles.commentActions}>
-                {loggedIn && (
+                {currentUser && currentUser === c.writer?.userName && (
+                  <div className={styles.menuWrapper}>
+                    <button
+                      type="button"
+                      className={styles.menuButton}
+                      onClick={() =>
+                        setMenuOpen(menuOpen === c.id ? null : c.id)
+                      }
+                      aria-label="Comment options"
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 4 16"
+                        fill="currentColor"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle cx="2" cy="2" r="2" />
+                        <circle cx="2" cy="8" r="2" />
+                        <circle cx="2" cy="14" r="2" />
+                      </svg>
+                    </button>
+                    {menuOpen === c.id && (
+                      <div className={styles.menu}>
+                        <button
+                          type="button"
+                          className={styles.menuItem}
+                          onClick={() => handleEditStart(c)}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.menuItem}
+                          onClick={() => handleDelete(c.id)}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+                {loggedIn && editingId !== c.id && (
                   <button
                     type="button"
                     className={styles.replyButton}

--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -27,7 +27,7 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
       const res = await apiFetch(
         API_ROUTES.ARTICLE.LIKE(articleId),
         {
-          method: 'PUT',
+          method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ type }),
         }
@@ -42,25 +42,25 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
       }
       const data = await res.json();
       if (data.message === 'unliked') {
-        if (type === 0) setLikes(likes - 1);
-        else setDislikes(dislikes - 1);
+        if (type === 0) setLikes((l) => l - 1);
+        else setDislikes((d) => d - 1);
         setStatus(null);
       } else if (data.message === 'Like changed') {
         if (type === 0) {
-          setLikes(likes + 1);
-          setDislikes(dislikes - 1);
+          setLikes((l) => l + 1);
+          setDislikes((d) => d - 1);
           setStatus('like');
         } else {
-          setDislikes(dislikes + 1);
-          setLikes(likes - 1);
+          setDislikes((d) => d + 1);
+          setLikes((l) => l - 1);
           setStatus('dislike');
         }
       } else if (data.message === 'Liked') {
         if (type === 0) {
-          setLikes(likes + 1);
+          setLikes((l) => l + 1);
           setStatus('like');
         } else {
-          setDislikes(dislikes + 1);
+          setDislikes((d) => d + 1);
           setStatus('dislike');
         }
       }


### PR DESCRIPTION
## Summary
- use POST and functional updates for article like/dislike requests
- add comment author menu with edit and delete actions
- style dot-menu and edit form

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac6b824780832791ac8636655cbb07