### PR TITLE
Pause slider rotation on hover

### DIFF
--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -33,6 +33,7 @@ export default function BreakingNewsSlider({
   const [articles, setArticles] = useState<BreakingArticle[]>(() => initialArticles ?? []);
   const [index, setIndex] = useState(0);
   const [direction, setDirection] = useState<'next' | 'prev'>('next');
+  const [isHovered, setIsHovered] = useState(false);
 
   // prevent duplicate fetch in React 18 dev Strict Mode
   const fetchedOnceRef = useRef(false);
@@ -111,11 +112,11 @@ export default function BreakingNewsSlider({
 
   // Auto-rotate only with 2+ items
   useEffect(() => {
-    if (articles.length < 2) return;
+    if (articles.length < 2 || isHovered) return;
     const t = setInterval(next, ROTATE_MS);
     return () => clearInterval(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [articles.length]);
+  }, [articles.length, isHovered]);
 
   // Marquee if title overflows
   useEffect(() => {
@@ -142,7 +143,11 @@ export default function BreakingNewsSlider({
   const snippet = current.content ? truncateWords(stripHtml(current.content)) : undefined;
 
   return (
-    <div className={`${styles.slider} ${className ?? ''}`.trim()}>
+    <div
+      className={`${styles.slider} ${className ?? ''}`.trim()}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <button
         className={`${styles.arrow} ${styles.left}`}
         onClick={prev}

--- a/WT4Q/src/components/LocalArticleSection.tsx
+++ b/WT4Q/src/components/LocalArticleSection.tsx
@@ -11,6 +11,7 @@ const ROTATE_MS = 5000;
 export default function LocalArticleSection() {
   const [articles, setArticles] = useState<Article[]>([]);
   const [index, setIndex] = useState(0);
+  const [isHovered, setIsHovered] = useState(false);
 
   const next = useCallback(() => {
     if (articles.length < 2) return;
@@ -68,10 +69,10 @@ export default function LocalArticleSection() {
   }, []);
 
   useEffect(() => {
-    if (articles.length < 2) return;
+    if (articles.length < 2 || isHovered) return;
     const t = setInterval(next, ROTATE_MS);
     return () => clearInterval(t);
-  }, [articles.length, next]);
+  }, [articles.length, isHovered, next]);
 
   if (articles.length === 0) return null;
 
@@ -80,7 +81,11 @@ export default function LocalArticleSection() {
   return (
     <section className={styles.container} aria-label="Local news">
       <h2 className={styles.heading}>Local News based on your location</h2>
-      <div className={styles.slider}>
+      <div
+        className={styles.slider}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
         {articles.length > 1 && (
           <>
             <button

--- a/WT4Q/src/components/TrendingNewsSlider.tsx
+++ b/WT4Q/src/components/TrendingNewsSlider.tsx
@@ -34,6 +34,7 @@ export default function TrendingNewsSlider({
   const [articles, setArticles] = useState<TrendingArticle[]>(() => initialArticles ?? []);
   const [index, setIndex] = useState(0);
   const [direction, setDirection] = useState<'next' | 'prev'>('next');
+  const [isHovered, setIsHovered] = useState(false);
 
   // prevent duplicate fetch in React 18 dev Strict Mode
   const fetchedOnceRef = useRef(false);
@@ -118,11 +119,11 @@ export default function TrendingNewsSlider({
 
   // Auto-rotate only with 2+ items
   useEffect(() => {
-    if (articles.length < 2) return;
+    if (articles.length < 2 || isHovered) return;
     const t = setInterval(next, ROTATE_MS);
     return () => clearInterval(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [articles.length]);
+  }, [articles.length, isHovered]);
 
   // Marquee if title overflows
   useEffect(() => {
@@ -149,7 +150,11 @@ export default function TrendingNewsSlider({
   const snippet = current.content ? truncateWords(stripHtml(current.content)) : undefined;
 
   return (
-    <div className={`${styles.slider} ${className ?? ''}`.trim()}>
+    <div
+      className={`${styles.slider} ${className ?? ''}`.trim()}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <button
         className={`${styles.arrow} ${styles.left}`}
         onClick={prev}


### PR DESCRIPTION
## Summary
- Pause auto-rotation in breaking news, trending news, and local article sliders when hovered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08bc9ec6483278e98f3e086145402