### PR TITLE
fix: allow articles to include images

### DIFF
--- a/WT4Q/src/components/ArticleCard.tsx
+++ b/WT4Q/src/components/ArticleCard.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import PrefetchLink from "@/components/PrefetchLink";
 import styles from "./ArticleCard.module.css";
 import { useRouter } from "next/navigation";
+import type { ArticleImage } from "@/lib/models";
 
 /** Replace with your own helper if you already have one */
 function truncateWords(html: string, words: number) {
@@ -21,6 +22,7 @@ export interface Article {
   createdDate?: string;
   views?: number;
   content: string;
+  images?: ArticleImage[];
 }
 
 type FinalPos = {


### PR DESCRIPTION
## Summary
- import ArticleImage type
- add optional images array to Article interface

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b073b2a64c8327886456111e903bd4