### PR TITLE
fix: define typing practice theme variables locally

### DIFF
--- a/WT4Q/src/app/tools/typing-practice/TypingPractice.module.css
+++ b/WT4Q/src/app/tools/typing-practice/TypingPractice.module.css
@@ -1,4 +1,4 @@
-:root {
+.main {
   --bg: #c0c8d900;
   --panel: #2b0a86;
   --text: #e5e7eb;
@@ -7,9 +7,6 @@
   --ok: #22c55e;
   --bad: #ef4444;
   --warn: #cd8f25;
-}
-
-.main {
   padding: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- scope CSS custom properties for typing practice to the main container

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1059c24883279dbf5a517321315b