### PR TITLE
Fix article auth check and sync view counter

### DIFF
--- a/WT4Q/src/app/articles/[title]/page.tsx
+++ b/WT4Q/src/app/articles/[title]/page.tsx
@@ -20,6 +20,7 @@ const articleInter = Inter({
 import type { ArticleImage } from '@/lib/models';
 import PrefetchLink from '@/components/PrefetchLink';
 import ArticleTTS from '@/components/ArticleTTS';
+import ArticleViewCounter from '@/components/ArticleViewCounter';
 const ReactionButtons = dynamic(() => import('@/components/ReactionButtons'));
 const CommentsSection = dynamic(() => import('@/components/CommentsSection'));
 const LocalArticleSection = dynamic(() => import('@/components/LocalArticleSection'));
@@ -197,16 +198,14 @@ export default async function ArticlePage(
         {article.summary && (
           <p className={styles.summary}>{article.summary}</p>
         )}
-          <p className={styles.meta}>
+        <p className={styles.meta}>
           {new Date(article.createdDate).toLocaleDateString(undefined, {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
           })}
           {article.countryName ? ` | ${article.countryName}` : ''}
-          {typeof article.views === 'number'
-            ? ` | ${article.views.toLocaleString()} views`
-            : ''}
+          <ArticleViewCounter articleId={article.id} initialViews={article.views} />
         </p>
 
         {article.images && article.images.length > 0 && (

--- a/WT4Q/src/components/ArticleViewCounter.tsx
+++ b/WT4Q/src/components/ArticleViewCounter.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { API_ROUTES } from '@/lib/api';
+
+function extractViews(data: unknown): number | null {
+  if (!data || typeof data !== 'object') return null;
+  const record = data as Record<string, unknown>;
+  const candidates = ['views', 'viewCount', 'viewsCount'];
+  for (const key of candidates) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+interface ArticleViewCounterProps {
+  articleId: string;
+  initialViews?: number | null;
+  pollIntervalMs?: number;
+}
+
+export default function ArticleViewCounter({
+  articleId,
+  initialViews,
+  pollIntervalMs = 30000,
+}: ArticleViewCounterProps) {
+  const [views, setViews] = useState<number | null>(
+    typeof initialViews === 'number' && Number.isFinite(initialViews)
+      ? initialViews
+      : null,
+  );
+
+  useEffect(() => {
+    if (!articleId) return undefined;
+
+    let cancelled = false;
+
+    const update = async () => {
+      try {
+        const res = await fetch(API_ROUTES.ARTICLE.GET_BY_ID(articleId), {
+          cache: 'no-store',
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        const next = extractViews(data);
+        if (!cancelled && typeof next === 'number') {
+          setViews(next);
+        }
+      } catch {
+        // Ignore network errors; they likely mean the API is temporarily unavailable.
+      }
+    };
+
+    const initialTimeout = setTimeout(update, 1200);
+    const interval = setInterval(update, pollIntervalMs);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(initialTimeout);
+      clearInterval(interval);
+    };
+  }, [articleId, pollIntervalMs]);
+
+  if (views === null) {
+    return null;
+  }
+
+  return <> | {views.toLocaleString()} views</>;
+}

--- a/WT4Q/src/components/CommentsSection.tsx
+++ b/WT4Q/src/components/CommentsSection.tsx
@@ -40,12 +40,19 @@ export default function CommentsSection({
     let active = true;
 
     if (isLoggedIn()) {
-      apiFetch(API_ROUTES.USERS.ME, { method: 'GET' })
+      apiFetch(API_ROUTES.AUTH.SESSION, { method: 'GET' })
         .then((res) => (res.ok ? res.json() : Promise.reject()))
-        .then((user: { userName?: string }) => {
+        .then((session: { authenticated?: boolean; user?: { userName?: string } }) => {
           if (!active) return;
-          setLoggedInState(true);
-          setCurrentUser(user.userName || null);
+          if (session.authenticated && session.user) {
+            setLoggedInState(true);
+            setCurrentUser(session.user.userName || null);
+            setLoggedIn(true);
+          } else {
+            setLoggedInState(false);
+            setCurrentUser(null);
+            setLoggedIn(false);
+          }
         })
         .catch(() => {
           if (!active) return;


### PR DESCRIPTION
## Summary
- switch the article comments auth check to the session endpoint so expired logins no longer hit `/api/User/me`
- add an `ArticleViewCounter` client component and wire it into the article page so the view total refreshes after logging the visit
- import the new counter on the article page to replace the inline view text

## Testing
- npm run lint
- npm test *(fails: existing Monopoly engine tests already failing locally)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2396315c8327a369de371fa3ecd5