### PR TITLE
feat: add structured category page

### DIFF
--- a/WT4Q/src/app/category/[category]/categoryPage.module.css
+++ b/WT4Q/src/app/category/[category]/categoryPage.module.css
@@ -1,0 +1,28 @@
+
+.categoryLabel {
+  font-size: 0.7em; /* 30% smaller */
+}
+
+.horizontalCards {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.dateSection {
+  padding-top: 1rem;
+  border-top: 1px solid var(--thin-rule, #b6b6b6);
+}
+
+.dateHeading {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
+  text-transform: capitalize;
+}
+
+.sectionHeading {
+  font-size: 1.5rem;
+  margin: 1rem 0 0.5rem;
+  text-transform: capitalize;
+}

--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -1,8 +1,10 @@
-import ArticleCard, { Article } from '@/components/ArticleCard';
-import { API_ROUTES } from '@/lib/api';
 import type { Metadata } from 'next';
-import styles from '../category.module.css';
-import LocalArticleSection from '@/components/LocalArticleSection';
+import WeatherWidget from '@/components/WeatherWidget';
+import { API_ROUTES } from '@/lib/api';
+import type { Article } from '@/components/ArticleCard';
+import CategoryArticleCard from '@/components/CategoryArticleCard';
+import baseStyles from '../../page.module.css';
+import styles from './categoryPage.module.css';
 
 async function fetchArticles(cat: string): Promise<Article[]> {
   try {
@@ -15,14 +17,18 @@ async function fetchArticles(cat: string): Promise<Article[]> {
     return data.sort(
       (a, b) =>
         new Date(b.createdDate ?? 0).getTime() -
-        new Date(a.createdDate ?? 0).getTime(),
+        new Date(a.createdDate ?? 0).getTime()
     );
   } catch {
     return [];
   }
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ category: string }> }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ category: string }>;
+}): Promise<Metadata> {
   const { category } = await params;
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || 'https://www.wt4q.com';
@@ -39,6 +45,15 @@ export async function generateMetadata({ params }: { params: Promise<{ category:
   };
 }
 
+function groupByDate(articles: Article[]): Record<string, Article[]> {
+  return articles.reduce((acc, article) => {
+    const d = new Date(article.createdDate ?? 0);
+    const key = d.toDateString();
+    (acc[key] ||= []).push(article);
+    return acc;
+  }, {} as Record<string, Article[]>);
+}
+
 export default async function CategoryPage({
   params,
 }: {
@@ -46,16 +61,70 @@ export default async function CategoryPage({
 }) {
   const { category } = await params;
   const articles = await fetchArticles(category);
-  return (
-    <div className={styles.container}>
 
-      <h1 className={styles.title}>{category}</h1>
-      <div className={styles.grid}>
-        {articles.map((a) => (
-          <ArticleCard key={a.id} article={a} />
-        ))}
-      </div>
-            <LocalArticleSection />
+  const today = new Date();
+  const dateline = today.toLocaleDateString('en-GB', {
+    weekday: 'long',
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const grouped = groupByDate(articles);
+  const todayKey = today.toDateString();
+  const todayArticles = grouped[todayKey] || [];
+  delete grouped[todayKey];
+  const pastDates = Object.keys(grouped).sort(
+    (a, b) => new Date(b).getTime() - new Date(a).getTime()
+  );
+
+  return (
+    <div className={baseStyles.newspaper}>
+      <header className={baseStyles.masthead} aria-label="Site masthead">
+        <div className={baseStyles.mastheadInner}>
+          <div className={baseStyles.brandBlock}>
+            <h1 className={baseStyles.brand}>
+              WT4Q NEWS <span className={styles.categoryLabel}>| {category}</span>
+            </h1>
+            <p className={baseStyles.tagline}>All the News That Matters</p>
+          </div>
+          <div className={baseStyles.dateline}>{dateline}</div>
+          <div className={baseStyles.weather}>
+            <WeatherWidget />
+          </div>
+        </div>
+      </header>
+      <div className={baseStyles.ruleThick} aria-hidden="true" />
+      <div className={baseStyles.ruleThin} aria-hidden="true" />
+
+      {todayArticles.length > 0 && (
+        <section>
+          <h2 className={styles.sectionHeading}>Today&apos;s News</h2>
+          <div className={styles.horizontalCards}>
+            {todayArticles.map((a) => (
+              <CategoryArticleCard key={a.id} article={a} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {pastDates.map((dateStr) => (
+        <section key={dateStr} className={styles.dateSection}>
+          <h2 className={styles.dateHeading}>
+            {new Date(dateStr).toLocaleDateString('en-GB', {
+              weekday: 'long',
+              day: '2-digit',
+              month: 'long',
+              year: 'numeric',
+            })}
+          </h2>
+          <div className={styles.horizontalCards}>
+            {grouped[dateStr].map((a) => (
+              <CategoryArticleCard key={a.id} article={a} />
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/WT4Q/src/components/CategoryArticleCard.module.css
+++ b/WT4Q/src/components/CategoryArticleCard.module.css
@@ -1,0 +1,31 @@
+.card {
+  flex: 0 0 300px;
+  border: 1px solid var(--thin-rule, #b6b6b6);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.title {
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.snippet {
+  flex-grow: 1;
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+  color: var(--muted-ink, #333);
+}
+
+.readMore {
+  font-size: 0.9rem;
+  color: var(--accent, #6a0000);
+  text-decoration: none;
+}
+
+.readMore:hover {
+  text-decoration: underline;
+}

--- a/WT4Q/src/components/CategoryArticleCard.tsx
+++ b/WT4Q/src/components/CategoryArticleCard.tsx
@@ -1,0 +1,28 @@
+import PrefetchLink from '@/components/PrefetchLink';
+import styles from './CategoryArticleCard.module.css';
+import type { Article } from '@/components/ArticleCard';
+
+function truncateWords(html: string, words: number) {
+  const text = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  const parts = text.split(' ');
+  return parts.length <= words ? text : parts.slice(0, words).join(' ') + '…';
+}
+
+export default function CategoryArticleCard({ article }: { article: Article }) {
+  const snippet = truncateWords(article.content || article.summary || '', 30);
+  return (
+    <div className={styles.card}>
+      <h3 className={styles.title}>{article.title}</h3>
+      <p
+        className={styles.snippet}
+        dangerouslySetInnerHTML={{ __html: snippet }}
+      />
+      <PrefetchLink
+        href={`/articles/${article.slug}`}
+        className={styles.readMore}
+      >
+        Read more
+      </PrefetchLink>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build dedicated category article card with snippet and "Read more" link
- style category page masthead and responsive horizontal card list
- group category articles by day for easier browsing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09bf035a48327a2b5d257af212d6e