### PR TITLE
Stabilize local news slider layout

### DIFF
--- a/WT4Q/src/components/ArticleCard.module.css
+++ b/WT4Q/src/components/ArticleCard.module.css
@@ -1,5 +1,7 @@
 .card {
-  display: block;
+  display: grid;
+  grid-template-rows: auto minmax(5.6em, auto) auto auto;
+  gap: 0.5rem;
   padding: 0.75rem;
   margin: 0.25rem 0;
   background: #ffffff00;
@@ -7,6 +9,8 @@
   border: 1px solid var(--thin-rule, #2c1616);
   box-shadow: inset 0 0 0 1px var(--thin-rule, #2c1616);
   border-radius: 0.5rem;
+  height: 100%;
+  box-sizing: border-box;
 }
 
 .title {
@@ -27,17 +31,23 @@
 }
 
 .summary {
-  margin: 0 0 0.5rem;
+  margin: 0;
   color: var(--muted, #555);
   line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-clamp: 4;
+  max-height: 5.6em;
 }
 
 .readMore {
   display: inline-block;
-  margin-bottom: 0.5rem;
   font-size: 0.75rem;
   color: var(--accent, #6a0000);
   text-decoration: none;
+  align-self: start;
 }
 
 .readMore:hover,
@@ -53,6 +63,7 @@
   gap: 0.5rem;
   font-size: 0.75rem;
   color: var(--muted, #666);
+  align-self: end;
 }
 
 .metaItem {

--- a/WT4Q/src/components/LocalArticleSection.module.css
+++ b/WT4Q/src/components/LocalArticleSection.module.css
@@ -7,8 +7,76 @@
   margin-bottom: 0.5rem;
 }
 
+.viewport {
+  position: relative;
+  min-height: var(--local-card-min-height, 16rem);
+}
+
 .slider {
   position: relative;
+  min-height: var(--local-card-min-height, 16rem);
+  display: flex;
+  align-items: stretch;
+}
+
+.slider :global(article) {
+  flex: 1;
+  height: 100%;
+  margin: 0;
+}
+
+.skeleton,
+.emptyState {
+  min-height: var(--local-card-min-height, 16rem);
+  border-radius: 0.5rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--thin-rule, #b6b6b6);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.skeleton {
+  display: grid;
+  gap: 0.75rem;
+  overflow: hidden;
+}
+
+.skeletonTitle,
+.skeletonLine,
+.skeletonMeta {
+  display: block;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.08));
+  background-size: 200% 100%;
+  animation: skeletonPulse 1.6s ease-in-out infinite;
+}
+
+.skeletonTitle {
+  height: 1.1rem;
+  width: 70%;
+}
+
+.skeletonLine {
+  width: 100%;
+}
+
+.skeletonLineShort {
+  width: 55%;
+}
+
+.skeletonMeta {
+  width: 40%;
+  height: 0.6rem;
+}
+
+.emptyState {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: var(--muted, #555);
+  font-size: 0.95rem;
+  line-height: 1.4;
 }
 
 .arrow {
@@ -49,3 +117,15 @@
 }
 
 .arrow:hover svg { transform: scale(1.12); }
+
+@keyframes skeletonPulse {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit loading/empty states to the local news section so the widget reserves space while location-based articles load
- redesign the local news styles and article cards to enforce a consistent card height and provide a skeleton placeholder that prevents layout shifts

## Testing
- npm run lint
- npm test *(fails: existing Monopoly engine tests already failing in main)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7fdbc0b08327bdc904b541120844