### PR TITLE
Fix like reaction API call

### DIFF
--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -40,7 +40,7 @@ export const API_ROUTES = {
     FILTER: `${API_BASE_URL}/api/ArticleFilter`,
     UPDATE: `${API_BASE_URL}/api/Article`,
     DELETE: `${API_BASE_URL}/api/Article`,
-    LIKE: (id: string) => `${API_BASE_URL}/api/Article/${id}/Like`,
+    LIKE: (id: string) => `${API_BASE_URL}/api/Article/${id}/like`,
     COMMENT: `${API_BASE_URL}/api/Article/Comment`,
     MODIFY_COMMENT: `${API_BASE_URL}/api/Article/ModifyComment`,
     REPORT_COMMENT: `${API_BASE_URL}/api/Article/ReportComment`,

--- a/WT4Q/src/components/ReactionButtons.tsx
+++ b/WT4Q/src/components/ReactionButtons.tsx
@@ -27,7 +27,7 @@ export default function ReactionButtons({ articleId, initialLikes, initialDislik
       const res = await apiFetch(
         API_ROUTES.ARTICLE.LIKE(articleId),
         {
-          method: 'POST',
+          method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ type }),
         }


### PR DESCRIPTION
## Summary
- use correct `/api/Article/{id}/like` endpoint
- send like reactions using PUT instead of POST

## Testing
- `npm test`
- `dotnet test Northeast/Northeast.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ac796cf3e083278409372465aacf9a