### PR TITLE
Fix inconsistent accessibility in astrology services

### DIFF
--- a/Northeast/Services/Astrology/AstrologyModels.cs
+++ b/Northeast/Services/Astrology/AstrologyModels.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Northeast.Services.Astrology
 {
-    internal class HoroscopeOutlookModel
+    public class HoroscopeOutlookModel
     {
         public string General { get; set; } = string.Empty;
         public string Love { get; set; } = string.Empty;
@@ -10,7 +10,7 @@ namespace Northeast.Services.Astrology
         public string Wellness { get; set; } = string.Empty;
     }
 
-    internal class HoroscopeRelationsModel
+    public class HoroscopeRelationsModel
     {
         public string People { get; set; } = string.Empty;
         public string Pets { get; set; } = string.Empty;
@@ -19,14 +19,14 @@ namespace Northeast.Services.Astrology
         public string Stones { get; set; } = string.Empty;
     }
 
-    internal class HoroscopeGuidanceModel
+    public class HoroscopeGuidanceModel
     {
         public string Ritual { get; set; } = string.Empty;
         public string Reflection { get; set; } = string.Empty;
         public string Adventure { get; set; } = string.Empty;
     }
 
-    internal class SignHoroscopeModel
+    public class SignHoroscopeModel
     {
         public string Id { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
@@ -47,7 +47,7 @@ namespace Northeast.Services.Astrology
         public List<int> LuckyNumbers { get; set; } = new();
     }
 
-    internal class DailyHoroscopeModel
+    public class DailyHoroscopeModel
     {
         public DateOnly ForDate { get; set; }
         public DateTime GeneratedAtUtc { get; set; }

--- a/Northeast/Services/Astrology/GeminiAstrologyClient.cs
+++ b/Northeast/Services/Astrology/GeminiAstrologyClient.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 
 namespace Northeast.Services.Astrology
 {
-    internal class GeminiAstrologyClient
+    public class GeminiAstrologyClient
     {
         private readonly HttpClient _httpClient;
         private readonly AstrologyOptions _options;
@@ -23,7 +23,7 @@ namespace Northeast.Services.Astrology
 
         private record GeminiPart(string Text);
 
-        internal class GeminiHoroscopePayload
+        public class GeminiHoroscopePayload
         {
             public string GeneratedFor { get; set; } = string.Empty;
             public string Summary { get; set; } = string.Empty;
@@ -33,7 +33,7 @@ namespace Northeast.Services.Astrology
             public List<GeminiSignPayload> Signs { get; set; } = new();
         }
 
-        internal class GeminiSignPayload
+        public class GeminiSignPayload
         {
             public string Id { get; set; } = string.Empty;
             public string Headline { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- make the astrology horoscope models public so they can be used by public service methods
- expose the Gemini astrology client and payload types to match the public service constructor and API surface

## Testing
- dotnet build *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b1cc73e4832782b422ba0b651d78