### PR TITLE
Add backend astrology services and integrate front-end

### DIFF
--- a/Northeast/Controllers/AstrologyController.cs
+++ b/Northeast/Controllers/AstrologyController.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Northeast.Data;
+using Northeast.DTOs;
+using Northeast.Services.Astrology;
+using Northeast.Utilities;
+
+namespace Northeast.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AstrologyController : ControllerBase
+    {
+        private readonly AstrologyService _astrologyService;
+        private readonly AstrologyDispatcher _dispatcher;
+        private readonly AstrologyOptions _options;
+        private readonly GetConnectedUser _connectedUser;
+        private readonly AppDbContext _dbContext;
+        public AstrologyController(
+            AstrologyService astrologyService,
+            AstrologyDispatcher dispatcher,
+            IOptions<AstrologyOptions> options,
+            GetConnectedUser connectedUser,
+            AppDbContext dbContext)
+        {
+            _astrologyService = astrologyService;
+            _dispatcher = dispatcher;
+            _options = options.Value;
+            _connectedUser = connectedUser;
+            _dbContext = dbContext;
+        }
+
+        [HttpGet("today")]
+        public async Task<ActionResult<DailyHoroscopeDto>> GetToday(CancellationToken cancellationToken)
+        {
+            var date = DateOnly.FromDateTime(DateTime.UtcNow);
+            var model = await _astrologyService.GetDailyHoroscopeAsync(date, cancellationToken);
+            var dto = _astrologyService.ToDto(model);
+            return Ok(dto);
+        }
+
+        private async Task<(Guid Id, string Email, string? Name)> RequireUserAsync(CancellationToken cancellationToken)
+        {
+            var userId = _connectedUser.Id;
+            if (userId == Guid.Empty)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            return (user.Id, user.Email, user.UserName);
+        }
+
+        private static AstrologySubscriptionDto ToDto(AstrologySubscription subscription)
+        {
+            var meta = ZodiacCatalogue.Find(subscription.SignId);
+            return new AstrologySubscriptionDto
+            {
+                SignId = subscription.SignId,
+                SignName = meta?.Name,
+                CountryCode = subscription.CountryCode,
+                TimeZone = subscription.TimeZone,
+                SendHour = subscription.SendHour,
+                LastSentLocalDate = subscription.LastSentForDate?.ToString("yyyy-MM-dd"),
+                Active = subscription.Active,
+                UserName = subscription.UserName
+            };
+        }
+
+        [Authorize]
+        [HttpGet("subscription")]
+        public async Task<ActionResult<AstrologySubscriptionDto?>> GetSubscription(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var (id, _, _) = await RequireUserAsync(cancellationToken);
+                var subscription = await _astrologyService.GetSubscriptionAsync(id, cancellationToken);
+                if (subscription == null)
+                {
+                    return Ok(null);
+                }
+
+                return Ok(ToDto(subscription));
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Unauthorized(new { message = "Not logged in" });
+            }
+        }
+
+        [Authorize]
+        [HttpPost("subscription")]
+        public async Task<ActionResult<AstrologySubscriptionDto>> UpsertSubscription(
+            [FromBody] AstrologySubscriptionRequest request,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var (id, email, name) = await RequireUserAsync(cancellationToken);
+
+                if (string.IsNullOrWhiteSpace(request.SignId))
+                {
+                    return BadRequest(new { message = "signId is required" });
+                }
+
+                var sign = ZodiacCatalogue.Find(request.SignId);
+                if (sign == null)
+                {
+                    return BadRequest(new { message = "Unknown zodiac sign" });
+                }
+
+                try
+                {
+                    TimeZoneInfo.FindSystemTimeZoneById(request.TimeZone);
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    return BadRequest(new { message = "Invalid time zone" });
+                }
+                catch (InvalidTimeZoneException)
+                {
+                    return BadRequest(new { message = "Invalid time zone" });
+                }
+
+                var allowedHours = new HashSet<int> { 5, 6 };
+                var sendHour = allowedHours.Contains(request.SendHour) ? request.SendHour : 5;
+
+                var subscription = await _astrologyService.UpsertSubscriptionAsync(
+                    id,
+                    email,
+                    name,
+                    sign.Id,
+                    request.CountryCode,
+                    request.TimeZone,
+                    sendHour,
+                    cancellationToken);
+
+                return Ok(ToDto(subscription));
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Unauthorized(new { message = "Not logged in" });
+            }
+        }
+
+        [Authorize]
+        [HttpDelete("subscription")]
+        public async Task<IActionResult> DeleteSubscription(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var (id, _, _) = await RequireUserAsync(cancellationToken);
+                await _astrologyService.RemoveSubscriptionAsync(id, cancellationToken);
+                return Ok(new { success = true });
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Unauthorized(new { message = "Not logged in" });
+            }
+        }
+
+        [HttpPost("dispatch")]
+        public async Task<ActionResult<AstrologyDispatchReportDto>> Dispatch(CancellationToken cancellationToken)
+        {
+            if (!AuthorizeDispatch(Request))
+            {
+                return Unauthorized(new { message = "Unauthorized" });
+            }
+
+            var report = await _dispatcher.DispatchAsync(cancellationToken);
+            return Ok(report);
+        }
+
+        private bool AuthorizeDispatch(HttpRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(_options.DispatchToken))
+            {
+                return true;
+            }
+
+            var header = request.Headers["Authorization"].FirstOrDefault();
+            if (header == null)
+            {
+                return false;
+            }
+
+            var token = header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                ? header.Substring("Bearer ".Length).Trim()
+                : header.Trim();
+
+            return string.Equals(token, _options.DispatchToken, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Northeast/DTOs/AstrologyDto.cs
+++ b/Northeast/DTOs/AstrologyDto.cs
@@ -1,0 +1,95 @@
+namespace Northeast.DTOs
+{
+    public class HoroscopeOutlookDto
+    {
+        public string General { get; set; } = string.Empty;
+        public string Love { get; set; } = string.Empty;
+        public string Career { get; set; } = string.Empty;
+        public string Wellness { get; set; } = string.Empty;
+    }
+
+    public class HoroscopeRelationsDto
+    {
+        public string People { get; set; } = string.Empty;
+        public string Pets { get; set; } = string.Empty;
+        public string Planets { get; set; } = string.Empty;
+        public string Stars { get; set; } = string.Empty;
+        public string Stones { get; set; } = string.Empty;
+    }
+
+    public class HoroscopeGuidanceDto
+    {
+        public string Ritual { get; set; } = string.Empty;
+        public string Reflection { get; set; } = string.Empty;
+        public string Adventure { get; set; } = string.Empty;
+    }
+
+    public class AstrologySignDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string DateRange { get; set; } = string.Empty;
+        public string Element { get; set; } = string.Empty;
+        public string Modality { get; set; } = string.Empty;
+        public string RulingPlanet { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public string Headline { get; set; } = string.Empty;
+        public string Summary { get; set; } = string.Empty;
+        public string Energy { get; set; } = string.Empty;
+        public HoroscopeOutlookDto Outlook { get; set; } = new();
+        public HoroscopeRelationsDto Relations { get; set; } = new();
+        public HoroscopeGuidanceDto Guidance { get; set; } = new();
+        public string Mood { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+        public string Mantra { get; set; } = string.Empty;
+        public IReadOnlyList<int> LuckyNumbers { get; set; } = Array.Empty<int>();
+    }
+
+    public class DailyHoroscopeDto
+    {
+        public string GeneratedFor { get; set; } = string.Empty;
+        public DateTime GeneratedAt { get; set; }
+
+        public string Summary { get; set; } = string.Empty;
+        public string CosmicWeather { get; set; } = string.Empty;
+        public string LunarPhase { get; set; } = string.Empty;
+        public string Highlight { get; set; } = string.Empty;
+        public IReadOnlyList<AstrologySignDto> Signs { get; set; } = Array.Empty<AstrologySignDto>();
+    }
+
+    public class AstrologySubscriptionDto
+    {
+        public string SignId { get; set; } = string.Empty;
+        public string? SignName { get; set; }
+        public string? CountryCode { get; set; }
+        public string TimeZone { get; set; } = "UTC";
+        public int SendHour { get; set; }
+        public string? LastSentLocalDate { get; set; }
+        public bool Active { get; set; }
+        public string? UserName { get; set; }
+    }
+
+    public class AstrologySubscriptionRequest
+    {
+        public string SignId { get; set; } = string.Empty;
+        public string? CountryCode { get; set; }
+        public string TimeZone { get; set; } = "UTC";
+        public int SendHour { get; set; } = 5;
+    }
+
+    public class AstrologyDispatchReportDto
+    {
+        public int Sent { get; set; }
+        public int Attempted { get; set; }
+        public int Skipped { get; set; }
+        public int Pending { get; set; }
+        public List<AstrologyDispatchDetailDto> Detail { get; set; } = new();
+    }
+
+    public class AstrologyDispatchDetailDto
+    {
+        public string Email { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string? Reason { get; set; }
+    }
+}

--- a/Northeast/Data/AppDbContext.cs
+++ b/Northeast/Data/AppDbContext.cs
@@ -32,6 +32,9 @@ namespace Northeast.Data
         public DbSet<PageVisit> PageVisits { get; set; }
         public DbSet<Notification> Notifications { get; set; }
         public DbSet<CommentReport> CommentReports { get; set; }
+        public DbSet<AstrologyHoroscope> AstrologyHoroscopes { get; set; }
+        public DbSet<AstrologySignForecast> AstrologySignForecasts { get; set; }
+        public DbSet<AstrologySubscription> AstrologySubscriptions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -74,6 +77,28 @@ namespace Northeast.Data
             modelBuilder.Entity<LikeEntity>()
                 .HasIndex(l => new { l.UserId, l.ArticleId })
                 .IsUnique();
+
+            modelBuilder.Entity<AstrologyHoroscope>(b =>
+            {
+                b.HasMany(h => h.Signs)
+                    .WithOne(s => s.Horoscope)
+                    .HasForeignKey(s => s.HoroscopeId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                b.Navigation(h => h.Signs).AutoInclude();
+            });
+
+            modelBuilder.Entity<AstrologySignForecast>(b =>
+            {
+                b.Property(s => s.LuckyNumbers)
+                    .HasColumnType("integer[]");
+            });
+
+            modelBuilder.Entity<AstrologySubscription>(b =>
+            {
+                b.Property(s => s.SendHour).HasDefaultValue(5);
+                b.Property(s => s.Active).HasDefaultValue(true);
+            });
         }
     }
 }

--- a/Northeast/Migrations/20241215000100_AddAstrologyFeatures.Designer.cs
+++ b/Northeast/Migrations/20241215000100_AddAstrologyFeatures.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Northeast.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Northeast.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241215000100_AddAstrologyFeatures")]
+    partial class AddAstrologyFeatures
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Northeast/Migrations/20241215000100_AddAstrologyFeatures.cs
+++ b/Northeast/Migrations/20241215000100_AddAstrologyFeatures.cs
@@ -1,0 +1,132 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Northeast.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAstrologyFeatures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AstrologyHoroscopes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ForDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    GeneratedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Summary = table.Column<string>(type: "text", nullable: false),
+                    CosmicWeather = table.Column<string>(type: "text", nullable: false),
+                    LunarPhase = table.Column<string>(type: "text", nullable: false),
+                    Highlight = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AstrologyHoroscopes", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AstrologySubscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Email = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: false),
+                    UserName = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: true),
+                    SignId = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CountryCode = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: true),
+                    TimeZone = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                    SendHour = table.Column<int>(type: "integer", nullable: false, defaultValue: 5),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastSentForDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    Active = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AstrologySubscriptions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AstrologySignForecasts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    HoroscopeId = table.Column<int>(type: "integer", nullable: false),
+                    SignId = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Headline = table.Column<string>(type: "text", nullable: false),
+                    Summary = table.Column<string>(type: "text", nullable: false),
+                    Energy = table.Column<string>(type: "text", nullable: false),
+                    OutlookGeneral = table.Column<string>(type: "text", nullable: false),
+                    OutlookLove = table.Column<string>(type: "text", nullable: false),
+                    OutlookCareer = table.Column<string>(type: "text", nullable: false),
+                    OutlookWellness = table.Column<string>(type: "text", nullable: false),
+                    RelationsPeople = table.Column<string>(type: "text", nullable: false),
+                    RelationsPets = table.Column<string>(type: "text", nullable: false),
+                    RelationsPlanets = table.Column<string>(type: "text", nullable: false),
+                    RelationsStars = table.Column<string>(type: "text", nullable: false),
+                    RelationsStones = table.Column<string>(type: "text", nullable: false),
+                    GuidanceRitual = table.Column<string>(type: "text", nullable: false),
+                    GuidanceReflection = table.Column<string>(type: "text", nullable: false),
+                    GuidanceAdventure = table.Column<string>(type: "text", nullable: false),
+                    Mood = table.Column<string>(type: "text", nullable: false),
+                    Color = table.Column<string>(type: "text", nullable: false),
+                    Mantra = table.Column<string>(type: "text", nullable: false),
+                    LuckyNumbers = table.Column<int[]>(type: "integer[]", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AstrologySignForecasts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AstrologySignForecasts_AstrologyHoroscopes_HoroscopeId",
+                        column: x => x.HoroscopeId,
+                        principalTable: "AstrologyHoroscopes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AstrologyHoroscopes_ForDate",
+                table: "AstrologyHoroscopes",
+                column: "ForDate",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AstrologySignForecasts_HoroscopeId_SignId",
+                table: "AstrologySignForecasts",
+                columns: new[] { "HoroscopeId", "SignId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AstrologySubscriptions_Email",
+                table: "AstrologySubscriptions",
+                column: "Email");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AstrologySubscriptions_UserId",
+                table: "AstrologySubscriptions",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AstrologySignForecasts");
+
+            migrationBuilder.DropTable(
+                name: "AstrologySubscriptions");
+
+            migrationBuilder.DropTable(
+                name: "AstrologyHoroscopes");
+        }
+    }
+}

--- a/Northeast/Models/AstrologyHoroscope.cs
+++ b/Northeast/Models/AstrologyHoroscope.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Northeast.Models
+{
+    [Index(nameof(ForDate), IsUnique = true)]
+    public class AstrologyHoroscope
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public DateOnly ForDate { get; set; }
+
+        public DateTime GeneratedAtUtc { get; set; }
+
+        [Required]
+        public string Summary { get; set; } = string.Empty;
+
+        [Required]
+        public string CosmicWeather { get; set; } = string.Empty;
+
+        [Required]
+        public string LunarPhase { get; set; } = string.Empty;
+
+        [Required]
+        public string Highlight { get; set; } = string.Empty;
+
+        public ICollection<AstrologySignForecast> Signs { get; set; } = new List<AstrologySignForecast>();
+    }
+}

