### PR TITLE
fix: normalize reaction types to show accurate counts

### DIFF
--- a/Northeast/Models/Like.cs
+++ b/Northeast/Models/Like.cs
@@ -2,11 +2,10 @@
 {
     public enum LikeType
     {
-        Like,
-        Sad, 
-        Dislike,
-        Happy
-        
+        Like = 0,
+        Dislike = 1,
+        Happy = 2,
+        Sad = 3
     }
 
 }

--- a/WT4Q/src/app/articles/[title]/page.tsx
+++ b/WT4Q/src/app/articles/[title]/page.tsx
@@ -9,6 +9,7 @@ import styles from '../article.module.css';
 import type { ArticleImage } from '@/lib/models';
 import PrefetchLink from '@/components/PrefetchLink';
 import LocalArticleSection from '@/components/LocalArticleSection';
+import { reactionNameFromType } from '@/components/ReactionIcon';
 
 /* ---------------------- types ---------------------- */
 
@@ -26,7 +27,7 @@ interface ArticleDetails {
   images?: ArticleImage[];
   embededCode?: string;
   comments?: Comment[];
-  like?: { id: number; type: number }[];
+  like?: { id: number; type: number | string }[];
   views?: number;
   keywords?: string[];
 }
@@ -144,10 +145,11 @@ export default async function ArticlePage(
 
   const related = await fetchRelated(title);
 
-  const likeCount = article.like?.filter((l) => l.type === 0).length ?? 0;
-  const happyCount = article.like?.filter((l) => l.type === 3).length ?? 0;
-  const dislikeCount = article.like?.filter((l) => l.type === 2).length ?? 0;
-  const sadCount = article.like?.filter((l) => l.type === 1).length ?? 0;
+  const counts = { like: 0, happy: 0, dislike: 0, sad: 0 };
+  (article.like ?? []).forEach((l) => {
+    counts[reactionNameFromType(l.type)]++;
+  });
+  const { like: likeCount, happy: happyCount, dislike: dislikeCount, sad: sadCount } = counts;
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
 

--- a/WT4Q/src/app/profile/page.tsx
+++ b/WT4Q/src/app/profile/page.tsx
@@ -23,11 +23,11 @@ interface Activity {
     articleTitle: string;
     content: string;
   }[];
-  likes: {
-    id: number;
-    articleTitle: string;
-    type: number;
-  }[];
+    likes: {
+      id: number;
+      articleTitle: string;
+      type: number | string;
+    }[];
 }
 
 export default function Profile() {

--- a/WT4Q/src/components/ReactionIcon.tsx
+++ b/WT4Q/src/components/ReactionIcon.tsx
@@ -4,20 +4,33 @@ export type ReactionName = 'like' | 'happy' | 'dislike' | 'sad';
 
 export const reactionType: Record<ReactionName, number> = {
   like: 0,
-  happy: 3,
-  dislike: 2,
-  sad: 1,
+  dislike: 1,
+  happy: 2,
+  sad: 3,
 };
 
-export function reactionNameFromType(type: number): ReactionName {
+export function reactionNameFromType(type: number | string): ReactionName {
+  if (typeof type === 'string') {
+    switch (type.toLowerCase()) {
+      case 'like':
+        return 'like';
+      case 'dislike':
+        return 'dislike';
+      case 'happy':
+        return 'happy';
+      case 'sad':
+      default:
+        return 'sad';
+    }
+  }
   switch (type) {
     case 0:
       return 'like';
-    case 3:
-      return 'happy';
-    case 2:
-      return 'dislike';
     case 1:
+      return 'dislike';
+    case 2:
+      return 'happy';
+    case 3:
     default:
       return 'sad';
   }


### PR DESCRIPTION
## Summary
- align backend LikeType enum with consistent numeric IDs
- update ReactionIcon mapping to match new backend order and parse mixed types

## Testing
- `npm test`
- `npm run lint`
- `dotnet test Northeast/Northeast.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ada2cf49a08327af074ec0bc69348c