### PR TITLE
Enhance SEO metadata and caching

### DIFF
--- a/WT4Q/lib/categories.ts
+++ b/WT4Q/lib/categories.ts
@@ -1,28 +1,167 @@
 export const UPLOADCATEGORIES = [
-  'Politics',
-  'Crime',
-  'Entertainment',
-  'Business',
-  'Health',
-  'Lifestyle',
-  'Technology',
-  'Science',
-  'Sports',
-  'Info'
+  "Politics",
+  "Crime",
+  "Entertainment",
+  "Business",
+  "Health",
+  "Lifestyle",
+  "Technology",
+  "Science",
+  "Sports",
+  "Info",
 ];
 
 export const CATEGORIES = [
-  'Politics',
-  'Crime',
-  'Entertainment',
-  'Business',
-  'Health',
-  'Lifestyle',
-  'Technology',
-  'Science',
-  'Sports',
-  'Info'
+  "Politics",
+  "Crime",
+  "Entertainment",
+  "Business",
+  "Health",
+  "Lifestyle",
+  "Technology",
+  "Science",
+  "Sports",
+  "Info",
 ];
+
+/**
+ * Rich descriptions and keyword sets for each category help us compose
+ * consistent metadata that search engines can understand. These strings are
+ * intentionally human readable so that they double as page copy when needed.
+ */
+export const CATEGORY_DETAILS: Record<
+  string,
+  { description: string; keywords: string[] }
+> = {
+  Politics: {
+    description:
+      "Independent political reporting, election coverage, public policy analysis and accountability journalism focused on governments across the globe.",
+    keywords: [
+      "politics news",
+      "government",
+      "public policy",
+      "elections",
+      "geopolitics",
+    ],
+  },
+  Crime: {
+    description:
+      "Breaking crime reports, justice system updates, public safety investigations and law-enforcement accountability stories.",
+    keywords: [
+      "crime news",
+      "courts",
+      "justice system",
+      "law enforcement",
+      "public safety",
+    ],
+  },
+  Entertainment: {
+    description:
+      "Entertainment headlines covering film, television, streaming, celebrity interviews and culture analysis from the 90s and today.",
+    keywords: [
+      "entertainment news",
+      "movies",
+      "television",
+      "celebrity",
+      "culture",
+    ],
+  },
+  Business: {
+    description:
+      "Market-moving business news, company earnings, entrepreneurship features and deep dives on the global economy.",
+    keywords: [
+      "business news",
+      "economy",
+      "markets",
+      "finance",
+      "entrepreneurship",
+    ],
+  },
+  Health: {
+    description:
+      "Health reporting spanning medical research, public health guidance, mental wellness and healthcare policy updates.",
+    keywords: [
+      "health news",
+      "medical research",
+      "public health",
+      "wellness",
+      "health policy",
+    ],
+  },
+  Lifestyle: {
+    description:
+      "Lifestyle stories about travel, food, fashion, home, relationships and inspiration for living well.",
+    keywords: [
+      "lifestyle news",
+      "travel",
+      "food",
+      "fashion",
+      "home inspiration",
+    ],
+  },
+  Technology: {
+    description:
+      "Technology reporting on innovation, startups, consumer gadgets, cybersecurity and the companies shaping the digital era.",
+    keywords: [
+      "technology news",
+      "startups",
+      "innovation",
+      "gadgets",
+      "cybersecurity",
+    ],
+  },
+  Science: {
+    description:
+      "Scientific discoveries, space exploration, climate research and explainers that make complex breakthroughs accessible.",
+    keywords: [
+      "science news",
+      "space",
+      "climate",
+      "research",
+      "discoveries",
+    ],
+  },
+  Sports: {
+    description:
+      "Scores, analysis and features from global sports, leagues, athletes and major tournaments.",
+    keywords: [
+      "sports news",
+      "athletes",
+      "scores",
+      "tournaments",
+      "analysis",
+    ],
+  },
+  Info: {
+    description:
+      "In-depth explainers, guides, fact checks and service journalism that help readers stay informed and prepared.",
+    keywords: [
+      "explainer",
+      "guides",
+      "how to",
+      "service journalism",
+      "fact check",
+    ],
+  },
+};
+
+const CATEGORY_LOOKUP = new Map<string, string>(
+  CATEGORIES.map((name) => [name.toLowerCase(), name] as const),
+);
+
+export function normalizeCategoryName(input: string): string | null {
+  const normalized = CATEGORY_LOOKUP.get(input.toLowerCase());
+  return normalized ?? null;
+}
+
+export function getCategoryDetails(category: string) {
+  const name = normalizeCategoryName(category) ?? category;
+  const details = CATEGORY_DETAILS[name] ?? {
+    description: `Latest ${name} coverage from The Nineties Times.`,
+    keywords: [name, "The Nineties Times", "90sTimes"],
+  };
+  return { name, ...details };
+}
 
 /*namespace Northeast.Models
 {

--- a/WT4Q/src/app/category/[category]/categoryPage.module.css
+++ b/WT4Q/src/app/category/[category]/categoryPage.module.css
@@ -3,6 +3,13 @@
   font-size: 0.6em; /* 30% smaller */
 }
 