--- a/Northeast/Models/AstrologySignForecast.cs
+++ b/Northeast/Models/AstrologySignForecast.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Northeast.Models
+{
+    [Index(nameof(HoroscopeId), nameof(SignId), IsUnique = true)]
+    public class AstrologySignForecast
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int HoroscopeId { get; set; }
+
+        public AstrologyHoroscope Horoscope { get; set; } = null!;
+
+        [Required]
+        [MaxLength(32)]
+        public string SignId { get; set; } = string.Empty;
+
+        [Required]
+        public string Headline { get; set; } = string.Empty;
+
+        [Required]
+        public string Summary { get; set; } = string.Empty;
+
+        [Required]
+        public string Energy { get; set; } = string.Empty;
+
+        [Required]
+        public string OutlookGeneral { get; set; } = string.Empty;
+
+        [Required]
+        public string OutlookLove { get; set; } = string.Empty;
+
+        [Required]
+        public string OutlookCareer { get; set; } = string.Empty;
+
+        [Required]
+        public string OutlookWellness { get; set; } = string.Empty;
+
+        [Required]
+        public string RelationsPeople { get; set; } = string.Empty;
+
+        [Required]
+        public string RelationsPets { get; set; } = string.Empty;
+
+        [Required]
+        public string RelationsPlanets { get; set; } = string.Empty;
+
+        [Required]
+        public string RelationsStars { get; set; } = string.Empty;
+
+        [Required]
+        public string RelationsStones { get; set; } = string.Empty;
+
+        [Required]
+        public string GuidanceRitual { get; set; } = string.Empty;
+
+        [Required]
+        public string GuidanceReflection { get; set; } = string.Empty;
+
+        [Required]
+        public string GuidanceAdventure { get; set; } = string.Empty;
+
+        [Required]
+        public string Mood { get; set; } = string.Empty;
+
+        [Required]
+        public string Color { get; set; } = string.Empty;
+
+        [Required]
+        public string Mantra { get; set; } = string.Empty;
+
+        public int[] LuckyNumbers { get; set; } = Array.Empty<int>();
+    }
+}

--- a/Northeast/Models/AstrologySubscription.cs
+++ b/Northeast/Models/AstrologySubscription.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Northeast.Models
+{
+    [Index(nameof(UserId), IsUnique = true)]
+    [Index(nameof(Email))]
+    public class AstrologySubscription
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public Guid UserId { get; set; }
+
+        [Required]
+        [MaxLength(320)]
+        public string Email { get; set; } = string.Empty;
+
+        [MaxLength(160)]
+        public string? UserName { get; set; }
+
+        [Required]
+        [MaxLength(32)]
+        public string SignId { get; set; } = string.Empty;
+
+        [MaxLength(8)]
+        public string? CountryCode { get; set; }
+
+        [Required]
+        [MaxLength(120)]
+        public string TimeZone { get; set; } = "UTC";
+
+        public int SendHour { get; set; } = 5;
+
+        public DateTime CreatedAtUtc { get; set; }
+
+        public DateTime UpdatedAtUtc { get; set; }
+
+        public DateOnly? LastSentForDate { get; set; }
+
+        public bool Active { get; set; } = true;
+    }
+}

--- a/Northeast/Program.cs
+++ b/Northeast/Program.cs
@@ -14,6 +14,7 @@ using Northeast.Options;
 using Northeast.Repository;
 using Northeast.Services;
 using Northeast.Services.Similarity;
+using Northeast.Services.Astrology;
 using Northeast.Utilities;
 using Polly.Timeout;                        // ✅ Polly timeout
 
@@ -77,6 +78,28 @@ builder.Services.AddScoped<CommentReportRepository>();
 builder.Services.AddScoped<ITokenizationService, TokenizationService>();
 builder.Services.AddScoped<ISimilarityService, SimilarityService>();
 builder.Services.AddScoped<IArticleRecommendationService, ArticleRecommendationService>();
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddOptions<AstrologyOptions>()
+    .Bind(builder.Configuration.GetSection("Astrology"))
+    .PostConfigure(options =>
+    {
+        if (string.IsNullOrWhiteSpace(options.ApiKey))
+        {
+            options.ApiKey = builder.Configuration["Astrology:ApiKey"]
+                ?? Environment.GetEnvironmentVariable("Astrology__ApiKey")
+                ?? Environment.GetEnvironmentVariable("GEMINI_API_KEY")
+                ?? string.Empty;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Model))
+        {
+            options.Model = "gemini-1.5-flash";
+        }
+    });
+builder.Services.AddHttpClient<GeminiAstrologyClient>();
+builder.Services.AddScoped<AstrologyService>();
+builder.Services.AddScoped<AstrologyDispatcher>();
+builder.Services.AddHostedService<AstrologyEmailBackgroundService>();
 
 // --- HTTP clients with resilience (named "default") ---
 builder.Services.AddHttpClient("default")

--- a/Northeast/Services/Astrology/AstrologyDispatcher.cs
+++ b/Northeast/Services/Astrology/AstrologyDispatcher.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Northeast.DTOs;
+using Northeast.Models;
+using Northeast.Services;
+
+namespace Northeast.Services.Astrology
+{
+    public class AstrologyDispatcher
+    {
+        private readonly AstrologyService _astrologyService;
+        private readonly SendEmail _mailer;
+        private readonly ILogger<AstrologyDispatcher> _logger;
+        private readonly TimeProvider _timeProvider;
+
+        public AstrologyDispatcher(
+            AstrologyService astrologyService,
+            SendEmail mailer,
+            ILogger<AstrologyDispatcher> logger,
+            TimeProvider timeProvider)
+        {
+            _astrologyService = astrologyService;
+            _mailer = mailer;
+            _logger = logger;
+            _timeProvider = timeProvider;
+        }
+
+        private static string FormatLuckyNumbers(IEnumerable<int> numbers) =>
+            string.Join(", ", numbers);
+
+        private static string BuildEmailBody(
+            DailyHoroscopeModel daily,
+            SignHoroscopeModel sign,
+            AstrologySubscription subscription)
+        {
+            var dateText = daily.ForDate.ToString("MMMM dd, yyyy", CultureInfo.InvariantCulture);
+            var greeting = string.IsNullOrWhiteSpace(subscription.UserName)
+                ? "Hello"
+                : $"Hello {subscription.UserName}";
+
+            var builder = new StringBuilder();
+            builder.Append("<div style=\"font-family:'Segoe UI',Arial,sans-serif;color:#1f2933;line-height:1.6;padding:16px;\">");
+            builder.AppendFormat("<p style=\"margin-top:0;\">{0},</p>", greeting);
+            builder.AppendFormat(
+                "<p style=\"margin:0 0 16px 0;\">Your <strong>{0}</strong> horoscope for <strong>{1}</strong> is ready. We generated today’s guidance at 00:00 GMT using Gemini and layered it with The Nineties Times fallback wisdom.</p>",
+                sign.Name,
+                dateText);
+
+            builder.Append("<div style=\"margin:24px 0;\">");
+            builder.Append("<h2 style=\"font-size:18px;color:#111827;margin-bottom:8px;\">Cosmic Weather</h2>");
+            builder.AppendFormat("<p style=\"margin:0 0 12px 0;\">{0}</p>", daily.CosmicWeather);
+            builder.Append("<h3 style=\"font-size:16px;color:#111827;margin:16px 0 8px 0;\">Lunar Pulse</h3>");
+            builder.AppendFormat("<p style=\"margin:0 0 12px 0;\">{0}</p>", daily.LunarPhase);
+            builder.Append("<h3 style=\"font-size:16px;color:#111827;margin:16px 0 8px 0;\">Highlight</h3>");
+            builder.AppendFormat("<p style=\"margin:0;\">{0}</p>", daily.Highlight);
+            builder.Append("</div>");
+
+            builder.Append("<div style=\"border-top:1px solid #e5e7eb;margin:24px 0;padding-top:24px;\">");
+            builder.AppendFormat(
+                "<h2 style=\"font-size:20px;color:#111827;margin:0 0 12px 0;\">{0} • {1}</h2>",
+                sign.Name,
+                sign.DateRange);
+            builder.AppendFormat(
+                "<p style=\"margin:0 0 16px 0;\"><em>{0}</em></p>",
+                sign.Mantra);
+            builder.AppendFormat(
+                "<p style=\"margin:0 0 16px 0;\">{0}</p>",
+                sign.Summary);
+
+            builder.Append("<table style=\"width:100%;border-collapse:collapse;margin:16px 0;\"><tbody>");
+            builder.Append("<tr>");
+            builder.AppendFormat(
+                "<td style=\"padding:8px;background:#f3f4f6;\"><strong>Mood</strong><br />{0}</td>",
+                sign.Mood);
+            builder.AppendFormat(
+                "<td style=\"padding:8px;background:#f9fafb;\"><strong>Aura Color</strong><br />{0}</td>",
+                sign.Color);
+            builder.AppendFormat(
+                "<td style=\"padding:8px;background:#f3f4f6;\"><strong>Lucky Numbers</strong><br />{0}</td>",
+                FormatLuckyNumbers(sign.LuckyNumbers));
+            builder.Append("</tr></tbody></table>");
+
+            builder.Append("<div style=\"margin:16px 0;\">");
+            builder.Append("<h3 style=\"font-size:16px;color:#111827;margin:16px 0 8px 0;\">Outlook</h3>");
+            builder.AppendFormat("<p style=\"margin:0 0 12px 0;\"><strong>General:</strong> {0}</p>", sign.Outlook.General);
+            builder.AppendFormat("<p style=\"margin:0 0 12px 0;\"><strong>Love:</strong> {0}</p>", sign.Outlook.Love);
+            builder.AppendFormat("<p style=\"margin:0 0 12px 0;\"><strong>Career:</strong> {0}</p>", sign.Outlook.Career);
+            builder.AppendFormat("<p style=\"margin:0 0 12px 0;\"><strong>Wellness:</strong> {0}</p>", sign.Outlook.Wellness);
+
+            builder.Append("<h3 style=\"font-size:16px;color:#111827;margin:16px 0 8px 0;\">Relational Constellations</h3>");
+            builder.Append("<ul style=\"margin:0 0 16px 16px;padding:0;\">");
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>People:</strong> {0}</li>", sign.Relations.People);
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Pets:</strong> {0}</li>", sign.Relations.Pets);
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Stars:</strong> {0}</li>", sign.Relations.Stars);
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Planets:</strong> {0}</li>", sign.Relations.Planets);
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Stones:</strong> {0}</li>", sign.Relations.Stones);
+            builder.Append("</ul>");
+
+            builder.Append("<h3 style=\"font-size:16px;color:#111827;margin:16px 0 8px 0;\">Guided Rituals</h3>");
+            builder.Append("<ul style=\"margin:0 0 16px 16px;padding:0;\">");
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Morning ritual:</strong> {0}</li>", sign.Guidance.Ritual);
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Reflection:</strong> {0}</li>", sign.Guidance.Reflection);
+            builder.AppendFormat("<li style=\"margin-bottom:8px;\"><strong>Adventure:</strong> {0}</li>", sign.Guidance.Adventure);
+            builder.Append("</ul>");
+            builder.Append("</div>");
+            builder.Append("</div>");
+
+            builder.Append("<p style=\"font-size:13px;color:#6b7280;margin-top:24px;\">You are receiving this email because you opted into daily horoscopes on 90stimes.com. Update your preferences or unsubscribe from your account settings at any time.</p>");
+            builder.Append("</div>");
+
+            return builder.ToString();
+        }
+
+        public async Task<AstrologyDispatchReportDto> DispatchAsync(CancellationToken cancellationToken)
+        {
+            var report = new AstrologyDispatchReportDto();
+            var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+            var forDate = DateOnly.FromDateTime(utcNow);
+
+            var horoscope = await _astrologyService.GetDailyHoroscopeAsync(forDate, cancellationToken);
+            var due = await _astrologyService.GetDueSubscriptionsAsync(utcNow, horoscope.ForDate, cancellationToken);
+
+            report.Pending = due.Count;
+
+            foreach (var subscription in due)
+            {
+                var detail = new AstrologyDispatchDetailDto
+                {
+                    Email = subscription.Email
+                };
+
+                try
+                {
+                    var sign = horoscope.Signs.FirstOrDefault(s =>
+                        string.Equals(s.Id, subscription.SignId, StringComparison.OrdinalIgnoreCase));
+
+                    if (sign == null)
+                    {
+                        detail.Status = "skipped";
+                        detail.Reason = "Sign not available";
+                        report.Skipped++;
+                        report.Detail.Add(detail);
+                        continue;
+                    }
+
+                    var subject = $"{sign.Name} Horoscope • {horoscope.ForDate:MMMM dd}";
+                    var body = BuildEmailBody(horoscope, sign, subscription);
+                    await _mailer.SendPersonalizedEmail(subscription.Email, subject, body);
+                    await _astrologyService.MarkDeliveredAsync(subscription, horoscope.ForDate, cancellationToken);
+
+                    detail.Status = "sent";
+                    report.Sent++;
+                }
+                catch (Exception ex)
+                {
+                    detail.Status = "skipped";
+                    detail.Reason = ex.Message;
+                    report.Skipped++;
+                    _logger.LogError(ex, "Failed to send horoscope email to {Email}", subscription.Email);
+                }
+
+                report.Attempted++;
+                report.Detail.Add(detail);
+            }
+
+            return report;
+        }
+    }
+}

--- a/Northeast/Services/Astrology/AstrologyEmailBackgroundService.cs
+++ b/Northeast/Services/Astrology/AstrologyEmailBackgroundService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Northeast.Services.Astrology
+{
+    public class AstrologyEmailBackgroundService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<AstrologyEmailBackgroundService> _logger;
+        private readonly TimeSpan _interval;
+
+        public AstrologyEmailBackgroundService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<AstrologyEmailBackgroundService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+            _interval = TimeSpan.FromMinutes(5);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("Astrology email dispatcher started.");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var dispatcher = scope.ServiceProvider.GetRequiredService<AstrologyDispatcher>();
+                    await dispatcher.DispatchAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Astrology email dispatch tick failed.");
+                }
+
+                try
+                {
+                    await Task.Delay(_interval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+
+            _logger.LogInformation("Astrology email dispatcher stopping.");
+        }
+    }
+}

