### PR TITLE
fix: align article update endpoint and client

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -146,27 +146,29 @@ namespace Northeast.Controllers
             return Ok(article);
         }
         [Authorize(Policy = "AdminOnly")]
-        [HttpPut]
-        public async Task<IActionResult> EditArticle(Guid Id, ArticleDto Article)
+        [HttpPut("{id:guid}")]
+        public async Task<IActionResult> EditArticle([FromRoute] Guid id, [FromBody] ArticleDto articleDto)
         {
-            if (Id == Guid.Empty)
+            if (id == Guid.Empty)
             {
                 return BadRequest(new { message = "Please enter an Id" });
             }
 
-            if (Article == null)
+            if (articleDto == null)
             {
                 return BadRequest(new { message = "Sorry, there is no ID" });
             }
-            var article = await articleUpload.GetArticleByID(Id);
-            if (article == null)
+
+            var existing = await articleUpload.GetArticleByID(id);
+            if (existing == null)
             {
                 return NotFound(new { message = "Sorry, there is no Articles with this ID" });
             }
             try
             {
-                await articleUpload.ModifyArticle(Id, Article);
-                return Ok(article);
+                await articleUpload.ModifyArticle(id, articleDto);
+                var updated = await articleUpload.GetArticleByID(id);
+                return Ok(updated);
             }
             catch (ArgumentException ex)
             {

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -38,7 +38,7 @@ export const API_ROUTES = {
       `${API_BASE_URL}/api/ArticleSearch?query=${encodeURIComponent(query)}`,
     SEARCH_ADVANCED: `${API_BASE_URL}/api/ArticleSearch/advanced`,
     FILTER: `${API_BASE_URL}/api/ArticleFilter`,
-    UPDATE: `${API_BASE_URL}/api/Article`,
+    UPDATE: (id: string) => `${API_BASE_URL}/api/Article/${id}`,
     DELETE: `${API_BASE_URL}/api/Article`,
     LIKE: (id: string) => `${API_BASE_URL}/api/Article/${id}/like`,
     COMMENT: `${API_BASE_URL}/api/Article/Comment`,

--- a/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
+++ b/WT4Q/src/app/admin/edit/[id]/EditArticleClient.tsx
@@ -137,11 +137,11 @@ export default function EditArticleClient({ id }: { id: string }) {
             .filter((k) => k.length > 0),
         } as Record<string, unknown>;
 
-          const res = await apiFetch(`${API_ROUTES.ARTICLE.UPDATE}?Id=${id}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-          });
+        const res = await apiFetch(API_ROUTES.ARTICLE.UPDATE(id), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
           const data = await res.json().catch(() => ({}));
           if (!res.ok) {
             throw new Error(data.message || 'Failed to update');


### PR DESCRIPTION
## Summary
- make `PUT /api/Article/{id}` accept article updates via route id and return updated article
- adjust Next.js client to call the new update route
- expose update endpoint in API routes helper

## Testing
- `npm test`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68aed28d15c883278bcfdd60b02a5081