### PR TITLE
Add trending news component and backend API

### DIFF
--- a/Northeast/Controllers/ArticleController.cs
+++ b/Northeast/Controllers/ArticleController.cs
@@ -78,6 +78,17 @@ namespace Northeast.Controllers
             return Ok(articles);
         }
 
+        [HttpGet("trending")]
+        public async Task<IActionResult> GetTrending([FromQuery] int limit = 5)
+        {
+            var articles = await articleUpload.GetTrendingArticles(limit);
+            if (!articles.Any())
+            {
+                return NotFound(new { message = "No trending news available" });
+            }
+            return Ok(articles);
+        }
+
         [HttpGet("{slug}")]
         public async Task<IActionResult> GetBySlug(string slug)
         {

--- a/Northeast/Repository/ArticleRepository.cs
+++ b/Northeast/Repository/ArticleRepository.cs
@@ -213,6 +213,15 @@ namespace Northeast.Repository
                 .ToListAsync();
         }
 
+        public async Task<IEnumerable<Article>> GetTrendingArticles(DateTime cutoff)
+        {
+            return await _context.Articles.AsNoTracking()
+                .Include(a => a.Like)
+                .Include(a => a.Comments)
+                .Where(a => a.CreatedDate >= cutoff)
+                .ToListAsync();
+        }
+
         public async Task<IEnumerable<Article>> GetRecentArticlesUsingProcedure(int limit)
         {
             return await _context.Articles

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -46,6 +46,7 @@ export const API_ROUTES = {
     REPORT_COMMENT: `${API_BASE_URL}/api/Article/ReportComment`,
     SEARCH_BY_AUTHOR: (id: string) => `${API_BASE_URL}/api/ArticleSearch/by-author/${id}`,
     BREAKING: `${API_BASE_URL}/api/Article/breaking`,
+    TRENDING: (limit = 5) => `${API_BASE_URL}/api/Article/trending?limit=${limit}`,
   },
 
   COCKTAIL: {

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -1,7 +1,9 @@
 // app/page.tsx
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import BreakingCenterpiece from '@/components/BreakingCenterpiece';
+import TrendingCenterpiece from '@/components/TrendingCenterpiece';
 import type { BreakingArticle } from '@/components/BreakingNewsSlider';
+import type { TrendingArticle } from '@/components/TrendingNewsSlider';
 import PrefetchLink from '@/components/PrefetchLink';
 import type { ArticleImage } from '@/lib/models';
 import { API_ROUTES } from '@/lib/api';
@@ -59,6 +61,23 @@ async function fetchBreakingNews(): Promise<BreakingArticle[]> {
   }
 }
 
+async function fetchTrendingNews(limit = 5): Promise<TrendingArticle[]> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.TRENDING(limit), { cache: 'no-store' });
+    if (!res.ok) return [];
+    const data = (await res.json()) as Article[];
+    return data.map((a) => ({
+      id: a.id,
+      slug: a.slug,
+      title: a.title,
+      content: a.content,
+      images: a.images as ArticleImage[],
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export default async function Home() {
   const categoriesWithArticles = await Promise.all(
     CATEGORIES.map(async (c) => ({
@@ -67,6 +86,7 @@ export default async function Home() {
     }))
   );
   const breaking = await fetchBreakingNews();
+  const trendingArticles = await fetchTrendingNews();
 
   // Take the first 4 categories for the rails around the centerpiece
   const leftRail = categoriesWithArticles.slice(0, 2);
@@ -149,7 +169,7 @@ export default async function Home() {
         </div>
       </div>
         <div className={styles.centerColumn}>
-          <BreakingCenterpiece articles={breaking} />
+          <TrendingCenterpiece articles={trendingArticles} />
         </div>
       {/* The rest of the sections in rows (keeps vertical barres) */}
       {remainingRows.map((row, i) => (

--- a/WT4Q/src/app/trending/page.module.css
+++ b/WT4Q/src/app/trending/page.module.css
@@ -1,0 +1,22 @@
+.container {
+  padding: 1rem;
+}
+.heading {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.rank {
+  font-weight: bold;
+  font-size: 1.25rem;
+}

--- a/WT4Q/src/app/trending/page.tsx
+++ b/WT4Q/src/app/trending/page.tsx
@@ -1,0 +1,36 @@
+import ArticleCard, { Article } from '@/components/ArticleCard';
+import { API_ROUTES } from '@/lib/api';
+import type { Metadata } from 'next';
+import styles from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'Trending News',
+  alternates: { canonical: '/trending' },
+};
+
+async function fetchTrending(): Promise<Article[]> {
+  try {
+    const res = await fetch(API_ROUTES.ARTICLE.TRENDING(10), { cache: 'no-store' });
+    if (!res.ok) return [];
+    return (await res.json()) as Article[];
+  } catch {
+    return [];
+  }
+}
+
+export default async function TrendingPage() {
+  const articles = await fetchTrending();
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>Top 10 Trending News</h1>
+      <ol className={styles.list}>
+        {articles.map((a, i) => (
+          <li key={a.id} className={styles.item}>
+            <span className={styles.rank}>{`#${i + 1}`}</span>
+            <ArticleCard article={a} />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/WT4Q/src/components/TrendingCenterpiece.tsx
+++ b/WT4Q/src/components/TrendingCenterpiece.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import TrendingNewsSlider, { TrendingArticle } from './TrendingNewsSlider';
+import PrefetchLink from '@/components/PrefetchLink';
+import styles from './BreakingCenterpiece.module.css';
+
+export default function TrendingCenterpiece({
+  articles,
+}: {
+  articles: TrendingArticle[];
+}) {
+  if (!articles || articles.length === 0) return null;
+
+  return (
+    <section className={styles.centerpiece} aria-label="Trending News">
+      <div className={styles.header}>
+        <PrefetchLink href="/trending" className={styles.badge}>
+          Trending News
+        </PrefetchLink>
+      </div>
+
+      <TrendingNewsSlider
+        articles={articles}
+        className={styles.slider}
+        showDetails
+      />
+    </section>
+  );
+}

--- a/WT4Q/src/components/TrendingNewsSlider.module.css
+++ b/WT4Q/src/components/TrendingNewsSlider.module.css
@@ -1,0 +1,115 @@
+.slider {
+  background:#c6bbbb00;
+  color: #0000006d;
+  padding: 0.5rem 0.7rem;
+  margin: 0.2rem 0;
+  border-radius: 4px;
+  text-align: center;
+  position: relative;
+  font-family: "Georgia", "Times New Roman", serif;
+
+}
+
+.item {
+  display: block;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dots {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
+  gap: 0.25rem;
+  
+}
+
+.dot {
+  width: 0.25rem;
+  height: 0.25rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.271);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+  position: absolute;
+}
+
+.active {
+  background: #fff;
+}
+
+.detail {
+  text-align: left;
+}
+
+.detailImage {
+  width: 100%;
+  height: auto;
+}
+
+.detailFigure {
+  margin: 0 0 0.5rem 0;
+}
+
+.detailCaption {
+  font-size: 0.75rem;
+  color: #0c0c0c;
+  text-align: center;
+}
+
+.detailTitle {
+  margin: 0.1rem 0;
+  font-size: x-large;
+  color: black;
+  overflow-wrap: anywhere;
+  
+}
+
+.snippet {
+  margin: 0.5rem 0;
+  font-size: large;
+  overflow-wrap: anywhere;
+}
+
+.readMore {
+  color: var(--ink);
+  font-size: medium;
+  text-decoration: underline;
+}
+
+.rank {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateX(10%);
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.3s;
+  padding: 0 0.25rem;
+  z-index: 1;
+}
+
+.slider:hover .arrow {
+  opacity: 1;
+}
+
+.left {
+  left: 0.25rem;
+}
+
+.right {
+  right: 0.25rem;
+}

--- a/WT4Q/src/components/TrendingNewsSlider.tsx
+++ b/WT4Q/src/components/TrendingNewsSlider.tsx
@@ -1,0 +1,223 @@
+'use client';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import PrefetchLink from '@/components/PrefetchLink';
+import styles from './TrendingNewsSlider.module.css';
+import type { ArticleImage } from '@/lib/models';
+import { stripHtml, truncateWords } from '@/lib/text';
+import { API_ROUTES, apiFetch } from '@/lib/api';
+
+export interface TrendingArticle {
+  id: string;
+  slug: string;
+  title: string;
+  content?: string;
+  images?: ArticleImage[];
+  createdDate?: string;
+  rank?: number;
+}
+
+type Props = {
+  /** If provided (non-empty), component will NOT fetch. */
+  articles?: TrendingArticle[];
+  className?: string;
+  showDetails?: boolean;
+};
+
+const ROTATE_MS = 5000;
+
+export default function TrendingNewsSlider({
+  articles: initialArticles,
+  className,
+  showDetails = false,
+}: Props) {
+  // initialize from props once; if props later become non-empty, we sync via an effect below
+  const [articles, setArticles] = useState<TrendingArticle[]>(() => initialArticles ?? []);
+  const [index, setIndex] = useState(0);
+  const [direction, setDirection] = useState<'next' | 'prev'>('next');
+
+  // prevent duplicate fetch in React 18 dev Strict Mode
+  const fetchedOnceRef = useRef(false);
+  // used for marquee calc
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  // 👇 key: stable boolean, not the array reference
+  const needFetch = useMemo(
+    () => !(initialArticles && initialArticles.length > 0),
+    [initialArticles?.length],
+  );
+
+  const next = () => {
+    if (articles.length < 2) return;
+    setDirection('next');
+    setIndex((i) => (i + 1) % articles.length);
+  };
+
+  const prev = () => {
+    if (articles.length < 2) return;
+    setDirection('prev');
+    setIndex((i) => (i - 1 + articles.length) % articles.length);
+  };
+
+  // If parent later provides articles (SSR/CSR timing), sync them in once.
+  useEffect(() => {
+    if (initialArticles && initialArticles.length > 0) {
+      setArticles(initialArticles);
+      setIndex(0);
+    }
+  }, [initialArticles?.length]);
+
+  // Fetch when we weren't given any articles
+  useEffect(() => {
+    if (!needFetch) return;
+    if (fetchedOnceRef.current) return;
+    fetchedOnceRef.current = true;
+
+    const ac = new AbortController();
+    (async () => {
+      const res = await apiFetch(API_ROUTES.ARTICLE.TRENDING(), {
+        signal: ac.signal,
+        headers: { Accept: 'application/json' },
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        // don’t silently loop on 4xx/5xx
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data: { id: string; slug: string; title: string; createdDate?: string }[] = await res.json();
+      setArticles(
+        data
+          .sort(
+            (a, b) =>
+              new Date(b.createdDate ?? 0).getTime() -
+              new Date(a.createdDate ?? 0).getTime(),
+          )
+          .slice(0, 20)
+          .map((a, i) => ({
+            id: a.id,
+            slug: a.slug,
+            title: a.title,
+            createdDate: a.createdDate,
+            rank: i + 1,
+          })),
+      );
+      setIndex(0);
+    })().catch((err: unknown) => {
+      if (!(err instanceof Error) || err.name !== 'AbortError') {
+        // Optional: keep empty to render null, or set a fallback message article
+        setArticles([]);
+      }
+    });
+
+    return () => ac.abort();
+  }, [needFetch]);
+
+  // Clamp index if list shrinks
+  useEffect(() => {
+    if (index >= articles.length) setIndex(0);
+  }, [articles.length, index]);
+
+  // Auto-rotate only with 2+ items
+  useEffect(() => {
+    if (articles.length < 2) return;
+    const t = setInterval(next, ROTATE_MS);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [articles.length]);
+
+  // Marquee if title overflows
+  useEffect(() => {
+    const el = textRef.current;
+    const container = el?.parentElement as HTMLElement | null;
+    if (!el || !container) return;
+
+    const offset = el.scrollWidth - container.clientWidth;
+    if (offset > 0) {
+      el.style.setProperty('--scroll-distance', `-${offset}px`);
+      el.style.setProperty('--scroll-duration', `${offset / 50}s`); // ~50px/sec
+      el.classList.add(styles.marquee);
+    } else {
+      el.classList.remove(styles.marquee);
+    }
+  }, [index, articles]);
+
+  if (articles.length === 0) return null;
+
+  const current = articles[index];
+  const first = current.images?.[0];
+  const base64 = first?.photo ? `data:image/jpeg;base64,${first.photo}` : undefined;
+  const imageSrc = first?.photoLink || base64;
+  const snippet = current.content ? truncateWords(stripHtml(current.content)) : undefined;
+
+  return (
+    <div className={`${styles.slider} ${className ?? ''}`.trim()}>
+      <button
+        className={`${styles.arrow} ${styles.left}`}
+        onClick={prev}
+        aria-label="Previous article"
+        type="button"
+      >
+        ‹
+      </button>
+
+      <button
+        className={`${styles.arrow} ${styles.right}`}
+        onClick={next}
+        aria-label="Next article"
+        type="button"
+      >
+        ›
+      </button>
+
+      {showDetails ? (
+        <div className={styles.detail}>
+          {imageSrc && (
+            <figure className={styles.detailFigure}>
+              <img
+                src={imageSrc}
+                alt={first?.altText || current.title}
+                className={styles.detailImage}
+                loading="lazy"
+                decoding="async"
+              />
+              {first?.caption && (
+                <figcaption className={styles.detailCaption}>{first.caption}</figcaption>
+              )}
+            </figure>
+          )}
+          {current.rank && (
+            <span className={styles.rank}>{`#${current.rank}`}</span>
+          )}
+          <h3 className={styles.detailTitle}>{current.title}</h3>
+          {snippet && <p className={styles.snippet}>{snippet}</p>}
+          <PrefetchLink href={`/articles/${current.slug}`} className={styles.readMore}>
+            Read more
+          </PrefetchLink>
+        </div>
+      ) : (
+        <div
+          className={`${styles.itemWrapper} ${
+            direction === 'next' ? styles.slideLeft : styles.slideRight
+          }`}
+        >
+          <PrefetchLink href={`/articles/${current.slug}`} className={styles.item}>
+            <span ref={textRef}>{`#${current.rank} ${current.title}`}</span>
+          </PrefetchLink>
+        </div>
+      )}
+
+      {/* <div className={styles.dots} role="tablist" aria-label="Breaking news">
+        {articles.map((_, i) => (
+          <button
+            key={i}
+            type="button"
+            role="tab"
+            aria-selected={i === index}
+            aria-label={`Show item ${i + 1}`}
+            className={`${styles.dot} ${i === index ? styles.active : ''}`}
+            onClick={() => setIndex(i)}
+          />
+        ))}
+      </div>*/}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API and service logic to score trending articles by views, likes and comments
- expose `/api/Article/trending` endpoint
- build frontend Trending News slider, centerpiece and page

## Testing
- `npm run lint`
- `npm test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b047f961a08327aef91cc2e74673cc