### PR TITLE
Fix route handler context typing for Next.js 15

### DIFF
--- a/WT4Q/src/app/news-sitemap-[index].xml/route.ts
+++ b/WT4Q/src/app/news-sitemap-[index].xml/route.ts
@@ -1,9 +1,11 @@
 import { chunkArticles, buildNewsXml, fetchRecentArticles, MAX_NEWS_ARTICLES } from '@/lib/news-sitemap';
 
-interface Params { params: { index: string } }
-
-export async function GET(_req: Request, { params }: Params): Promise<Response> {
-  const idx = Number(params.index);
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ index: string }> },
+): Promise<Response> {
+  const { index } = await params;
+  const idx = Number(index);
   if (!Number.isInteger(idx)) {
     return new Response('Not found', { status: 404 });
   }


### PR DESCRIPTION
## Summary
- update news sitemap route to use async params in Next.js 15

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adad51ff9c8327bef0df390d6ae3eb