### PR TITLE
Add category dropdown to navbar

### DIFF
--- a/WT4Q/src/app/category/category.module.css
+++ b/WT4Q/src/app/category/category.module.css
@@ -17,6 +17,17 @@
   gap: 2rem;
 }
 
+.categoryLink {
+  text-decoration: none;
+  color: var(--primary);
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+.categoryLink:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 700px) {
   .grid {
     grid-template-columns: 1fr;

--- a/WT4Q/src/app/category/page.tsx
+++ b/WT4Q/src/app/category/page.tsx
@@ -1,0 +1,26 @@
+import PrefetchLink from '@/components/PrefetchLink';
+import { CATEGORIES } from '@/lib/categories';
+import styles from './category.module.css';
+
+export const metadata = {
+  title: 'Categories - WT4Q',
+};
+
+export default function CategoriesPage() {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Categories</h1>
+      <div className={styles.grid}>
+        {CATEGORIES.map((c) => (
+          <PrefetchLink
+            key={c}
+            href={`/category/${c}`}
+            className={styles.categoryLink}
+          >
+            {c}
+          </PrefetchLink>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -15,16 +15,27 @@ export default function CategoryNavbar({ open, onNavigate }: Props = {}) {
         <HomeIcon className={styles.homeIcon} />
         <span className={styles.homeText}>Home</span>
       </PrefetchLink>
-      {CATEGORIES.map((c) => (
+      <div className={styles.dropdown}>
         <PrefetchLink
-          key={c}
-          href={`/category/${c}`}
+          href="/category"
           className={styles.link}
           onClick={onNavigate}
         >
-          {c}
+          Category
         </PrefetchLink>
-      ))}
+        <div className={styles.dropdownMenu}>
+          {CATEGORIES.map((c) => (
+            <PrefetchLink
+              key={c}
+              href={`/category/${c}`}
+              className={styles.link}
+              onClick={onNavigate}
+            >
+              {c}
+            </PrefetchLink>
+          ))}
+        </div>
+      </div>
       <div className={styles.dropdown}>
         <PrefetchLink href="/tools" className={styles.link} onClick={onNavigate}>
           Tools


### PR DESCRIPTION
## Summary
- Consolidate category links into a single navbar dropdown
- Add Categories index page listing all categories
- Style category links for the new page

## Testing
- `npm test`
- `npm run lint`
- `dotnet test Northeast/Northeast.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ada1e1fce48327b1df087959470adc