+.categoryDescription {
+  margin: 0.5rem 0 1.5rem;
+  max-width: 60ch;
+  color: var(--muted-text, #4a4a4a);
+  line-height: 1.6;
+}
+
 .horizontalCards {
   display: flex;
   gap: 1rem;

--- a/WT4Q/src/app/news-sitemap-[index].xml/route.ts
+++ b/WT4Q/src/app/news-sitemap-[index].xml/route.ts
@@ -1,5 +1,7 @@
 import { chunkArticles, buildNewsXml, fetchRecentArticles, MAX_NEWS_ARTICLES } from '@/lib/news-sitemap';
 import type { NextRequest } from 'next/server';
+
+export const revalidate = 300;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export async function GET(

--- a/WT4Q/src/app/news-sitemap.xml/route.ts
+++ b/WT4Q/src/app/news-sitemap.xml/route.ts
@@ -1,5 +1,7 @@
 import { chunkArticles, buildNewsXml, buildNewsIndex, fetchRecentArticles, MAX_NEWS_ARTICLES } from '@/lib/news-sitemap';
 
+export const revalidate = 300;
+
 export async function GET(): Promise<Response> {
   const articles = await fetchRecentArticles();
   const chunks = chunkArticles(articles, MAX_NEWS_ARTICLES);

--- a/WT4Q/src/app/search/page.tsx
+++ b/WT4Q/src/app/search/page.tsx
@@ -1,13 +1,27 @@
 'use client';
 
-export const dynamic = 'force-dynamic';
-
+import type { Metadata } from 'next';
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import PrefetchLink from '@/components/PrefetchLink';
 import ArticleCard, { Article } from '@/components/ArticleCard';
 import { API_ROUTES } from '@/lib/api';
 import styles from './search.module.css';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Search the archives | The Nineties Times',
+  description:
+    'Find articles across politics, business, sports, culture and more from The Nineties Times archive.',
+  robots: {
+    index: false,
+    follow: true,
+  },
+  alternates: {
+    canonical: '/search',
+  },
+};
 
 function SearchContent() {
   const router = useRouter();

--- a/WT4Q/src/app/sitemap.ts
+++ b/WT4Q/src/app/sitemap.ts
@@ -1,28 +1,45 @@
 import type { MetadataRoute } from 'next';
+import { unstable_cache } from 'next/cache';
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
 
-async function fetchArticlePaths(): Promise<string[]> {
-  try {
-    const res = await fetch(API_ROUTES.ARTICLE.GET_ALL, { cache: 'no-store' });
-    if (!res.ok) return [];
-    const articles: { slug: string; createdDate?: string }[] = await res.json();
-    // Newest first by createdDate; unknown dates go last
-    articles.sort((a, b) => {
-      const ta = new Date(a.createdDate ?? 0).getTime();
-      const tb = new Date(b.createdDate ?? 0).getTime();
-      return tb - ta;
-    });
-    return articles.map(a => `/articles/${a.slug}`);
-  } catch {
-    return [];
-  }
+type ArticleRoute = { path: string; lastModified?: Date };
+
+const loadArticleRoutes = unstable_cache(
+  async (): Promise<ArticleRoute[]> => {
+    try {
+      const res = await fetch(API_ROUTES.ARTICLE.GET_ALL, {
+        next: { revalidate: 600 },
+      });
+      if (!res.ok) return [];
+      const articles: { slug: string; createdDate?: string; updatedDate?: string }[] =
+        await res.json();
+      return articles.map((article) => {
+        const candidate = article.updatedDate ?? article.createdDate;
+        const time = candidate ? new Date(candidate) : undefined;
+        const lastModified =
+          time && !Number.isNaN(time.getTime()) ? time : undefined;
+        return {
+          path: `/articles/${article.slug}`,
+          lastModified,
+        } satisfies ArticleRoute;
+      });
+    } catch {
+      return [];
+    }
+  },
+  ['sitemap-article-routes'],
+  { revalidate: 600 },
+);
+
+async function fetchArticlePaths(): Promise<ArticleRoute[]> {
+  return loadArticleRoutes();
 }
 
 function getCategoryPaths(): string[] {
-  return CATEGORIES.map(c => `/category/${encodeURIComponent(c)}`);
+  return CATEGORIES.map((c) => `/category/${encodeURIComponent(c)}`);
 }
 
 async function getSubPaths(dir: string): Promise<string[]> {
@@ -33,7 +50,7 @@ async function getSubPaths(dir: string): Promise<string[]> {
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const files = await readdir(join(base, entry.name));
-      if (files.some(f => /^page\.(t|j)sx?$/.test(f))) {
+      if (files.some((f) => /^page\.(t|j)sx?$/.test(f))) {
         paths.push(`/${dir}/${entry.name}`);
       }
     }
@@ -45,31 +62,105 @@ async function getSubPaths(dir: string): Promise<string[]> {
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.90stimes.com';
-  const [articlePaths, categoryPaths, toolPaths, gamePaths] = await Promise.all([
+  const [articleRoutes, categoryPaths, toolPaths, gamePaths] = await Promise.all([
     fetchArticlePaths(),
     getCategoryPaths(),
     getSubPaths('tools'),
     getSubPaths('games'),
   ]);
-  const staticPages = [
-    '/',
-    '/about',
-    '/contact',
-    '/games',
-    '/tools',
-    '/search',
-    '/privacy',
-    '/terms',
-    '/weather',
+
+  const now = new Date();
+
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: `${siteUrl}/`,
+      changeFrequency: 'hourly',
+      priority: 1,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/about`,
+      changeFrequency: 'yearly',
+      priority: 0.6,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/contact`,
+      changeFrequency: 'yearly',
+      priority: 0.5,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/games`,
+      changeFrequency: 'weekly',
+      priority: 0.6,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/tools`,
+      changeFrequency: 'weekly',
+      priority: 0.6,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/search`,
+      changeFrequency: 'monthly',
+      priority: 0.3,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/privacy`,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/terms`,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+      lastModified: now,
+    },
+    {
+      url: `${siteUrl}/weather`,
+      changeFrequency: 'daily',
+      priority: 0.4,
+      lastModified: now,
+    },
   ];
 
-  return [
-    ...staticPages,
-    ...categoryPaths,
-    ...articlePaths,
-    ...toolPaths,
-    ...gamePaths,
-  ].map(path => ({
+  const categoryEntries: MetadataRoute.Sitemap = categoryPaths.map((path) => ({
     url: `${siteUrl}${path}`,
+    changeFrequency: 'hourly',
+    priority: 0.7,
   }));
+
+  const articleEntries: MetadataRoute.Sitemap = articleRoutes.map(({
+    path,
+    lastModified,
+  }) => ({
+    url: `${siteUrl}${path}`,
+    changeFrequency: 'hourly',
+    priority: 0.8,
+    lastModified,
+  }));
+
+  const toolEntries: MetadataRoute.Sitemap = toolPaths.map((path) => ({
+    url: `${siteUrl}${path}`,
+    changeFrequency: 'weekly',
+    priority: 0.4,
+  }));
+
+  const gameEntries: MetadataRoute.Sitemap = gamePaths.map((path) => ({
+    url: `${siteUrl}${path}`,
+    changeFrequency: 'weekly',
+    priority: 0.4,
+  }));
+
+  return [
+    ...staticEntries,
+    ...categoryEntries,
+    ...articleEntries,
+    ...toolEntries,
+    ...gameEntries,
+  ];
 }


### PR DESCRIPTION
## Summary
- add rich category metadata, static generation, structured data, and capped fetch sizes to improve category page SEO/performance
- cache article listings for sitemaps/news sitemaps and expose change frequency + last modified hints for crawlers
- annotate search and local news features with better SEO defaults and lifecycle handling

## Testing
- ✅ `npm run lint`
- ❌ `npm run test` *(fails in existing tests: engine basics > allows buying unowned property / pays rent when landing on opponent property)*

------
https://chatgpt.com/codex/tasks/task_e_68cda2ebb87c8327bdbd0d9f7ae29161