--- a/Northeast/Services/Astrology/AstrologyFallbackBuilder.cs
+++ b/Northeast/Services/Astrology/AstrologyFallbackBuilder.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Northeast.Services.Astrology
+{
+    internal static class AstrologyFallbackBuilder
+    {
+        private static readonly string[] EnergyWords =
+        {
+            "Magnetic momentum",
+            "Steady resonance",
+            "Curious cadence",
+            "Heart-led tide",
+            "Solar flourish",
+            "Mindful craftsmanship",
+            "Balanced breeze",
+            "Alchemical depth",
+            "Vision quest",
+            "Mountain stride",
+            "Future-forward spark",
+            "Dreamstream glow"
+        };
+
+        private static readonly string[] Moods =
+        {
+            "Trailblazing",
+            "Comfort-craving",
+            "Story weaving",
+            "Sentimental",
+            "Spotlight-ready",
+            "Solution seeking",
+            "Graceful",
+            "Devoted",
+            "Expansive",
+            "Strategic",
+            "Inventive",
+            "Ethereal"
+        };
+
+        private static readonly string[] Colors =
+        {
+            "Crimson ember",
+            "Verdant moss",
+            "Skyline silver",
+            "Moonlit pearl",
+            "Golden flare",
+            "Sage parchment",
+            "Rose quartz",
+            "Noir garnet",
+            "Cobalt horizon",
+            "Granite slate",
+            "Electric aqua",
+            "Seafoam opal"
+        };
+
+        private static string FormatDate(DateOnly date)
+        {
+            var dt = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+            return dt.ToString("dddd, MMMM d, yyyy", CultureInfo.InvariantCulture);
+        }
+
+        private static (string summary, string weather, string lunar, string highlight) BuildSummary(DateOnly date)
+        {
+            var prettyDate = FormatDate(date);
+            return (
+                $"Celestial currents for {prettyDate} emphasise intentional presence. Temper the pace, invite reflection, and let conversations with the cosmos refine your plans.",
+                "Planetary harmonics layer fire and water signatures, asking us to blend conviction with compassion in our everyday exchanges.",
+                "The Moon sketches a gentle trine with Saturn, rewarding steady rituals and systems that honour both body and intuition.",
+                "Small acts of care ripple far today—attend to your relationships with the same reverence you give your ambitions."
+            );
+        }
+
+        private static List<int> LuckyNumbersFor(int index, int seed)
+        {
+            var numbers = new HashSet<int>();
+            var value = seed + index * 11;
+            while (numbers.Count < 5)
+            {
+                value = (value * 17 + 13) % 89;
+                numbers.Add((value % 53) + 1);
+            }
+
+            return numbers.OrderBy(n => n).ToList();
+        }
+
+        private static string GeneralOutlook(string signName, IReadOnlyList<string> keywords)
+        {
+            var flavour = keywords.Count > 0 ? keywords[0] : "innate";
+            return $"{signName}, your {flavour} instincts tune into the collective pulse today. Notice where a single bold move can align your personal rhythm with the wider world.";
+        }
+
+        private static string LoveOutlook(string element, string rulingPlanet)
+        {
+            return $"Lead with your {element.ToLowerInvariant()} heart. Conversations under {rulingPlanet} guidance open a window for tenderness—share a vulnerability to strengthen trust.";
+        }
+
+        private static string CareerOutlook(string modality, IReadOnlyList<string> keywords)
+        {
+            var focus = keywords.Count > 1 ? keywords[1] : "dedicated";
+            return $"{modality} momentum supports professional pivots. Translate your {focus} thinking into a tangible milestone and celebrate incremental progress.";
+        }
+
+        private static string WellnessOutlook(string element, IReadOnlyList<string> keywords)
+        {
+            var cue = keywords.Count > 2 ? keywords[2] : "grounded";
+            return $"Anchor the day with a {element.ToLowerInvariant()} ritual—a mindful walk, nourishing meal, or breathing practice keeps your {cue} energy replenished.";
+        }
+
+        private static string PeopleRelations(string signName)
+        {
+            return $"A trusted ally seeks your perspective. Co-create plans and let mutual inspiration remind you why collaboration with {signName} at the helm sparks magic.";
+        }
+
+        private static string PetRelations(string element)
+        {
+            return $"Animal companions mirror your mood; offer play or quiet cuddles according to the {element.ToLowerInvariant()} tone you’re setting.";
+        }
+
+        private static string PlanetRelations(string rulingPlanet)
+        {
+            return $"{rulingPlanet} whispers about timing—listen for intuitive nudges before saying yes to new commitments.";
+        }
+
+        private static string StarRelations(string modality)
+        {
+            return $"{modality} stars outline a constellation of possibility. Chart micro goals and let constellations of past wins guide today’s choices.";
+        }
+
+        private static string StoneRelations(string element)
+        {
+            return element switch
+            {
+                "Fire" => "Carnelian warms your confidence; hold it during affirmations for a potent solar spark.",
+                "Earth" => "Green aventurine grounds optimism—keep a stone in your pocket to steady practical steps.",
+                "Air" => "Blue lace agate soothes busy thoughts, clarifying conversations and creative brainstorming.",
+                _ => "Moonstone attunes your tides—place it near water to amplify intuition and gentle resilience."
+            };
+        }
+
+        private static string RitualGuidance(string element)
+        {
+            return $"Begin with a {element.ToLowerInvariant()} ritual—light a candle, tend a plant, open the window, or brew a tea that honours today’s element.";
+        }
+
+        private static string ReflectionGuidance(string modality, string signName)
+        {
+            return $"{modality} wisdom invites journaling. Ask yourself where {signName} can release an old pattern and invite fresher flow.";
+        }
+
+        private static string AdventureGuidance(IReadOnlyList<string> keywords)
+        {
+            var idea = keywords.Count > 2 ? keywords[2] : keywords.FirstOrDefault() ?? "spirited";
+            return $"Schedule a micro-adventure that highlights your {idea} spirit—an unfamiliar route, a new recipe, or a podcast swap with a friend.";
+        }
+
+        public static DailyHoroscopeModel Build(DateOnly date)
+        {
+            var (summary, weather, lunar, highlight) = BuildSummary(date);
+            var now = DateTime.UtcNow;
+
+            var signs = ZodiacCatalogue.All
+                .Select((sign, index) => new SignHoroscopeModel
+                {
+                    Id = sign.Id,
+                    Name = sign.Name,
+                    DateRange = ZodiacCatalogue.FormatDateRange(sign),
+                    Element = sign.Element,
+                    Modality = sign.Modality,
+                    RulingPlanet = sign.RulingPlanet,
+                    Icon = sign.Icon,
+                    Headline = $"{sign.Name} Focus",
+                    Summary = GeneralOutlook(sign.Name, sign.Keywords),
+                    Energy = EnergyWords[index % EnergyWords.Length],
+                    Outlook = new HoroscopeOutlookModel
+                    {
+                        General = GeneralOutlook(sign.Name, sign.Keywords),
+                        Love = LoveOutlook(sign.Element, sign.RulingPlanet),
+                        Career = CareerOutlook(sign.Modality, sign.Keywords),
+                        Wellness = WellnessOutlook(sign.Element, sign.Keywords)
+                    },
+                    Relations = new HoroscopeRelationsModel
+                    {
+                        People = PeopleRelations(sign.Name),
+                        Pets = PetRelations(sign.Element),
+                        Planets = PlanetRelations(sign.RulingPlanet),
+                        Stars = StarRelations(sign.Modality),
+                        Stones = StoneRelations(sign.Element)
+                    },
+                    Guidance = new HoroscopeGuidanceModel
+                    {
+                        Ritual = RitualGuidance(sign.Element),
+                        Reflection = ReflectionGuidance(sign.Modality, sign.Name),
+                        Adventure = AdventureGuidance(sign.Keywords)
+                    },
+                    Mood = Moods[index % Moods.Length],
+                    Color = Colors[index % Colors.Length],
+                    Mantra = $"{sign.Name} breathes in confidence and exhales possibility.",
+                    LuckyNumbers = LuckyNumbersFor(index, date.Day)
+                })
+                .ToList();
+
+            return new DailyHoroscopeModel
+            {
+                ForDate = date,
+                GeneratedAtUtc = now,
+                Summary = summary,
+                CosmicWeather = weather,
+                LunarPhase = lunar,
+                Highlight = highlight,
+                Signs = signs
+            };
+        }
+    }
+}

