### PR TITLE
feat: add news sitemap generator

### DIFF
--- a/WT4Q/lib/news-sitemap.ts
+++ b/WT4Q/lib/news-sitemap.ts
@@ -1,0 +1,70 @@
+import { API_ROUTES } from '@/lib/api';
+
+export interface NewsArticle {
+  slug: string;
+  title: string;
+  createdDate: string;
+}
+
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
+const PUBLICATION_NAME = 'WT4Q';
+const LANGUAGE = 'en';
+export const MAX_NEWS_ARTICLES = 1000;
+const MS_48_HOURS = 48 * 60 * 60 * 1000;
+
+export async function fetchRecentArticles(): Promise<NewsArticle[]> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.GET_ALL, { cache: 'no-store' });
+    if (!res.ok) return [];
+    const articles: NewsArticle[] = await res.json();
+    const cutoff = Date.now() - MS_48_HOURS;
+    return articles.filter(a => {
+      const time = new Date(a.createdDate).getTime();
+      return !Number.isNaN(time) && time >= cutoff;
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function chunkArticles<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/[<>&'\"]/g, c => {
+    switch (c) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case "'":
+        return '&apos;';
+      case '"':
+        return '&quot;';
+      default:
+        return c;
+    }
+  });
+}
+
+export function buildNewsXml(articles: NewsArticle[]): string {
+  const items = articles
+    .map(a => {
+      const pubDate = new Date(a.createdDate).toISOString();
+      return `\n  <url>\n    <loc>${SITE_URL}/articles/${a.slug}</loc>\n    <news:news>\n      <news:publication>\n        <news:name>${PUBLICATION_NAME}</news:name>\n        <news:language>${LANGUAGE}</news:language>\n      </news:publication>\n      <news:publication_date>${pubDate}</news:publication_date>\n      <news:title>${escapeXml(a.title)}</news:title>\n    </news:news>\n  </url>`;
+    })
+    .join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">${items}\n</urlset>`;
+}
+
+export function buildNewsIndex(count: number): string {
+  const items = Array.from({ length: count }, (_, i) => `\n  <sitemap>\n    <loc>${SITE_URL}/news-sitemap-${i}.xml</loc>\n  </sitemap>`).join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${items}\n</sitemapindex>`;
+}

--- a/WT4Q/src/app/news-sitemap-[index].xml/route.ts
+++ b/WT4Q/src/app/news-sitemap-[index].xml/route.ts
@@ -1,0 +1,19 @@
+import { chunkArticles, buildNewsXml, fetchRecentArticles, MAX_NEWS_ARTICLES } from '@/lib/news-sitemap';
+
+interface Params { params: { index: string } }
+
+export async function GET(_req: Request, { params }: Params): Promise<Response> {
+  const idx = Number(params.index);
+  if (!Number.isInteger(idx)) {
+    return new Response('Not found', { status: 404 });
+  }
+  const articles = await fetchRecentArticles();
+  const chunks = chunkArticles(articles, MAX_NEWS_ARTICLES);
+  if (idx < 0 || idx >= chunks.length) {
+    return new Response('Not found', { status: 404 });
+  }
+  const body = buildNewsXml(chunks[idx]);
+  return new Response(body, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
+}

--- a/WT4Q/src/app/news-sitemap.xml/route.ts
+++ b/WT4Q/src/app/news-sitemap.xml/route.ts
@@ -1,0 +1,10 @@
+import { chunkArticles, buildNewsXml, buildNewsIndex, fetchRecentArticles, MAX_NEWS_ARTICLES } from '@/lib/news-sitemap';
+
+export async function GET(): Promise<Response> {
+  const articles = await fetchRecentArticles();
+  const chunks = chunkArticles(articles, MAX_NEWS_ARTICLES);
+  const body = chunks.length === 1 ? buildNewsXml(chunks[0]) : buildNewsIndex(chunks.length);
+  return new Response(body, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
+}


### PR DESCRIPTION
## Summary
- add helper to build Google News sitemaps and indexes
- expose `/news-sitemap.xml` and `/news-sitemap-<n>.xml` endpoints

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ada8e7093c832792e359191d7af81a