### PR TITLE
feat: add IndexNow verification route

### DIFF
--- a/WT4Q/src/app/[indexnowApi].txt/route.ts
+++ b/WT4Q/src/app/[indexnowApi].txt/route.ts
@@ -1,0 +1,12 @@
+export function GET(
+  _req: Request,
+  { params }: { params: { indexnowApi: string } }
+) {
+  const apiKey = process.env.INDEXNOW_API ?? "e37c5166e3b64c0a97d1f5c7a97e4afc";
+  if (params.indexnowApi !== apiKey) {
+    return new Response("Not found", { status: 404 });
+  }
+  return new Response(apiKey, {
+    headers: { "Content-Type": "text/plain" },
+  });
+}


### PR DESCRIPTION
## Summary
- add dynamic `[indexnowApi].txt` route to serve IndexNow verification key
- allow key override through `INDEXNOW_API` environment variable

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af432531888327b2025753aeab4972