### PR TITLE
Fix like flow and comment editing issues

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -18,17 +18,20 @@ namespace Northeast.Controllers
         private readonly LikeRepository _likeRepository;
         private readonly GetConnectedUser _connectedUser;
         private readonly IArticleRecommendationService _recommendations;
+        private readonly CommentRepository _commentRepository;
 
         public ArticleController(
             ArticleServices _articleUpload,
             LikeRepository likeRepository,
             GetConnectedUser connectedUser,
-            IArticleRecommendationService recommendations)
+            IArticleRecommendationService recommendations,
+            CommentRepository commentRepository)
         {
             articleUpload = _articleUpload;
             _likeRepository = likeRepository;
             _connectedUser = connectedUser;
             _recommendations = recommendations;
+            _commentRepository = commentRepository;
         }
 
         [Authorize(Policy = "AdminOnly")]
@@ -263,16 +266,14 @@ namespace Northeast.Controllers
         [HttpPost("ModifyComment")]
         public async Task<IActionResult> ModifyComment(Guid CommentId, string Comment)
         {
-
             if (CommentId == Guid.Empty || Comment == null)
             {
                 return BadRequest(new { message = " Error Occoured while performing task" });
             }
-            var article = await articleUpload.GetArticleByID(CommentId);
-
-            if (article == null)
+            var comment = await _commentRepository.GetByGUId(CommentId);
+            if (comment == null)
             {
-                return NotFound(new { message = "Article doesnot exists" });
+                return NotFound(new { message = "Comment does not exist" });
             }
             await articleUpload.ModifyComment(CommentId, Comment);
 

--- a/Northeast/Data/AppDbContext.cs
+++ b/Northeast/Data/AppDbContext.cs
@@ -70,6 +70,10 @@ namespace Northeast.Data
                 .HasOne(c => c.ParentComment)
                 .WithMany()
                 .HasForeignKey(c => c.ParentCommentId);
+
+            modelBuilder.Entity<LikeEntity>()
+                .HasIndex(l => new { l.UserId, l.ArticleId })
+                .IsUnique();
         }
     }
 }

--- a/Northeast/Models/LikeEntity.cs
+++ b/Northeast/Models/LikeEntity.cs
@@ -7,7 +7,7 @@ namespace Northeast.Models
     {
         [Key]
         [Required]
-        public int Id { get; set; } = new int(); // Primary Key
+        public int Id { get; set; } // Primary Key
         public LikeType Type { get; set; } // Enum for Like, Sad, etc.
 
         [ForeignKey(nameof(User))]

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -134,6 +134,8 @@ builder.Services.AddAuthentication(options =>
     options.Cookie.SecurePolicy = builder.Environment.IsDevelopment()
         ? CookieSecurePolicy.None
         : CookieSecurePolicy.Always;
+    options.Cookie.HttpOnly = true;
+    options.Cookie.Domain = ".wt4q.com";
 
     options.Events = new CookieAuthenticationEvents
     {

--- a/Northeast/Repository/LikeRepository.cs
+++ b/Northeast/Repository/LikeRepository.cs
@@ -12,15 +12,8 @@ namespace Northeast.Repository
             _context = context;
         }
 
-        public async Task<LikeEntity?> GetLikeByUserAndArticle(Guid UserId, Guid ArticleId) {
-            var liked = await UserAlreadyLiked(UserId, ArticleId);
-            if (liked) {
-                var like = await _context.Likes
-       .FirstOrDefaultAsync(l => l.UserId == UserId && l.ArticleId == ArticleId);
-                return like;
-            }
-            return null;
-        }
+        public Task<LikeEntity?> GetLikeByUserAndArticle(Guid userId, Guid articleId) =>
+            _context.Likes.FirstOrDefaultAsync(l => l.UserId == userId && l.ArticleId == articleId);
 
         public async Task<bool> UserAlreadyLiked(Guid userId, Guid articleId)
         {

--- a/Northeast/Services/ArticleUpload.cs
+++ b/Northeast/Services/ArticleUpload.cs
@@ -182,15 +182,15 @@ namespace Northeast.Services
             await SetViewsAsync(results);
             return results;
         }
-        public async Task<LikeEntity> GetLikeByUserAndArticle(Guid ArticleId)
+        public async Task<LikeEntity?> GetLikeByUserAndArticle(Guid articleId)
         {
-           var UserId = _connectedUser.Id;
-            if (UserId == Guid.Empty) {
+            var userId = _connectedUser.Id;
+            if (userId == Guid.Empty)
+            {
                 return null;
             }
-            var like = await _likeRepository.GetLikeByUserAndArticle(UserId,ArticleId);
+            var like = await _likeRepository.GetLikeByUserAndArticle(userId, articleId);
             return like;
-
         }
 
 


### PR DESCRIPTION
## Summary
- Simplify like lookup with nullable return
- Set cookie domain for cross-subdomain auth and enforce unique like entries
- Fix comment editing by validating comment ID instead of article ID

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9bb8d0548327890c9e41e9fc4c01