### PR TITLE
Fix IndexNow route typing

### DIFF
--- a/WT4Q/next.config.ts
+++ b/WT4Q/next.config.ts
@@ -12,6 +12,15 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
   },
 
+  async rewrites() {
+    return [
+      {
+        source: "/:indexnowApi.txt",
+        destination: "/api/indexnow/:indexnowApi",
+      },
+    ];
+  },
+
   async headers() {
     return [
       // Build assets: cache hard for a year

--- a/WT4Q/src/app/api/indexnow/[indexnowApi]/route.ts
+++ b/WT4Q/src/app/api/indexnow/[indexnowApi]/route.ts
@@ -1,11 +1,14 @@
-export function GET(
+export async function GET(
   _req: Request,
-  { params }: { params: { indexnowApi: string } }
+  context: { params: Promise<{ indexnowApi: string }> }
 ) {
   const apiKey = process.env.INDEXNOW_API ?? "e37c5166e3b64c0a97d1f5c7a97e4afc";
-  if (params.indexnowApi !== apiKey) {
+  const { indexnowApi } = await context.params;
+
+  if (indexnowApi !== apiKey) {
     return new Response("Not found", { status: 404 });
   }
+
   return new Response(apiKey, {
     headers: { "Content-Type": "text/plain" },
   });


### PR DESCRIPTION
## Summary
- fix IndexNow route handler to use promised params
- add rewrite from `/:indexnowApi.txt` to the new handler

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af4d770dcc83278ace49defcc3bcb3