### PR TITLE
Reduce header-induced layout shifts

### DIFF
--- a/WT4Q/next-env.d.ts
+++ b/WT4Q/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/WT4Q/src/app/globals.css
+++ b/WT4Q/src/app/globals.css
@@ -64,8 +64,8 @@
   --transition-fast: 120ms;
   --shadow-elev: 0 6px 15px rgba(0,0,0,0.4);
   --shadow-elev-lg: 0 12px 25px rgba(0,0,0,0.45);
-  /* Fixed header height placeholder, updated at runtime */
-  --header-height: 120px;
+  /* Reserve space for the fixed header without JS measurements */
+  --header-height: calc(clamp(1.6rem, 6vw, 3.6rem) * 1.1 + 6.75rem);
 }
 
 /* Dark scheme tweaks (kept) */

--- a/WT4Q/src/components/Header.tsx
+++ b/WT4Q/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import PrefetchLink from './PrefetchLink';
 import CategoryNavbar from './CategoryNavbar';
 import UserMenu from './UserMenu';
@@ -13,7 +13,6 @@ import styles from './Header.module.css';
 export default function Header() {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const headerRef = useRef<HTMLElement | null>(null);
   const dateline = new Date().toLocaleDateString('en-US', {
     weekday: 'long',
     year: 'numeric',
@@ -44,28 +43,6 @@ export default function Header() {
     };
   }, []);
 
-  // Measure header height to offset page content below fixed header
-  useEffect(() => {
-    const updateHeight = () => {
-      const h = headerRef.current?.offsetHeight || 0;
-      if (h > 0) {
-        document.documentElement.style.setProperty('--header-height', `${h}px`);
-      }
-    };
-    updateHeight();
-    // Observe size changes for dynamic elements (e.g., categories show/hide)
-    let ro: ResizeObserver | null = null;
-    if (typeof window !== 'undefined' && 'ResizeObserver' in window && headerRef.current) {
-      ro = new ResizeObserver(() => updateHeight());
-      ro.observe(headerRef.current);
-    }
-    window.addEventListener('resize', updateHeight);
-    return () => {
-      ro?.disconnect();
-      window.removeEventListener('resize', updateHeight);
-    };
-  }, [scrolled]);
-
   // Reflect scrolled state as a root class for cross-component styling
   useEffect(() => {
     const root = document.documentElement;
@@ -79,7 +56,7 @@ export default function Header() {
   // No portal: rely on CSS to show/hide the sidebar when scrolled/mobile
 
   return (
-    <header ref={headerRef} className={`${styles.header} ${scrolled ? styles.scrolled : ''}`}>
+    <header className={`${styles.header} ${scrolled ? styles.scrolled : ''}`}>
       {open && <div className={styles.overlay} onClick={() => setOpen(false)} />}
       <div className={styles.inner}>
         {/* Mobile menu button at top-left */}


### PR DESCRIPTION
## Summary
- remove the runtime header height measurement effect and rely on CSS only
- define a responsive header-height custom property so the body offset stays stable
- accept Next.js' generated update to next-env types

## Testing
- npm run lint
- npm run test *(fails: existing engine tests expect buying/rent prompts to pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ced4f2b0ec8327b739d44cc72e1537