### PR TITLE
Avoid hitting authenticated APIs for logged-out visitors

### DIFF
--- a/WT4Q/src/components/VisitorMap.tsx
+++ b/WT4Q/src/components/VisitorMap.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { API_ROUTES, apiFetch } from '@/lib/api';
+import { isLoggedIn } from '@/lib/auth';
 import styles from './VisitorMap.module.css';
 
 interface VisitorInfo {
@@ -14,10 +15,21 @@ export default function VisitorMap() {
   const [info, setInfo] = useState<VisitorInfo | null>(null);
 
   useEffect(() => {
+    if (!isLoggedIn()) return;
+
+    let active = true;
+
     apiFetch(API_ROUTES.USER_LOCATION.GET)
       .then((res) => (res.ok ? res.json() : null))
-      .then((data) => setInfo(data))
+      .then((data) => {
+        if (!active) return;
+        setInfo(data);
+      })
       .catch(() => {});
+
+    return () => {
+      active = false;
+    };
   }, []);
 
   if (!info) return null;


### PR DESCRIPTION
## Summary
- check the client login flag before requesting session/me endpoints
- clear the stored login flag when authenticated requests fail to avoid loops
- skip loading the visitor map when the viewer is logged out

## Testing
- npm test *(fails: tests/engine.test.ts > engine basics > allows buying unowned property, pays rent when landing on opponent property)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1019cfa083278a1e09022086dfd7