--- a/Northeast/Services/Astrology/AstrologyModels.cs
+++ b/Northeast/Services/Astrology/AstrologyModels.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace Northeast.Services.Astrology
+{
+    internal class HoroscopeOutlookModel
+    {
+        public string General { get; set; } = string.Empty;
+        public string Love { get; set; } = string.Empty;
+        public string Career { get; set; } = string.Empty;
+        public string Wellness { get; set; } = string.Empty;
+    }
+
+    internal class HoroscopeRelationsModel
+    {
+        public string People { get; set; } = string.Empty;
+        public string Pets { get; set; } = string.Empty;
+        public string Planets { get; set; } = string.Empty;
+        public string Stars { get; set; } = string.Empty;
+        public string Stones { get; set; } = string.Empty;
+    }
+
+    internal class HoroscopeGuidanceModel
+    {
+        public string Ritual { get; set; } = string.Empty;
+        public string Reflection { get; set; } = string.Empty;
+        public string Adventure { get; set; } = string.Empty;
+    }
+
+    internal class SignHoroscopeModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string DateRange { get; set; } = string.Empty;
+        public string Element { get; set; } = string.Empty;
+        public string Modality { get; set; } = string.Empty;
+        public string RulingPlanet { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public string Headline { get; set; } = string.Empty;
+        public string Summary { get; set; } = string.Empty;
+        public string Energy { get; set; } = string.Empty;
+        public HoroscopeOutlookModel Outlook { get; set; } = new();
+        public HoroscopeRelationsModel Relations { get; set; } = new();
+        public HoroscopeGuidanceModel Guidance { get; set; } = new();
+        public string Mood { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+        public string Mantra { get; set; } = string.Empty;
+        public List<int> LuckyNumbers { get; set; } = new();
+    }
+
+    internal class DailyHoroscopeModel
+    {
+        public DateOnly ForDate { get; set; }
+        public DateTime GeneratedAtUtc { get; set; }
+        public string Summary { get; set; } = string.Empty;
+        public string CosmicWeather { get; set; } = string.Empty;
+        public string LunarPhase { get; set; } = string.Empty;
+        public string Highlight { get; set; } = string.Empty;
+        public List<SignHoroscopeModel> Signs { get; set; } = new();
+    }
+}

--- a/Northeast/Services/Astrology/AstrologyOptions.cs
+++ b/Northeast/Services/Astrology/AstrologyOptions.cs
@@ -1,0 +1,13 @@
+namespace Northeast.Services.Astrology
+{
+    public class AstrologyOptions
+    {
+        public string ApiKey { get; set; } = string.Empty;
+        public string Model { get; set; } = "gemini-1.5-flash";
+        public double Temperature { get; set; } = 0.7;
+        public double TopP { get; set; } = 0.9;
+        public int TopK { get; set; } = 40;
+        public int MaxOutputTokens { get; set; } = 2048;
+        public string? DispatchToken { get; set; }
+    }
+}

--- a/Northeast/Services/Astrology/AstrologyService.cs
+++ b/Northeast/Services/Astrology/AstrologyService.cs
@@ -1,0 +1,485 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Northeast.Data;
+using Northeast.DTOs;
+using Northeast.Models;
+
+namespace Northeast.Services.Astrology
+{
+    public class AstrologyService
+    {
+        private readonly AppDbContext _dbContext;
+        private readonly GeminiAstrologyClient _gemini;
+        private readonly ILogger<AstrologyService> _logger;
+
+        public AstrologyService(
+            AppDbContext dbContext,
+            GeminiAstrologyClient gemini,
+            ILogger<AstrologyService> logger)
+        {
+            _dbContext = dbContext;
+            _gemini = gemini;
+            _logger = logger;
+        }
+
+        private static DailyHoroscopeModel MapFromEntity(AstrologyHoroscope entity)
+        {
+            var model = new DailyHoroscopeModel
+            {
+                ForDate = entity.ForDate,
+                GeneratedAtUtc = entity.GeneratedAtUtc,
+                Summary = entity.Summary,
+                CosmicWeather = entity.CosmicWeather,
+                LunarPhase = entity.LunarPhase,
+                Highlight = entity.Highlight,
+                Signs = new List<SignHoroscopeModel>()
+            };
+
+            foreach (var meta in ZodiacCatalogue.All)
+            {
+                var signEntity = entity.Signs.FirstOrDefault(s => s.SignId == meta.Id);
+                if (signEntity == null)
+                {
+                    continue;
+                }
+
+                model.Signs.Add(new SignHoroscopeModel
+                {
+                    Id = meta.Id,
+                    Name = meta.Name,
+                    DateRange = ZodiacCatalogue.FormatDateRange(meta),
+                    Element = meta.Element,
+                    Modality = meta.Modality,
+                    RulingPlanet = meta.RulingPlanet,
+                    Icon = meta.Icon,
+                    Headline = signEntity.Headline,
+                    Summary = signEntity.Summary,
+                    Energy = signEntity.Energy,
+                    Outlook = new HoroscopeOutlookModel
+                    {
+                        General = signEntity.OutlookGeneral,
+                        Love = signEntity.OutlookLove,
+                        Career = signEntity.OutlookCareer,
+                        Wellness = signEntity.OutlookWellness
+                    },
+                    Relations = new HoroscopeRelationsModel
+                    {
+                        People = signEntity.RelationsPeople,
+                        Pets = signEntity.RelationsPets,
+                        Planets = signEntity.RelationsPlanets,
+                        Stars = signEntity.RelationsStars,
+                        Stones = signEntity.RelationsStones
+                    },
+                    Guidance = new HoroscopeGuidanceModel
+                    {
+                        Ritual = signEntity.GuidanceRitual,
+                        Reflection = signEntity.GuidanceReflection,
+                        Adventure = signEntity.GuidanceAdventure
+                    },
+                    Mood = signEntity.Mood,
+                    Color = signEntity.Color,
+                    Mantra = signEntity.Mantra,
+                    LuckyNumbers = signEntity.LuckyNumbers?.ToList() ?? new List<int>()
+                });
+            }
+
+            return model;
+        }
+
+        private static AstrologyHoroscope MapToEntity(DailyHoroscopeModel model)
+        {
+            var entity = new AstrologyHoroscope
+            {
+                ForDate = model.ForDate,
+                GeneratedAtUtc = model.GeneratedAtUtc,
+                Summary = model.Summary,
+                CosmicWeather = model.CosmicWeather,
+                LunarPhase = model.LunarPhase,
+                Highlight = model.Highlight,
+                Signs = new List<AstrologySignForecast>()
+            };
+
+            foreach (var sign in model.Signs)
+            {
+                entity.Signs.Add(new AstrologySignForecast
+                {
+                    SignId = sign.Id,
+                    Headline = sign.Headline,
+                    Summary = sign.Summary,
+                    Energy = sign.Energy,
+                    OutlookGeneral = sign.Outlook.General,
+                    OutlookLove = sign.Outlook.Love,
+                    OutlookCareer = sign.Outlook.Career,
+                    OutlookWellness = sign.Outlook.Wellness,
+                    RelationsPeople = sign.Relations.People,
+                    RelationsPets = sign.Relations.Pets,
+                    RelationsPlanets = sign.Relations.Planets,
+                    RelationsStars = sign.Relations.Stars,
+                    RelationsStones = sign.Relations.Stones,
+                    GuidanceRitual = sign.Guidance.Ritual,
+                    GuidanceReflection = sign.Guidance.Reflection,
+                    GuidanceAdventure = sign.Guidance.Adventure,
+                    Mood = sign.Mood,
+                    Color = sign.Color,
+                    Mantra = sign.Mantra,
+                    LuckyNumbers = sign.LuckyNumbers.ToArray()
+                });
+            }
+
+            return entity;
+        }
+
+        private static List<int> SanitizeLuckyNumbers(List<int>? numbers, List<int> fallback)
+        {
+            if (numbers == null || numbers.Count == 0)
+            {
+                return fallback;
+            }
+
+            var cleaned = numbers
+                .Where(n => n > 0)
+                .Distinct()
+                .Take(6)
+                .ToList();
+
+            return cleaned.Count > 0 ? cleaned : fallback;
+        }
+
+        private static DailyHoroscopeModel Merge(DailyHoroscopeModel fallback, GeminiAstrologyClient.GeminiHoroscopePayload? gemini)
+        {
+            if (gemini == null)
+            {
+                return fallback;
+            }
+
+            var responseMap = gemini.Signs
+                .GroupBy(sign => sign.Id, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+            var signs = new List<SignHoroscopeModel>();
+
+            foreach (var fallbackSign in fallback.Signs)
+            {
+                responseMap.TryGetValue(fallbackSign.Id, out var dynamicSign);
+
+                var merged = new SignHoroscopeModel
+                {
+                    Id = fallbackSign.Id,
+                    Name = fallbackSign.Name,
+                    DateRange = fallbackSign.DateRange,
+                    Element = fallbackSign.Element,
+                    Modality = fallbackSign.Modality,
+                    RulingPlanet = fallbackSign.RulingPlanet,
+                    Icon = fallbackSign.Icon,
+                    Headline = !string.IsNullOrWhiteSpace(dynamicSign?.Headline) ? dynamicSign!.Headline.Trim() : fallbackSign.Headline,
+                    Summary = !string.IsNullOrWhiteSpace(dynamicSign?.Summary) ? dynamicSign!.Summary.Trim() : fallbackSign.Summary,
+                    Energy = !string.IsNullOrWhiteSpace(dynamicSign?.Energy) ? dynamicSign!.Energy.Trim() : fallbackSign.Energy,
+                    Outlook = new HoroscopeOutlookModel
+                    {
+                        General = !string.IsNullOrWhiteSpace(dynamicSign?.Outlook.General)
+                            ? dynamicSign!.Outlook.General.Trim()
+                            : fallbackSign.Outlook.General,
+                        Love = !string.IsNullOrWhiteSpace(dynamicSign?.Outlook.Love)
+                            ? dynamicSign!.Outlook.Love.Trim()
+                            : fallbackSign.Outlook.Love,
+                        Career = !string.IsNullOrWhiteSpace(dynamicSign?.Outlook.Career)
+                            ? dynamicSign!.Outlook.Career.Trim()
+                            : fallbackSign.Outlook.Career,
+                        Wellness = !string.IsNullOrWhiteSpace(dynamicSign?.Outlook.Wellness)
+                            ? dynamicSign!.Outlook.Wellness.Trim()
+                            : fallbackSign.Outlook.Wellness
+                    },
+                    Relations = new HoroscopeRelationsModel
+                    {
+                        People = !string.IsNullOrWhiteSpace(dynamicSign?.Relations.People)
+                            ? dynamicSign!.Relations.People.Trim()
+                            : fallbackSign.Relations.People,
+                        Pets = !string.IsNullOrWhiteSpace(dynamicSign?.Relations.Pets)
+                            ? dynamicSign!.Relations.Pets.Trim()
+                            : fallbackSign.Relations.Pets,
+                        Planets = !string.IsNullOrWhiteSpace(dynamicSign?.Relations.Planets)
+                            ? dynamicSign!.Relations.Planets.Trim()
+                            : fallbackSign.Relations.Planets,
+                        Stars = !string.IsNullOrWhiteSpace(dynamicSign?.Relations.Stars)
+                            ? dynamicSign!.Relations.Stars.Trim()
+                            : fallbackSign.Relations.Stars,
+                        Stones = !string.IsNullOrWhiteSpace(dynamicSign?.Relations.Stones)
+                            ? dynamicSign!.Relations.Stones.Trim()
+                            : fallbackSign.Relations.Stones
+                    },
+                    Guidance = new HoroscopeGuidanceModel
+                    {
+                        Ritual = !string.IsNullOrWhiteSpace(dynamicSign?.Guidance.Ritual)
+                            ? dynamicSign!.Guidance.Ritual.Trim()
+                            : fallbackSign.Guidance.Ritual,
+                        Reflection = !string.IsNullOrWhiteSpace(dynamicSign?.Guidance.Reflection)
+                            ? dynamicSign!.Guidance.Reflection.Trim()
+                            : fallbackSign.Guidance.Reflection,
+                        Adventure = !string.IsNullOrWhiteSpace(dynamicSign?.Guidance.Adventure)
+                            ? dynamicSign!.Guidance.Adventure.Trim()
+                            : fallbackSign.Guidance.Adventure
+                    },
+                    Mood = !string.IsNullOrWhiteSpace(dynamicSign?.Mood) ? dynamicSign!.Mood.Trim() : fallbackSign.Mood,
+                    Color = !string.IsNullOrWhiteSpace(dynamicSign?.Color) ? dynamicSign!.Color.Trim() : fallbackSign.Color,
+                    Mantra = !string.IsNullOrWhiteSpace(dynamicSign?.Mantra) ? dynamicSign!.Mantra.Trim() : fallbackSign.Mantra,
+                    LuckyNumbers = SanitizeLuckyNumbers(dynamicSign?.LuckyNumbers, fallbackSign.LuckyNumbers)
+                };
+
+                signs.Add(merged);
+            }
+
+            var generatedFor = fallback.ForDate;
+            if (DateOnly.TryParse(gemini.GeneratedFor, out var parsedDate))
+            {
+                generatedFor = parsedDate;
+            }
+
+            return new DailyHoroscopeModel
+            {
+                ForDate = generatedFor,
+                GeneratedAtUtc = DateTime.UtcNow,
+                Summary = string.IsNullOrWhiteSpace(gemini.Summary) ? fallback.Summary : gemini.Summary.Trim(),
+                CosmicWeather = string.IsNullOrWhiteSpace(gemini.CosmicWeather) ? fallback.CosmicWeather : gemini.CosmicWeather.Trim(),
+                LunarPhase = string.IsNullOrWhiteSpace(gemini.LunarPhase) ? fallback.LunarPhase : gemini.LunarPhase.Trim(),
+                Highlight = string.IsNullOrWhiteSpace(gemini.Highlight) ? fallback.Highlight : gemini.Highlight.Trim(),
+                Signs = signs
+            };
+        }
+
+        public async Task<DailyHoroscopeModel> GetDailyHoroscopeAsync(DateOnly date, CancellationToken cancellationToken)
+        {
+            var existing = await _dbContext.AstrologyHoroscopes
+                .Include(h => h.Signs)
+                .FirstOrDefaultAsync(h => h.ForDate == date, cancellationToken);
+
+            if (existing != null && existing.Signs.Count == ZodiacCatalogue.All.Count)
+            {
+                return MapFromEntity(existing);
+            }
+
+            return await GenerateAndStoreAsync(date, cancellationToken);
+        }
+
+        private async Task<DailyHoroscopeModel> GenerateAndStoreAsync(DateOnly date, CancellationToken cancellationToken)
+        {
+            var fallback = AstrologyFallbackBuilder.Build(date);
+            GeminiAstrologyClient.GeminiHoroscopePayload? gemini = null;
+
+            try
+            {
+                gemini = await _gemini.GenerateAsync(date, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Gemini astrology generation failed. Using fallback horoscope for {Date}.", date);
+            }
+
+            var merged = Merge(fallback, gemini);
+
+            // Remove any existing entry for the date to avoid duplicates
+            var previous = await _dbContext.AstrologyHoroscopes
+                .Include(h => h.Signs)
+                .Where(h => h.ForDate == merged.ForDate)
+                .ToListAsync(cancellationToken);
+
+            if (previous.Count > 0)
+            {
+                _dbContext.AstrologyHoroscopes.RemoveRange(previous);
+            }
+
+            var entity = MapToEntity(merged);
+            _dbContext.AstrologyHoroscopes.Add(entity);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return MapFromEntity(entity);
+        }
+
+        public DailyHoroscopeDto ToDto(DailyHoroscopeModel model)
+        {
+            return new DailyHoroscopeDto
+            {
+                GeneratedFor = model.ForDate.ToString("yyyy-MM-dd"),
+                GeneratedAt = model.GeneratedAtUtc,
+                Summary = model.Summary,
+                CosmicWeather = model.CosmicWeather,
+                LunarPhase = model.LunarPhase,
+                Highlight = model.Highlight,
+                Signs = model.Signs.Select(sign => new AstrologySignDto
+                {
+                    Id = sign.Id,
+                    Name = sign.Name,
+                    DateRange = sign.DateRange,
+                    Element = sign.Element,
+                    Modality = sign.Modality,
+                    RulingPlanet = sign.RulingPlanet,
+                    Icon = sign.Icon,
+                    Headline = sign.Headline,
+                    Summary = sign.Summary,
+                    Energy = sign.Energy,
+                    Outlook = new HoroscopeOutlookDto
+                    {
+                        General = sign.Outlook.General,
+                        Love = sign.Outlook.Love,
+                        Career = sign.Outlook.Career,
+                        Wellness = sign.Outlook.Wellness
+                    },
+                    Relations = new HoroscopeRelationsDto
+                    {
+                        People = sign.Relations.People,
+                        Pets = sign.Relations.Pets,
+                        Planets = sign.Relations.Planets,
+                        Stars = sign.Relations.Stars,
+                        Stones = sign.Relations.Stones
+                    },
+                    Guidance = new HoroscopeGuidanceDto
+                    {
+                        Ritual = sign.Guidance.Ritual,
+                        Reflection = sign.Guidance.Reflection,
+                        Adventure = sign.Guidance.Adventure
+                    },
+                    Mood = sign.Mood,
+                    Color = sign.Color,
+                    Mantra = sign.Mantra,
+                    LuckyNumbers = sign.LuckyNumbers
+                }).ToList()
+            };
+        }
+
+        public async Task<AstrologySubscription?> GetSubscriptionAsync(Guid userId, CancellationToken cancellationToken)
+        {
+            return await _dbContext.AstrologySubscriptions
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.UserId == userId, cancellationToken);
+        }
+
+        public async Task<AstrologySubscription> UpsertSubscriptionAsync(
+            Guid userId,
+            string email,
+            string? userName,
+            string signId,
+            string? countryCode,
+            string timeZone,
+            int sendHour,
+            CancellationToken cancellationToken)
+        {
+            var now = DateTime.UtcNow;
+            var normalizedSign = signId.ToLowerInvariant();
+            var normalizedCountry = string.IsNullOrWhiteSpace(countryCode) ? null : countryCode.ToUpperInvariant();
+            var normalizedTimeZone = string.IsNullOrWhiteSpace(timeZone) ? "UTC" : timeZone.Trim();
+            var hour = Math.Clamp(sendHour, 0, 23);
+
+            var existing = await _dbContext.AstrologySubscriptions
+                .FirstOrDefaultAsync(s => s.UserId == userId, cancellationToken);
+
+            if (existing != null)
+            {
+                existing.SignId = normalizedSign;
+                existing.CountryCode = normalizedCountry;
+                existing.TimeZone = normalizedTimeZone;
+                existing.SendHour = hour;
+                existing.Email = email;
+                existing.UserName = userName;
+                existing.Active = true;
+                existing.UpdatedAtUtc = now;
+
+                await _dbContext.SaveChangesAsync(cancellationToken);
+                return existing;
+            }
+
+            var subscription = new AstrologySubscription
+            {
+                UserId = userId,
+                Email = email,
+                UserName = userName,
+                SignId = normalizedSign,
+                CountryCode = normalizedCountry,
+                TimeZone = normalizedTimeZone,
+                SendHour = hour,
+                CreatedAtUtc = now,
+                UpdatedAtUtc = now,
+                Active = true
+            };
+
+            _dbContext.AstrologySubscriptions.Add(subscription);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return subscription;
+        }
+
+        public async Task RemoveSubscriptionAsync(Guid userId, CancellationToken cancellationToken)
+        {
+            var existing = await _dbContext.AstrologySubscriptions
+                .FirstOrDefaultAsync(s => s.UserId == userId, cancellationToken);
+
+            if (existing != null)
+            {
+                _dbContext.AstrologySubscriptions.Remove(existing);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        public async Task<List<AstrologySubscription>> GetActiveSubscriptionsAsync(CancellationToken cancellationToken)
+        {
+            return await _dbContext.AstrologySubscriptions
+                .Where(s => s.Active)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<List<AstrologySubscription>> GetDueSubscriptionsAsync(
+            DateTime utcNow,
+            DateOnly forDate,
+            CancellationToken cancellationToken)
+        {
+            var subscriptions = await GetActiveSubscriptionsAsync(cancellationToken);
+            var due = new List<AstrologySubscription>();
+
+            foreach (var subscription in subscriptions)
+            {
+                TimeZoneInfo? timeZone = null;
+                try
+                {
+                    timeZone = TimeZoneInfo.FindSystemTimeZoneById(subscription.TimeZone);
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    _logger.LogWarning("Astrology subscription {Email} has invalid timezone {TimeZone}", subscription.Email, subscription.TimeZone);
+                }
+                catch (InvalidTimeZoneException)
+                {
+                    _logger.LogWarning("Astrology subscription {Email} has invalid timezone {TimeZone}", subscription.Email, subscription.TimeZone);
+                }
+
+                if (timeZone == null)
+                {
+                    continue;
+                }
+
+                var local = TimeZoneInfo.ConvertTimeFromUtc(utcNow, timeZone);
+                if (local.Hour < subscription.SendHour)
+                {
+                    continue;
+                }
+
+                if (subscription.LastSentForDate.HasValue && subscription.LastSentForDate.Value >= forDate)
+                {
+                    continue;
+                }
+
+                due.Add(subscription);
+            }
+
+            return due;
+        }
+
+        public async Task MarkDeliveredAsync(AstrologySubscription subscription, DateOnly forDate, CancellationToken cancellationToken)
+        {
+            subscription.LastSentForDate = forDate;
+            subscription.UpdatedAtUtc = DateTime.UtcNow;
+            _dbContext.AstrologySubscriptions.Update(subscription);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/Northeast/Services/Astrology/GeminiAstrologyClient.cs
+++ b/Northeast/Services/Astrology/GeminiAstrologyClient.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Northeast.Services.Astrology
+{
+    internal class GeminiAstrologyClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly AstrologyOptions _options;
+        private readonly ILogger<GeminiAstrologyClient> _logger;
+
+        private record GeminiResponse(GeminiCandidate[] Candidates);
+
+        private record GeminiCandidate(GeminiContent Content);
+
+        private record GeminiContent(GeminiPart[] Parts);
+
+        private record GeminiPart(string Text);
+
+        internal class GeminiHoroscopePayload
+        {
+            public string GeneratedFor { get; set; } = string.Empty;
+            public string Summary { get; set; } = string.Empty;
+            public string CosmicWeather { get; set; } = string.Empty;
+            public string LunarPhase { get; set; } = string.Empty;
+            public string Highlight { get; set; } = string.Empty;
+            public List<GeminiSignPayload> Signs { get; set; } = new();
+        }
+
+        internal class GeminiSignPayload
+        {
+            public string Id { get; set; } = string.Empty;
+            public string Headline { get; set; } = string.Empty;
+            public string Summary { get; set; } = string.Empty;
+            public string Energy { get; set; } = string.Empty;
+            public HoroscopeOutlookModel Outlook { get; set; } = new();
+            public HoroscopeRelationsModel Relations { get; set; } = new();
+            public HoroscopeGuidanceModel Guidance { get; set; } = new();
+            public string Mood { get; set; } = string.Empty;
+            public string Color { get; set; } = string.Empty;
+            public string Mantra { get; set; } = string.Empty;
+            public List<int>? LuckyNumbers { get; set; }
+        }
+
+        public GeminiAstrologyClient(
+            HttpClient httpClient,
+            IOptions<AstrologyOptions> options,
+            ILogger<GeminiAstrologyClient> logger)
+        {
+            _httpClient = httpClient;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        private string BuildPrompt(DateOnly date)
+        {
+            var catalogue = string.Join(
+                "\n",
+                ZodiacCatalogue.All.Select(sign =>
+                    string.Join(
+                        '|',
+                        new[]
+                        {
+                            sign.Id,
+                            sign.Name,
+                            sign.Element,
+                            sign.Modality,
+                            sign.RulingPlanet,
+                            ZodiacCatalogue.FormatDateRange(sign),
+                            string.Join(',', sign.Keywords)
+                        })));
+
+            return $@"You are the resident astrologer for an independent news organisation. Compose a richly-detailed daily horoscope for {date:yyyy-MM-dd}.
+Focus on actionable, poetic and contemporary language. Mention practical guidance, energetic tone, and relational insights for people, pets, planets, stars and stones. Use inclusive language and avoid fatalistic statements.
+
+For reference, here is the zodiac catalogue (id|name|element|modality|rulingPlanet|dateRange|keywords):
+{catalogue}
+
+Respond ONLY with valid JSON that matches this TypeScript definition exactly:
+interface HoroscopeResponse {{
+  generatedFor: string; // the provided date in YYYY-MM-DD format
+  summary: string; // overall summary for all signs
+  cosmicWeather: string; // planetary climate description
+  lunarPhase: string; // mention the Moon influence
+  highlight: string; // key takeaway for the day
+  signs: {{
+    id: string; // one of the ids from the catalogue
+    headline: string; // short focus statement for the sign
+    summary: string; // a 2-3 sentence synopsis
+    energy: string; // energetic descriptor
+    outlook: {{
+      general: string;
+      love: string;
+      career: string;
+      wellness: string;
+    }};
+    relations: {{
+      people: string;
+      pets: string;
+      planets: string;
+      stars: string;
+      stones: string;
+    }};
+    guidance: {{
+      ritual: string;
+      reflection: string;
+      adventure: string;
+    }};
+    mood: string;
+    color: string;
+    mantra: string;
+    luckyNumbers: number[]; // 3-6 positive integers
+  }}[];
+}}
+Ensure every zodiac sign from the catalogue appears once in the signs array (matching the order of the catalogue).
+Do not include markdown fences or commentary.";
+        }
+
+        public async Task<GeminiHoroscopePayload> GenerateAsync(DateOnly date, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(_options.ApiKey))
+            {
+                throw new InvalidOperationException("Astrology: Gemini API key is not configured.");
+            }
+
+            var endpoint = $"https://generativelanguage.googleapis.com/v1beta/models/{_options.Model}:generateContent?key={_options.ApiKey}";
+
+            var requestPayload = new
+            {
+                contents = new[]
+                {
+                    new
+                    {
+                        role = "user",
+                        parts = new[]
+                        {
+                            new { text = BuildPrompt(date) }
+                        }
+                    }
+                },
+                generationConfig = new
+                {
+                    temperature = _options.Temperature,
+                    topP = _options.TopP,
+                    topK = _options.TopK,
+                    maxOutputTokens = _options.MaxOutputTokens,
+                    responseMimeType = "application/json"
+                }
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(requestPayload),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Gemini astrology request failed: {Status} {Body}", response.StatusCode, content);
+                throw new InvalidOperationException($"Gemini astrology request failed with status {(int)response.StatusCode}.");
+            }
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                throw new InvalidOperationException("Gemini astrology response was empty.");
+            }
+
+            GeminiResponse? parsed;
+            try
+            {
+                parsed = JsonSerializer.Deserialize<GeminiResponse>(content, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "Failed to parse Gemini astrology envelope");
+                throw new InvalidOperationException("Unable to parse Gemini astrology response envelope.", ex);
+            }
+
+            var text = parsed?.Candidates?.FirstOrDefault()?.Content?.Parts?.FirstOrDefault()?.Text;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                throw new InvalidOperationException("Gemini astrology response missing text content.");
+            }
+
+            var cleaned = text
+                .Replace("```json", string.Empty, StringComparison.OrdinalIgnoreCase)
+                .Replace("```", string.Empty, StringComparison.OrdinalIgnoreCase)
+                .Trim();
+
+            try
+            {
+                var payload = JsonSerializer.Deserialize<GeminiHoroscopePayload>(cleaned, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                if (payload == null || string.IsNullOrWhiteSpace(payload.GeneratedFor) || payload.Signs.Count == 0)
+                {
+                    throw new InvalidOperationException("Gemini astrology payload incomplete.");
+                }
+
+                return payload;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "Failed to parse Gemini astrology JSON {Json}", cleaned);
+                throw new InvalidOperationException("Gemini astrology payload could not be parsed.", ex);
+            }
+        }
+    }
+}

--- a/Northeast/Services/Astrology/ZodiacCatalogue.cs
+++ b/Northeast/Services/Astrology/ZodiacCatalogue.cs
@@ -1,0 +1,197 @@
+using System.Globalization;
+using System.Linq;
+
+namespace Northeast.Services.Astrology
+{
+    internal record ZodiacSignMeta(
+        string Id,
+        string Name,
+        int StartMonth,
+        int StartDay,
+        int EndMonth,
+        int EndDay,
+        string Element,
+        string Modality,
+        string RulingPlanet,
+        string Icon,
+        IReadOnlyList<string> Keywords);
+
+    internal static class ZodiacCatalogue
+    {
+        public static readonly IReadOnlyList<ZodiacSignMeta> All = new List<ZodiacSignMeta>
+        {
+            new(
+                "aries",
+                "Aries",
+                3,
+                21,
+                4,
+                19,
+                "Fire",
+                "Cardinal",
+                "Mars",
+                "/images/astrology/aries.svg",
+                new[] { "trailblazing", "spontaneous", "courageous" }
+            ),
+            new(
+                "taurus",
+                "Taurus",
+                4,
+                20,
+                5,
+                20,
+                "Earth",
+                "Fixed",
+                "Venus",
+                "/images/astrology/taurus.svg",
+                new[] { "grounded", "sensual", "steadfast" }
+            ),
+            new(
+                "gemini",
+                "Gemini",
+                5,
+                21,
+                6,
+                20,
+                "Air",
+                "Mutable",
+                "Mercury",
+                "/images/astrology/gemini.svg",
+                new[] { "curious", "expressive", "versatile" }
+            ),
+            new(
+                "cancer",
+                "Cancer",
+                6,
+                21,
+                7,
+                22,
+                "Water",
+                "Cardinal",
+                "Moon",
+                "/images/astrology/cancer.svg",
+                new[] { "nurturing", "intuitive", "protective" }
+            ),
+            new(
+                "leo",
+                "Leo",
+                7,
+                23,
+                8,
+                22,
+                "Fire",
+                "Fixed",
+                "Sun",
+                "/images/astrology/leo.svg",
+                new[] { "radiant", "dramatic", "charismatic" }
+            ),
+            new(
+                "virgo",
+                "Virgo",
+                8,
+                23,
+                9,
+                22,
+                "Earth",
+                "Mutable",
+                "Mercury",
+                "/images/astrology/virgo.svg",
+                new[] { "practical", "precise", "service-oriented" }
+            ),
+            new(
+                "libra",
+                "Libra",
+                9,
+                23,
+                10,
+                22,
+                "Air",
+                "Cardinal",
+                "Venus",
+                "/images/astrology/libra.svg",
+                new[] { "harmonising", "diplomatic", "refined" }
+            ),
+            new(
+                "scorpio",
+                "Scorpio",
+                10,
+                23,
+                11,
+                21,
+                "Water",
+                "Fixed",
+                "Pluto",
+                "/images/astrology/scorpio.svg",
+                new[] { "intense", "transformative", "magnetic" }
+            ),
+            new(
+                "sagittarius",
+                "Sagittarius",
+                11,
+                22,
+                12,
+                21,
+                "Fire",
+                "Mutable",
+                "Jupiter",
+                "/images/astrology/sagittarius.svg",
+                new[] { "adventurous", "optimistic", "philosophical" }
+            ),
+            new(
+                "capricorn",
+                "Capricorn",
+                12,
+                22,
+                1,
+                19,
+                "Earth",
+                "Cardinal",
+                "Saturn",
+                "/images/astrology/capricorn.svg",
+                new[] { "ambitious", "structured", "resilient" }
+            ),
+            new(
+                "aquarius",
+                "Aquarius",
+                1,
+                20,
+                2,
+                18,
+                "Air",
+                "Fixed",
+                "Uranus",
+                "/images/astrology/aquarius.svg",
+                new[] { "visionary", "progressive", "unconventional" }
+            ),
+            new(
+                "pisces",
+                "Pisces",
+                2,
+                19,
+                3,
+                20,
+                "Water",
+                "Mutable",
+                "Neptune",
+                "/images/astrology/pisces.svg",
+                new[] { "dreamy", "empathetic", "mystical" }
+            )
+        };
+
+        public static ZodiacSignMeta? Find(string id) =>
+            All.FirstOrDefault(sign => string.Equals(sign.Id, id, StringComparison.OrdinalIgnoreCase));
+
+        public static string FormatDateRange(ZodiacSignMeta sign)
+        {
+            var start = new DateTime(2000, sign.StartMonth, sign.StartDay);
+            var end = new DateTime(
+                sign.EndMonth < sign.StartMonth ? 2001 : 2000,
+                sign.EndMonth,
+                sign.EndDay);
+
+            string Format(DateTime value) => value.ToString("MMM dd", CultureInfo.InvariantCulture);
+
+            return $"{Format(start)} – {Format(end)}";
+        }
+    }
+}

--- a/Northeast/appsettings.Production.json
+++ b/Northeast/appsettings.Production.json
@@ -56,6 +56,11 @@
       "ApiKey": "AIzaSyBYlTSAJL2HJsx-e4V-0v35y4tafUFBxDY",
       "Model": "gemini-2.5-pro"
     },
+    "Astrology": {
+      "ApiKey": "",
+      "Model": "gemini-1.5-flash",
+      "DispatchToken": ""
+    },
 
     "IndexNow": {
       "Enabled": true,

--- a/WT4Q/lib/api.ts
+++ b/WT4Q/lib/api.ts
@@ -90,6 +90,11 @@ export const API_ROUTES = {
   CONTACT: {
     POST: `${API_BASE_URL}/api/Contact`,
   },
+  ASTROLOGY: {
+    TODAY: `${API_BASE_URL}/api/Astrology/today`,
+    SUBSCRIPTION: `${API_BASE_URL}/api/Astrology/subscription`,
+    DISPATCH: `${API_BASE_URL}/api/Astrology/dispatch`,
+  },
 };
 // Wrapper around fetch that always includes credentials and retries once on 401
 export async function apiFetch(

--- a/WT4Q/package-lock.json
+++ b/WT4Q/package-lock.json
@@ -13,6 +13,7 @@
         "immer": "^10.1.1",
         "lucide-react": "^0.469.0",
         "next": "^15.4.2",
+        "nodemailer": "^6.9.14",
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -5828,6 +5829,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nwsapi": {

--- a/WT4Q/package.json
+++ b/WT4Q/package.json
@@ -14,6 +14,7 @@
     "html2canvas": "^1.4.1",
     "immer": "^10.1.1",
     "lucide-react": "^0.469.0",
+    "nodemailer": "^6.9.14",
     "next": "^15.4.2",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",

--- a/WT4Q/public/images/astrology/aquarius.svg
+++ b/WT4Q/public/images/astrology/aquarius.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Aquarius glyph</title>
+  <g fill="none" stroke="#267b8f" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 54c12-12 24-12 36 0s24 12 36 0 24-12 36 0"/>
+    <path d="M20 86c12-12 24-12 36 0s24 12 36 0 24-12 36 0"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/aries.svg
+++ b/WT4Q/public/images/astrology/aries.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Aries glyph</title>
+  <g fill="none" stroke="#a37c40" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M32 100c0-48 20-76 32-76s32 28 32 76"/>
+    <path d="M34 54c-6-10-10-22-2-32 6-8 16-12 26-10 10 2 18 10 20 20"/>
+    <path d="M94 54c6-10 10-22 2-32-6-8-16-12-26-10-10 2-18 10-20 20"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/cancer.svg
+++ b/WT4Q/public/images/astrology/cancer.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Cancer glyph</title>
+  <g fill="none" stroke="#3b6d6b" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M42 54c-10 0-18-8-18-18s8-18 18-18 18 8 18 18c0 10-8 18-18 18z"/>
+    <path d="M86 92c10 0 18 8 18 18s-8 18-18 18-18-8-18-18c0-10 8-18 18-18z"/>
+    <path d="M28 70c16-10 36-10 52 0"/>
+    <path d="M48 38c16 10 36 10 52 0"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/capricorn.svg
+++ b/WT4Q/public/images/astrology/capricorn.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Capricorn glyph</title>
+  <g fill="none" stroke="#4a4f5c" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M36 26v64c0 14 10 24 24 24s24-10 24-24"/>
+    <path d="M36 58c6-12 16-20 28-20 18 0 30 14 30 32s-10 32-26 32"/>
+    <path d="M96 102c8 0 14 6 14 14s-6 14-14 14c-10 0-16-8-16-18"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/gemini.svg
+++ b/WT4Q/public/images/astrology/gemini.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Gemini glyph</title>
+  <g fill="none" stroke="#4d6c8c" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M36 28c12 6 28 8 44 8s32-2 44-8"/>
+    <path d="M36 100c12-6 28-8 44-8s32 2 44 8"/>
+    <path d="M48 32v64"/>
+    <path d="M80 32v64"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/leo.svg
+++ b/WT4Q/public/images/astrology/leo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Leo glyph</title>
+  <g fill="none" stroke="#c06a32" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M56 52c0-20 14-36 32-36 12 0 22 10 22 22 0 16-14 24-30 24"/>
+    <circle cx="40" cy="80" r="24"/>
+    <path d="M64 104c8 12 20 18 36 18"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/libra.svg
+++ b/WT4Q/public/images/astrology/libra.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Libra glyph</title>
+  <g fill="none" stroke="#5c6d90" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 94h88"/>
+    <path d="M20 78h88"/>
+    <path d="M32 78c6-18 18-30 32-30s26 12 32 30"/>
+    <path d="M48 48c0-14 8-26 16-26s16 12 16 26"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/pisces.svg
+++ b/WT4Q/public/images/astrology/pisces.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Pisces glyph</title>
+  <g fill="none" stroke="#3b5f8a" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M32 100c12-18 12-54 0-72"/>
+    <path d="M96 28c-12 18-12 54 0 72"/>
+    <path d="M24 64h80"/>
+    <path d="M24 38c14 8 34 12 52 12 14 0 26-2 36-6"/>
+    <path d="M24 90c14-8 34-12 52-12 14 0 26 2 36 6"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/sagittarius.svg
+++ b/WT4Q/public/images/astrology/sagittarius.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Sagittarius glyph</title>
+  <g fill="none" stroke="#5a3f9c" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M30 98l68-68"/>
+    <path d="M74 30h24v24"/>
+    <path d="M32 50h32v32"/>
+    <path d="M88 46l18-18"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/scorpio.svg
+++ b/WT4Q/public/images/astrology/scorpio.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Scorpio glyph</title>
+  <g fill="none" stroke="#6a2f3c" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M30 100V36c0-10 8-18 18-18s18 8 18 18v44"/>
+    <path d="M66 80c4-12 12-20 22-20 14 0 22 10 22 24s-8 26-24 38"/>
+    <path d="M106 122l10-10-10-10"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/taurus.svg
+++ b/WT4Q/public/images/astrology/taurus.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Taurus glyph</title>
+  <g fill="none" stroke="#6f7f3d" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="64" cy="74" r="28"/>
+    <path d="M32 36c8-18 24-28 32-28s24 10 32 28"/>
+    <path d="M40 28c6 8 14 12 24 12s18-4 24-12"/>
+  </g>
+</svg>

--- a/WT4Q/public/images/astrology/virgo.svg
+++ b/WT4Q/public/images/astrology/virgo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Virgo glyph</title>
+  <g fill="none" stroke="#7b6a58" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M34 98V34c0-10 8-18 18-18s18 8 18 18v64"/>
+    <path d="M70 62c4-10 12-18 22-18 12 0 20 8 20 20s-8 22-22 34l-20 16"/>
+    <path d="M34 64h36"/>
+  </g>
+</svg>

--- a/WT4Q/services/astrology/fallback.ts
+++ b/WT4Q/services/astrology/fallback.ts
@@ -1,0 +1,203 @@
+import { DailyHoroscope, SignHoroscope } from './types';
+import { ZODIAC_SIGNS, formatDateRange } from './signs';
+
+const ENERGY_WORDS = [
+  'Magnetic momentum',
+  'Steady resonance',
+  'Curious cadence',
+  'Heart-led tide',
+  'Solar flourish',
+  'Mindful craftsmanship',
+  'Balanced breeze',
+  'Alchemical depth',
+  'Vision quest',
+  'Mountain stride',
+  'Future-forward spark',
+  'Dreamstream glow',
+];
+
+const MOODS = [
+  'Trailblazing',
+  'Comfort-craving',
+  'Story weaving',
+  'Sentimental',
+  'Spotlight-ready',
+  'Solution seeking',
+  'Graceful',
+  'Devoted',
+  'Expansive',
+  'Strategic',
+  'Inventive',
+  'Ethereal',
+];
+
+const COLORS = [
+  'Crimson ember',
+  'Verdant moss',
+  'Skyline silver',
+  'Moonlit pearl',
+  'Golden flare',
+  'Sage parchment',
+  'Rose quartz',
+  'Noir garnet',
+  'Cobalt horizon',
+  'Granite slate',
+  'Electric aqua',
+  'Seafoam opal',
+];
+
+function formatDate(date: string): string {
+  const [year, month, day] = date.split('-').map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return date;
+  }
+  const value = new Date(Date.UTC(year, month - 1, day));
+  return value.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function buildSummary(date: string): { summary: string; cosmicWeather: string; lunarPhase: string; highlight: string } {
+  const prettyDate = formatDate(date);
+  return {
+    summary: `Celestial currents for ${prettyDate} emphasise intentional presence. Temper the pace, invite reflection, and let conversations with the cosmos refine your plans.`,
+    cosmicWeather:
+      'Planetary harmonics layer fire and water signatures, asking us to blend conviction with compassion in our everyday exchanges.',
+    lunarPhase:
+      'The Moon sketches a gentle trine with Saturn, rewarding steady rituals and systems that honour both body and intuition.',
+    highlight:
+      'Small acts of care ripple far today—attend to your relationships with the same reverence you give your ambitions.',
+  };
+}
+
+function luckyNumbersFor(index: number, seed: number): number[] {
+  const numbers = new Set<number>();
+  let value = seed + index * 11;
+  while (numbers.size < 5) {
+    value = (value * 17 + 13) % 89;
+    numbers.add((value % 53) + 1);
+  }
+  return Array.from(numbers).sort((a, b) => a - b);
+}
+
+function generalOutlook(signName: string, keywords: string[]): string {
+  const flavour = keywords[0];
+  return `${signName}, your ${flavour} instincts tune into the collective pulse today. Notice where a single bold move can align your personal rhythm with the wider world.`;
+}
+
+function loveOutlook(element: string, rulingPlanet: string): string {
+  return `Lead with your ${element.toLowerCase()} heart. Conversations under ${rulingPlanet} guidance open a window for tenderness—share a vulnerability to strengthen trust.`;
+}
+
+function careerOutlook(modality: string, keywords: string[]): string {
+  const focus = keywords[1] ?? 'dedicated';
+  return `${modality} momentum supports professional pivots. Translate your ${focus} thinking into a tangible milestone and celebrate incremental progress.`;
+}
+
+function wellnessOutlook(element: string, keywords: string[]): string {
+  const cue = keywords[2] ?? 'grounded';
+  return `Anchor the day with a ${element.toLowerCase()} ritual—a mindful walk, nourishing meal, or breathing practice keeps your ${cue} energy replenished.`;
+}
+
+function peopleRelations(signName: string): string {
+  return `A trusted ally seeks your perspective. Co-create plans and let mutual inspiration remind you why collaboration with ${signName} at the helm sparks magic.`;
+}
+
+function petRelations(element: string): string {
+  return `Animal companions mirror your mood; offer play or quiet cuddles according to the ${element.toLowerCase()} tone you’re setting.`;
+}
+
+function planetRelations(rulingPlanet: string): string {
+  return `${rulingPlanet} whispers about timing—listen for intuitive nudges before saying yes to new commitments.`;
+}
+
+function starRelations(modality: string): string {
+  return `${modality} stars outline a constellation of possibility. Chart micro goals and let constellations of past wins guide today’s choices.`;
+}
+
+function stoneRelations(element: string): string {
+  switch (element) {
+    case 'Fire':
+      return 'Carnelian warms your confidence; hold it during affirmations for a potent solar spark.';
+    case 'Earth':
+      return 'Green aventurine grounds optimism—keep a stone in your pocket to steady practical steps.';
+    case 'Air':
+      return 'Blue lace agate soothes busy thoughts, clarifying conversations and creative brainstorming.';
+    case 'Water':
+    default:
+      return 'Moonstone attunes your tides—place it near water to amplify intuition and gentle resilience.';
+  }
+}
+
+function ritualGuidance(element: string): string {
+  return `Begin with a ${element.toLowerCase()} ritual—light a candle, tend a plant, open the window, or brew a tea that honours today’s element.`;
+}
+
+function reflectionGuidance(modality: string, signName: string): string {
+  return `${modality} wisdom invites journaling. Ask yourself where ${signName} can release an old pattern and invite fresher flow.`;
+}
+
+function adventureGuidance(keywords: string[]): string {
+  const idea = keywords[2] ?? keywords[0];
+  return `Schedule a micro-adventure that highlights your ${idea} spirit—an unfamiliar route, a new recipe, or a podcast swap with a friend.`;
+}
+
+export function buildFallbackHoroscope(date: string): DailyHoroscope {
+  const { summary, cosmicWeather, lunarPhase, highlight } = buildSummary(date);
+  const baseTimestamp = new Date().toISOString();
+
+  const signs: SignHoroscope[] = ZODIAC_SIGNS.map((sign, index) => {
+    const energy = ENERGY_WORDS[index % ENERGY_WORDS.length];
+    const mood = MOODS[index % MOODS.length];
+    const color = COLORS[index % COLORS.length];
+    const luckyNumbers = luckyNumbersFor(index, new Date(date).getUTCDate());
+
+    return {
+      id: sign.id,
+      name: sign.name,
+      dateRange: formatDateRange(sign),
+      element: sign.element,
+      modality: sign.modality,
+      rulingPlanet: sign.rulingPlanet,
+      icon: sign.icon,
+      headline: `${sign.name} Focus`,
+      summary: generalOutlook(sign.name, sign.keywords),
+      energy,
+      outlook: {
+        general: generalOutlook(sign.name, sign.keywords),
+        love: loveOutlook(sign.element, sign.rulingPlanet),
+        career: careerOutlook(sign.modality, sign.keywords),
+        wellness: wellnessOutlook(sign.element, sign.keywords),
+      },
+      relations: {
+        people: peopleRelations(sign.name),
+        pets: petRelations(sign.element),
+        planets: planetRelations(sign.rulingPlanet),
+        stars: starRelations(sign.modality),
+        stones: stoneRelations(sign.element),
+      },
+      guidance: {
+        ritual: ritualGuidance(sign.element),
+        reflection: reflectionGuidance(sign.modality, sign.name),
+        adventure: adventureGuidance(sign.keywords),
+      },
+      mood,
+      color,
+      mantra: `${sign.name} breathes in confidence and exhales possibility.`,
+      luckyNumbers,
+    };
+  });
+
+  return {
+    generatedFor: date,
+    generatedAt: baseTimestamp,
+    summary,
+    cosmicWeather,
+    lunarPhase,
+    highlight,
+    signs,
+  };
+}

--- a/WT4Q/services/astrology/index.ts
+++ b/WT4Q/services/astrology/index.ts
@@ -1,0 +1,42 @@
+import { API_ROUTES } from '@/lib/api';
+import { buildFallbackHoroscope } from './fallback';
+import type { DailyHoroscope } from './types';
+
+function todayUtcDate(): string {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+    .toISOString()
+    .slice(0, 10);
+}
+
+function isValidHoroscope(payload: unknown): payload is DailyHoroscope {
+  if (!payload || typeof payload !== 'object') return false;
+  const candidate = payload as DailyHoroscope;
+  return (
+    typeof candidate.generatedFor === 'string' &&
+    typeof candidate.generatedAt === 'string' &&
+    Array.isArray(candidate.signs) &&
+    candidate.signs.length === 12
+  );
+}
+
+export async function getDailyHoroscope(): Promise<DailyHoroscope> {
+  const fallbackDate = todayUtcDate();
+  try {
+    const response = await fetch(API_ROUTES.ASTROLOGY.TODAY, {
+      cache: 'no-store',
+      next: { revalidate: 0 },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to load horoscope: ${response.status}`);
+    }
+    const payload = (await response.json()) as unknown;
+    if (!isValidHoroscope(payload)) {
+      throw new Error('Horoscope payload malformed');
+    }
+    return payload;
+  } catch (error) {
+    console.error('[Astrology] Using local fallback horoscope', error);
+    return buildFallbackHoroscope(fallbackDate);
+  }
+}

--- a/WT4Q/services/astrology/signs.ts
+++ b/WT4Q/services/astrology/signs.ts
@@ -1,0 +1,202 @@
+export interface ZodiacSign {
+  id:
+    | 'aries'
+    | 'taurus'
+    | 'gemini'
+    | 'cancer'
+    | 'leo'
+    | 'virgo'
+    | 'libra'
+    | 'scorpio'
+    | 'sagittarius'
+    | 'capricorn'
+    | 'aquarius'
+    | 'pisces';
+  name: string;
+  startMonth: number;
+  startDay: number;
+  endMonth: number;
+  endDay: number;
+  element: 'Fire' | 'Earth' | 'Air' | 'Water';
+  modality: 'Cardinal' | 'Fixed' | 'Mutable';
+  rulingPlanet: string;
+  icon: string;
+  keywords: string[];
+}
+
+export const ZODIAC_SIGNS: ZodiacSign[] = [
+  {
+    id: 'aries',
+    name: 'Aries',
+    startMonth: 3,
+    startDay: 21,
+    endMonth: 4,
+    endDay: 19,
+    element: 'Fire',
+    modality: 'Cardinal',
+    rulingPlanet: 'Mars',
+    icon: '/images/astrology/aries.svg',
+    keywords: ['trailblazing', 'spontaneous', 'courageous'],
+  },
+  {
+    id: 'taurus',
+    name: 'Taurus',
+    startMonth: 4,
+    startDay: 20,
+    endMonth: 5,
+    endDay: 20,
+    element: 'Earth',
+    modality: 'Fixed',
+    rulingPlanet: 'Venus',
+    icon: '/images/astrology/taurus.svg',
+    keywords: ['grounded', 'sensual', 'steadfast'],
+  },
+  {
+    id: 'gemini',
+    name: 'Gemini',
+    startMonth: 5,
+    startDay: 21,
+    endMonth: 6,
+    endDay: 20,
+    element: 'Air',
+    modality: 'Mutable',
+    rulingPlanet: 'Mercury',
+    icon: '/images/astrology/gemini.svg',
+    keywords: ['curious', 'expressive', 'versatile'],
+  },
+  {
+    id: 'cancer',
+    name: 'Cancer',
+    startMonth: 6,
+    startDay: 21,
+    endMonth: 7,
+    endDay: 22,
+    element: 'Water',
+    modality: 'Cardinal',
+    rulingPlanet: 'Moon',
+    icon: '/images/astrology/cancer.svg',
+    keywords: ['nurturing', 'intuitive', 'protective'],
+  },
+  {
+    id: 'leo',
+    name: 'Leo',
+    startMonth: 7,
+    startDay: 23,
+    endMonth: 8,
+    endDay: 22,
+    element: 'Fire',
+    modality: 'Fixed',
+    rulingPlanet: 'Sun',
+    icon: '/images/astrology/leo.svg',
+    keywords: ['radiant', 'dramatic', 'charismatic'],
+  },
+  {
+    id: 'virgo',
+    name: 'Virgo',
+    startMonth: 8,
+    startDay: 23,
+    endMonth: 9,
+    endDay: 22,
+    element: 'Earth',
+    modality: 'Mutable',
+    rulingPlanet: 'Mercury',
+    icon: '/images/astrology/virgo.svg',
+    keywords: ['practical', 'precise', 'service-oriented'],
+  },
+  {
+    id: 'libra',
+    name: 'Libra',
+    startMonth: 9,
+    startDay: 23,
+    endMonth: 10,
+    endDay: 22,
+    element: 'Air',
+    modality: 'Cardinal',
+    rulingPlanet: 'Venus',
+    icon: '/images/astrology/libra.svg',
+    keywords: ['harmonising', 'diplomatic', 'refined'],
+  },
+  {
+    id: 'scorpio',
+    name: 'Scorpio',
+    startMonth: 10,
+    startDay: 23,
+    endMonth: 11,
+    endDay: 21,
+    element: 'Water',
+    modality: 'Fixed',
+    rulingPlanet: 'Pluto',
+    icon: '/images/astrology/scorpio.svg',
+    keywords: ['intense', 'transformative', 'magnetic'],
+  },
+  {
+    id: 'sagittarius',
+    name: 'Sagittarius',
+    startMonth: 11,
+    startDay: 22,
+    endMonth: 12,
+    endDay: 21,
+    element: 'Fire',
+    modality: 'Mutable',
+    rulingPlanet: 'Jupiter',
+    icon: '/images/astrology/sagittarius.svg',
+    keywords: ['adventurous', 'optimistic', 'philosophical'],
+  },
+  {
+    id: 'capricorn',
+    name: 'Capricorn',
+    startMonth: 12,
+    startDay: 22,
+    endMonth: 1,
+    endDay: 19,
+    element: 'Earth',
+    modality: 'Cardinal',
+    rulingPlanet: 'Saturn',
+    icon: '/images/astrology/capricorn.svg',
+    keywords: ['ambitious', 'structured', 'resilient'],
+  },
+  {
+    id: 'aquarius',
+    name: 'Aquarius',
+    startMonth: 1,
+    startDay: 20,
+    endMonth: 2,
+    endDay: 18,
+    element: 'Air',
+    modality: 'Fixed',
+    rulingPlanet: 'Uranus',
+    icon: '/images/astrology/aquarius.svg',
+    keywords: ['visionary', 'progressive', 'unconventional'],
+  },
+  {
+    id: 'pisces',
+    name: 'Pisces',
+    startMonth: 2,
+    startDay: 19,
+    endMonth: 3,
+    endDay: 20,
+    element: 'Water',
+    modality: 'Mutable',
+    rulingPlanet: 'Neptune',
+    icon: '/images/astrology/pisces.svg',
+    keywords: ['dreamy', 'empathetic', 'mystical'],
+  },
+];
+
+function pad(num: number): string {
+  return num.toString().padStart(2, '0');
+}
+
+function monthName(month: number): string {
+  return new Date(Date.UTC(2000, month - 1, 1)).toLocaleString('en-US', { month: 'short' });
+}
+
+export function formatDateRange(sign: ZodiacSign): string {
+  const start = `${monthName(sign.startMonth)} ${pad(sign.startDay)}`;
+  const end = `${monthName(sign.endMonth)} ${pad(sign.endDay)}`;
+  return `${start} – ${end}`;
+}
+
+export function findZodiacSign(id: string): ZodiacSign | undefined {
+  return ZODIAC_SIGNS.find((sign) => sign.id === id);
+}

--- a/WT4Q/services/astrology/types.ts
+++ b/WT4Q/services/astrology/types.ts
@@ -1,0 +1,97 @@
+export interface HoroscopeOutlook {
+  general: string;
+  love: string;
+  career: string;
+  wellness: string;
+}
+
+export interface HoroscopeRelations {
+  people: string;
+  pets: string;
+  planets: string;
+  stars: string;
+  stones: string;
+}
+
+export interface HoroscopeGuidance {
+  ritual: string;
+  reflection: string;
+  adventure: string;
+}
+
+export interface SignHoroscope {
+  id: string;
+  name: string;
+  dateRange: string;
+  element: string;
+  modality: string;
+  rulingPlanet: string;
+  icon: string;
+  headline: string;
+  summary: string;
+  energy: string;
+  outlook: HoroscopeOutlook;
+  relations: HoroscopeRelations;
+  guidance: HoroscopeGuidance;
+  mood: string;
+  color: string;
+  mantra: string;
+  luckyNumbers: number[];
+}
+
+export interface DailyHoroscope {
+  generatedFor: string; // YYYY-MM-DD in UTC
+  generatedAt: string; // ISO timestamp
+  summary: string;
+  cosmicWeather: string;
+  lunarPhase: string;
+  highlight: string;
+  signs: SignHoroscope[];
+}
+
+export interface GeminiHoroscopeResponse {
+  generatedFor: string;
+  summary: string;
+  cosmicWeather: string;
+  lunarPhase: string;
+  highlight: string;
+  signs: {
+    id: string;
+    headline: string;
+    summary: string;
+    energy: string;
+    outlook: HoroscopeOutlook;
+    relations: HoroscopeRelations;
+    guidance: HoroscopeGuidance;
+    mood: string;
+    color: string;
+    mantra: string;
+    luckyNumbers: number[];
+  }[];
+}
+
+export interface AstrologySubscription {
+  email: string;
+  userId?: string;
+  userName?: string;
+  signId: string;
+  countryCode: string;
+  timeZone: string;
+  sendHour: number;
+  createdAt: string;
+  updatedAt: string;
+  lastSentLocalDate?: string; // YYYY-MM-DD in subscriber timezone
+  active: boolean;
+}
+
+export interface DispatchReport {
+  sent: number;
+  attempted: number;
+  skipped: number;
+  pending: number;
+  detail: {
+    email: string;
+    reason?: string;
+    status: 'sent' | 'skipped' | 'pending';
+  }[];
+}

--- a/WT4Q/src/app/api/astrology/dispatch/route.ts
+++ b/WT4Q/src/app/api/astrology/dispatch/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_ROUTES } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function authorize(request: NextRequest): string | null {
+  const expected = process.env.ASTROLOGY_DISPATCH_TOKEN;
+  if (!expected) {
+    return request.headers.get('authorization') ?? null;
+  }
+  const header = request.headers.get('authorization');
+  if (!header) {
+    return null;
+  }
+  const token = header.replace(/^Bearer\s+/i, '').trim();
+  return token === expected ? header : null;
+}
+
+function forwardHeaders(source: Headers): Headers {
+  const headers = new Headers();
+  const contentType = source.get('content-type');
+  if (contentType) headers.set('content-type', contentType);
+  headers.set('cache-control', 'no-store');
+  return headers;
+}
+
+export async function POST(request: NextRequest) {
+  const authHeader = authorize(request);
+  if (process.env.ASTROLOGY_DISPATCH_TOKEN && !authHeader) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const response = await fetch(API_ROUTES.ASTROLOGY.DISPATCH, {
+    method: 'POST',
+    headers: authHeader ? { authorization: authHeader } : undefined,
+    cache: 'no-store',
+  });
+  const body = await response.text();
+  return new NextResponse(body, {
+    status: response.status,
+    headers: forwardHeaders(response.headers),
+  });
+}

--- a/WT4Q/src/app/api/astrology/subscribe/route.ts
+++ b/WT4Q/src/app/api/astrology/subscribe/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_ROUTES } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function forwardHeaders(source: Headers): Headers {
+  const headers = new Headers();
+  const contentType = source.get('content-type');
+  if (contentType) headers.set('content-type', contentType);
+  headers.set('cache-control', 'no-store');
+  return headers;
+}
+
+async function forward(request: NextRequest, init: RequestInit): Promise<NextResponse> {
+  const cookie = request.headers.get('cookie') ?? '';
+  const response = await fetch(API_ROUTES.ASTROLOGY.SUBSCRIPTION, {
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      cookie,
+    },
+    cache: 'no-store',
+  });
+
+  const body = await response.text();
+  return new NextResponse(body, {
+    status: response.status,
+    headers: forwardHeaders(response.headers),
+  });
+}
+
+export async function GET(request: NextRequest) {
+  return forward(request, { method: 'GET' });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  return forward(request, {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+export async function DELETE(request: NextRequest) {
+  return forward(request, { method: 'DELETE' });
+}

--- a/WT4Q/src/app/api/astrology/today/route.ts
+++ b/WT4Q/src/app/api/astrology/today/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { getDailyHoroscope } from '@/services/astrology';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET() {
+  const horoscope = await getDailyHoroscope();
+  return NextResponse.json(horoscope, {
+    headers: {
+      'Cache-Control': 'no-store, max-age=0',
+    },
+  });
+}

--- a/WT4Q/src/app/astrology/Astrology.module.css
+++ b/WT4Q/src/app/astrology/Astrology.module.css
@@ -1,0 +1,435 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-5), 3vw, var(--space-6));
+  color: var(--text-default);
+}
+
+.hero {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: calc(var(--radius) * 1.25);
+  box-shadow: 0 18px 38px rgba(20, 16, 10, 0.16);
+  padding: clamp(var(--space-5), 4vw, var(--space-6));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.heroDate {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: #9c7a3c;
+}
+
+.heroTitle {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-variant: small-caps;
+  margin-bottom: var(--space-2);
+}
+
+.heroSummary {
+  font-size: clamp(1.05rem, 1.2rem + 0.2vw, 1.35rem);
+  line-height: 1.6;
+  color: #44372a;
+}
+
+.heroHighlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.heroCard {
+  background: rgba(248, 246, 241, 0.9);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  border: 1px solid rgba(163, 124, 64, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.heroCard h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a37c40;
+  margin-bottom: var(--space-2);
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.refreshButton {
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(163, 124, 64, 0.35);
+  background: linear-gradient(135deg, #f2e9da 0%, #fdf8f0 100%);
+  color: #3a2b1d;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.refreshButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(20, 16, 10, 0.18);
+}
+
+.refreshButton:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.generatedTime {
+  font-size: 0.85rem;
+  color: #5d5245;
+}
+
+.error {
+  color: var(--error-red);
+  font-weight: 600;
+}
+
+.sectionTitle {
+  font-size: clamp(1.4rem, 1.2rem + 0.6vw, 2rem);
+  margin-bottom: var(--space-3);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.signGridSection {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: calc(var(--radius) * 1.1);
+  padding: clamp(var(--space-5), 4vw, var(--space-6));
+  box-shadow: 0 15px 32px rgba(18, 15, 11, 0.14);
+}
+
+.signGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-4);
+}
+
+.signCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius);
+  border: 1px solid rgba(163, 124, 64, 0.2);
+  background: rgba(250, 247, 240, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border var(--transition-fast);
+  text-align: center;
+}
+
+.signCard:hover,
+.signCard:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px rgba(20, 16, 10, 0.18);
+}
+
+.signCardActive {
+  border-color: #a37c40;
+  box-shadow: 0 14px 32px rgba(163, 124, 64, 0.22);
+}
+
+.signIcon {
+  width: 72px;
+  height: 72px;
+}
+
+.signName {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.signDates {
+  font-size: 0.85rem;
+  color: #5e5245;
+}
+
+.signEnergy {
+  font-size: 0.95rem;
+  color: #7b664c;
+}
+
+.detailSection {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: calc(var(--radius) * 1.2);
+  padding: clamp(var(--space-5), 4vw, var(--space-6));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  box-shadow: 0 18px 38px rgba(18, 15, 11, 0.16);
+}
+
+.detailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.detailHeading {
+  display: flex;
+  gap: var(--space-4);
+  align-items: center;
+}
+
+.detailIcon {
+  width: 96px;
+  height: 96px;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.12));
+}
+
+.detailMeta {
+  color: #6b5a46;
+  font-size: 0.95rem;
+}
+
+.detailMantra {
+  color: #3f3226;
+  font-style: italic;
+  margin-top: var(--space-2);
+}
+
+.detailStats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+}
+
+.detailStats div {
+  background: rgba(248, 245, 237, 0.9);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  border: 1px solid rgba(163, 124, 64, 0.18);
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #a37c40;
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
+.detailBody {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-4);
+}
+
+.detailCard {
+  background: rgba(250, 247, 240, 0.95);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  border: 1px solid rgba(163, 124, 64, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.detailCard h3 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a37c40;
+}
+
+.detailCard h4 {
+  font-size: 0.95rem;
+  margin-top: var(--space-2);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7b664c;
+}
+
+.detailCard ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.detailCard li p {
+  margin-top: var(--space-1);
+  color: #3f3327;
+}
+
+.subscriptionSection {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: calc(var(--radius) * 1.2);
+  padding: clamp(var(--space-5), 4vw, var(--space-6));
+  box-shadow: 0 18px 38px rgba(18, 15, 11, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.subscriptionIntro {
+  color: #4c3f32;
+  max-width: 60ch;
+}
+
+.subscriptionForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.formField {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-weight: 600;
+  color: #3f3226;
+}
+
+.select,
+.input {
+  border: 1px solid rgba(163, 124, 64, 0.35);
+  border-radius: var(--radius);
+  padding: 0.75rem 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  font: inherit;
+  color: inherit;
+}
+
+.select:focus,
+.input:focus {
+  border-color: #a37c40;
+  box-shadow: 0 0 0 2px rgba(163, 124, 64, 0.2);
+}
+
+.helpText {
+  font-size: 0.8rem;
+  color: #6b5a46;
+}
+
+.radioField {
+  border: 1px solid rgba(163, 124, 64, 0.35);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  background: rgba(250, 247, 240, 0.85);
+}
+
+.legend {
+  font-weight: 600;
+  color: #3f3226;
+  margin-right: var(--space-3);
+}
+
+.radioOption {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: 500;
+}
+
+.formActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.submitButton,
+.unsubscribeButton {
+  padding: 0.75rem 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(163, 124, 64, 0.4);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.submitButton {
+  background: linear-gradient(135deg, #f1e3c7 0%, #fdf7eb 100%);
+  color: #3f3226;
+}
+
+.unsubscribeButton {
+  background: transparent;
+  color: #6b5a46;
+}
+
+.submitButton:hover,
+.unsubscribeButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(18, 15, 11, 0.18);
+}
+
+.submitButton:disabled,
+.unsubscribeButton:disabled {
+  opacity: 0.6;
+  cursor: wait;
+  box-shadow: none;
+}
+
+.success {
+  color: #2f8f5b;
+  font-weight: 600;
+}
+
+.loginPrompt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+  background: rgba(250, 247, 240, 0.85);
+  border: 1px dashed rgba(163, 124, 64, 0.45);
+  border-radius: var(--radius);
+  padding: clamp(var(--space-4), 3vw, var(--space-5));
+}
+
+.loginLink {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(163, 124, 64, 0.4);
+  background: linear-gradient(135deg, #f2e9da 0%, #fdf8f0 100%);
+  font-weight: 600;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.loginLink:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(18, 15, 11, 0.18);
+}
+
+@media (max-width: 640px) {
+  .heroHighlights {
+    grid-template-columns: 1fr;
+  }
+
+  .detailHeading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .radioField {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .formActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/WT4Q/src/app/astrology/AstrologyClient.tsx
+++ b/WT4Q/src/app/astrology/AstrologyClient.tsx
@@ -1,0 +1,502 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+import PrefetchLink from '@/components/PrefetchLink';
+import { API_ROUTES, apiFetch } from '@/lib/api';
+import type { DailyHoroscope, SignHoroscope } from '@/services/astrology/types';
+import { ZODIAC_SIGNS } from '@/services/astrology/signs';
+import styles from './Astrology.module.css';
+
+type Props = {
+  initialHoroscope: DailyHoroscope;
+};
+
+type Country = {
+  name: string;
+  code: string;
+};
+
+type SessionUser = {
+  email: string;
+  userName?: string;
+};
+
+type SubscriptionResponse = {
+  signId: string;
+  countryCode: string;
+  timeZone: string;
+  sendHour: number;
+  lastSentLocalDate: string | null;
+  active: boolean;
+  signName: string;
+  userName: string | null;
+} | null;
+
+const DEFAULT_SEND_HOUR = 5;
+
+function formatDisplayDate(isoDate: string, timeZone?: string) {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  return date.toLocaleDateString('en-US', {
+    timeZone: timeZone || 'UTC',
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatUtcTime(iso: string) {
+  const time = new Date(iso);
+  return time.toLocaleString('en-US', {
+    timeZone: 'UTC',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function luckyNumbersText(sign: SignHoroscope) {
+  if (!sign.luckyNumbers || sign.luckyNumbers.length === 0) return '—';
+  return sign.luckyNumbers.join(', ');
+}
+
+export default function AstrologyClient({ initialHoroscope }: Props) {
+  const [horoscope, setHoroscope] = useState<DailyHoroscope>(initialHoroscope);
+  const [selectedSignId, setSelectedSignId] = useState<string>(
+    initialHoroscope.signs[0]?.id || ZODIAC_SIGNS[0].id,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [countries, setCountries] = useState<Country[]>([]);
+  const [user, setUser] = useState<SessionUser | null>(null);
+  const [subscription, setSubscription] = useState<SubscriptionResponse>(null);
+  const [formSignId, setFormSignId] = useState<string>(initialHoroscope.signs[0]?.id || 'aries');
+  const [countryCode, setCountryCode] = useState('');
+  const [timeZone, setTimeZone] = useState<string>(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch {
+      return 'UTC';
+    }
+  });
+  const [sendHour, setSendHour] = useState<number>(DEFAULT_SEND_HOUR);
+  const [feedback, setFeedback] = useState('');
+  const [formError, setFormError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const subscriptionSyncedRef = useRef(false);
+
+  const selectedSign = useMemo(() => {
+    return horoscope.signs.find((sign) => sign.id === selectedSignId) || horoscope.signs[0];
+  }, [horoscope.signs, selectedSignId]);
+
+  useEffect(() => {
+    fetch('/datas/Countries.json')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: Country[]) => {
+        if (Array.isArray(data)) {
+          const sorted = [...data].sort((a, b) => a.name.localeCompare(b.name));
+          setCountries(sorted);
+        }
+      })
+      .catch(() => setCountries([]));
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    apiFetch(API_ROUTES.AUTH.SESSION, { method: 'GET' })
+      .then((res) => res.json())
+      .then((session: { authenticated: boolean; user?: SessionUser }) => {
+        if (!mounted) return;
+        if (session.authenticated && session.user) {
+          setUser(session.user);
+        } else {
+          setUser(null);
+        }
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setUser(null);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const loadSubscription = () => {
+    if (!user) {
+      setSubscription(null);
+      subscriptionSyncedRef.current = false;
+      return;
+    }
+    fetch('/api/astrology/subscribe', { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: SubscriptionResponse) => {
+        setSubscription(data);
+        if (data) {
+          setFormSignId(data.signId);
+          setCountryCode(data.countryCode || '');
+          setSendHour(data.sendHour || DEFAULT_SEND_HOUR);
+          if (data.timeZone) setTimeZone(data.timeZone);
+          if (!subscriptionSyncedRef.current) {
+            setSelectedSignId(data.signId);
+            subscriptionSyncedRef.current = true;
+          }
+        } else {
+          subscriptionSyncedRef.current = false;
+        }
+      })
+      .catch(() => setSubscription(null));
+  };
+
+  useEffect(() => {
+    loadSubscription();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.email]);
+
+  const handleRefresh = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/astrology/today', { cache: 'no-store' });
+      if (!res.ok) {
+        throw new Error('Unable to refresh horoscope');
+      }
+      const data: DailyHoroscope = await res.json();
+      setHoroscope(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to refresh horoscope');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectSign = (id: string) => {
+    setSelectedSignId(id);
+    setFormSignId(id);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!user) return;
+    setSubmitting(true);
+    setFormError('');
+    setFeedback('');
+    try {
+      const res = await fetch('/api/astrology/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          signId: formSignId,
+          countryCode,
+          timeZone,
+          sendHour,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.message || 'Unable to save preference');
+      }
+      const data: SubscriptionResponse = await res.json();
+      setSubscription(data);
+      subscriptionSyncedRef.current = true;
+      setFeedback(
+        `Daily horoscope emails enabled for ${data?.signName || formSignId}. Delivery scheduled for ${sendHour}:00 AM ${timeZone}.`,
+      );
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Unable to save preference');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUnsubscribe = async () => {
+    if (!user) return;
+    setSubmitting(true);
+    setFormError('');
+    setFeedback('');
+    try {
+      const res = await fetch('/api/astrology/subscribe', { method: 'DELETE' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.message || 'Unable to update subscription');
+      }
+      setSubscription(null);
+      subscriptionSyncedRef.current = false;
+      setFeedback('Daily horoscope emails have been disabled.');
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Unable to update subscription');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const heroDate = formatDisplayDate(horoscope.generatedFor, timeZone);
+
+  return (
+    <main className={styles.main}>
+      <header className={styles.hero}>
+        <p className={styles.heroDate}>{heroDate}</p>
+        <h1 className={styles.heroTitle}>Today&apos;s Cosmic Horoscope</h1>
+        <p className={styles.heroSummary}>{horoscope.summary}</p>
+        <div className={styles.heroHighlights}>
+          <article className={styles.heroCard}>
+            <h2>Cosmic Weather</h2>
+            <p>{horoscope.cosmicWeather}</p>
+          </article>
+          <article className={styles.heroCard}>
+            <h2>Lunar Pulse</h2>
+            <p>{horoscope.lunarPhase}</p>
+          </article>
+          <article className={styles.heroCard}>
+            <h2>Daily Highlight</h2>
+            <p>{horoscope.highlight}</p>
+          </article>
+        </div>
+        <div className={styles.heroActions}>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            className={styles.refreshButton}
+            disabled={loading}
+          >
+            {loading ? 'Refreshing…' : 'Refresh horoscope'}
+          </button>
+          <span className={styles.generatedTime}>Generated at {formatUtcTime(horoscope.generatedAt)} UTC</span>
+        </div>
+        {error && <p className={styles.error}>{error}</p>}
+      </header>
+
+      <section className={styles.signGridSection}>
+        <h2 className={styles.sectionTitle}>Select your sign</h2>
+        <div className={styles.signGrid}>
+          {horoscope.signs.map((sign) => (
+            <button
+              key={sign.id}
+              type="button"
+              className={`${styles.signCard} ${selectedSignId === sign.id ? styles.signCardActive : ''}`}
+              onClick={() => handleSelectSign(sign.id)}
+              aria-pressed={selectedSignId === sign.id}
+            >
+              <Image
+                src={sign.icon}
+                alt={`${sign.name} symbol`}
+                width={72}
+                height={72}
+                className={styles.signIcon}
+              />
+              <span className={styles.signName}>{sign.name}</span>
+              <span className={styles.signDates}>{sign.dateRange}</span>
+              <span className={styles.signEnergy}>{sign.energy}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {selectedSign && (
+        <section className={styles.detailSection}>
+          <header className={styles.detailHeader}>
+            <div className={styles.detailHeading}>
+              <Image
+                src={selectedSign.icon}
+                alt={`${selectedSign.name} glyph`}
+                width={96}
+                height={96}
+                className={styles.detailIcon}
+              />
+              <div>
+                <h2>{selectedSign.name}</h2>
+                <p className={styles.detailMeta}>
+                  {selectedSign.dateRange} • {selectedSign.element} • {selectedSign.modality} •{' '}
+                  {selectedSign.rulingPlanet}
+                </p>
+                <p className={styles.detailMantra}>{selectedSign.mantra}</p>
+              </div>
+            </div>
+            <div className={styles.detailStats}>
+              <div>
+                <span className={styles.label}>Mood</span>
+                <span>{selectedSign.mood}</span>
+              </div>
+              <div>
+                <span className={styles.label}>Aura Color</span>
+                <span>{selectedSign.color}</span>
+              </div>
+              <div>
+                <span className={styles.label}>Lucky Numbers</span>
+                <span>{luckyNumbersText(selectedSign)}</span>
+              </div>
+            </div>
+          </header>
+          <div className={styles.detailBody}>
+            <article className={styles.detailCard}>
+              <h3>General Outlook</h3>
+              <p>{selectedSign.outlook.general}</p>
+              <h4>Love &amp; Relations</h4>
+              <p>{selectedSign.outlook.love}</p>
+              <h4>Career &amp; Purpose</h4>
+              <p>{selectedSign.outlook.career}</p>
+              <h4>Wellness</h4>
+              <p>{selectedSign.outlook.wellness}</p>
+            </article>
+            <article className={styles.detailCard}>
+              <h3>Relational Constellations</h3>
+              <ul>
+                <li>
+                  <span className={styles.label}>People</span>
+                  <p>{selectedSign.relations.people}</p>
+                </li>
+                <li>
+                  <span className={styles.label}>Pets</span>
+                  <p>{selectedSign.relations.pets}</p>
+                </li>
+                <li>
+                  <span className={styles.label}>Stars</span>
+                  <p>{selectedSign.relations.stars}</p>
+                </li>
+                <li>
+                  <span className={styles.label}>Planets</span>
+                  <p>{selectedSign.relations.planets}</p>
+                </li>
+                <li>
+                  <span className={styles.label}>Stones</span>
+                  <p>{selectedSign.relations.stones}</p>
+                </li>
+              </ul>
+            </article>
+            <article className={styles.detailCard}>
+              <h3>Guided Rituals</h3>
+              <ul>
+                <li>
+                  <span className={styles.label}>Morning ritual</span>
+                  <p>{selectedSign.guidance.ritual}</p>
+                </li>
+                <li>
+                  <span className={styles.label}>Reflection prompt</span>
+                  <p>{selectedSign.guidance.reflection}</p>
+                </li>
+                <li>
+                  <span className={styles.label}>Adventure cue</span>
+                  <p>{selectedSign.guidance.adventure}</p>
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      )}
+
+      <section className={styles.subscriptionSection}>
+        <h2 className={styles.sectionTitle}>Daily horoscope email</h2>
+        <p className={styles.subscriptionIntro}>
+          We compile your sign&apos;s horoscope every night at 00:00 GMT using Gemini, then deliver it to your
+          inbox at dawn. Choose a 5:00 AM or 6:00 AM delivery in your local timezone.
+        </p>
+        {user ? (
+          <form onSubmit={handleSubmit} className={styles.subscriptionForm}>
+            <div className={styles.formRow}>
+              <label className={styles.formField}>
+                Zodiac sign
+                <select
+                  value={formSignId}
+                  onChange={(e) => {
+                    setFormSignId(e.target.value);
+                    setSelectedSignId(e.target.value);
+                  }}
+                  className={styles.select}
+                >
+                  {horoscope.signs.map((sign) => (
+                    <option key={sign.id} value={sign.id}>
+                      {sign.name} ({sign.dateRange})
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className={styles.formField}>
+                Country
+                <select
+                  value={countryCode}
+                  onChange={(e) => setCountryCode(e.target.value)}
+                  className={styles.select}
+                >
+                  <option value="">Select country</option>
+                  {countries.map((country) => (
+                    <option key={country.code} value={country.code}>
+                      {country.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className={styles.formRow}>
+              <label className={styles.formField}>
+                Time zone
+                <input
+                  type="text"
+                  value={timeZone}
+                  onChange={(e) => setTimeZone(e.target.value)}
+                  className={styles.input}
+                  placeholder="e.g. America/New_York"
+                  required
+                />
+                <span className={styles.helpText}>
+                  Detected: {timeZone || 'UTC'} — emails send at your selected hour.
+                </span>
+              </label>
+              <fieldset className={`${styles.formField} ${styles.radioField}`}>
+                <legend className={styles.legend}>Delivery time</legend>
+                <label className={styles.radioOption}>
+                  <input
+                    type="radio"
+                    name="sendHour"
+                    value="5"
+                    checked={sendHour === 5}
+                    onChange={() => setSendHour(5)}
+                  />
+                  5:00 AM
+                </label>
+                <label className={styles.radioOption}>
+                  <input
+                    type="radio"
+                    name="sendHour"
+                    value="6"
+                    checked={sendHour === 6}
+                    onChange={() => setSendHour(6)}
+                  />
+                  6:00 AM
+                </label>
+              </fieldset>
+            </div>
+            <div className={styles.formActions}>
+              <button type="submit" className={styles.submitButton} disabled={submitting}>
+                {submitting ? 'Saving…' : 'Save preferences'}
+              </button>
+              {subscription && (
+                <button
+                  type="button"
+                  className={styles.unsubscribeButton}
+                  onClick={handleUnsubscribe}
+                  disabled={submitting}
+                >
+                  Stop emails
+                </button>
+              )}
+            </div>
+            {feedback && <p className={styles.success}>{feedback}</p>}
+            {formError && <p className={styles.error}>{formError}</p>}
+            {subscription?.lastSentLocalDate && (
+              <p className={styles.helpText}>
+                Last delivered on {formatDisplayDate(subscription.lastSentLocalDate, timeZone)}.
+              </p>
+            )}
+          </form>
+        ) : (
+          <div className={styles.loginPrompt}>
+            <p>Sign in to schedule your personalised daily horoscope email.</p>
+            <PrefetchLink href="/login" className={styles.loginLink}>
+              Sign in to subscribe
+            </PrefetchLink>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/WT4Q/src/app/astrology/page.tsx
+++ b/WT4Q/src/app/astrology/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { getDailyHoroscope } from '@/services/astrology';
+import AstrologyClient from './AstrologyClient';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: 'Daily Astrology Horoscope | The Nineties Times',
+  description:
+    'Personalised daily astrology from The Nineties Times. Explore Gemini-powered guidance for every zodiac sign, relationship tips, rituals, stones, and celestial influences, refreshed at midnight GMT.',
+  keywords: [
+    'daily horoscope',
+    'astrology forecast',
+    'zodiac compatibility',
+    'horoscope email subscription',
+    'gemini ai horoscope',
+    'the nineties times astrology',
+  ],
+};
+
+export default async function AstrologyPage() {
+  const horoscope = await getDailyHoroscope();
+  return <AstrologyClient initialHoroscope={horoscope} />;
+}

--- a/WT4Q/src/app/sitemap.ts
+++ b/WT4Q/src/app/sitemap.ts
@@ -55,6 +55,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/',
     '/about',
     '/contact',
+    '/astrology',
     '/games',
     '/tools',
     '/search',

--- a/WT4Q/src/components/CategoryNavbar.tsx
+++ b/WT4Q/src/components/CategoryNavbar.tsx
@@ -108,6 +108,9 @@ export default function CategoryNavbar({ open, onNavigate, forceSidebar }: Props
       <PrefetchLink href="/weather" className={styles.link} onClick={onNavigate}>
         Weather
       </PrefetchLink>
+      <PrefetchLink href="/astrology" className={styles.link} onClick={onNavigate}>
+        Astrology
+      </PrefetchLink>
       <PrefetchLink href="/bar" className={styles.link} onClick={onNavigate}>
         Bar
       </PrefetchLink>


### PR DESCRIPTION
## Summary
- introduce ASP.NET astrology models, services, Gemini client, dispatcher, and controller to generate, cache, and email daily horoscopes
- add EF Core migration and DbContext updates for horoscope records and user subscriptions
- point the Next.js astrology routes and utilities to the ASP.NET API and remove local file-based handling

## Testing
- npm run lint *(warnings: pre-existing eslint notices in mememaker and ArticleCard components)*

------
https://chatgpt.com/codex/tasks/task_e_68c998050f4c8327b2b3f8306c7d1465