### PR TITLE
Improve category article fetching to avoid cache limit

### DIFF
--- a/WT4Q/lib/server/articles.ts
+++ b/WT4Q/lib/server/articles.ts
@@ -1,0 +1,212 @@
+import 'server-only';
+
+import { unstable_cache } from 'next/cache';
+import { API_ROUTES } from '@/lib/api';
+import type { Article } from '@/components/ArticleCard';
+import type { ArticleImage } from '@/lib/models';
+import { stripHtml, truncateWords } from '@/lib/text';
+
+const DEFAULT_LIMIT = 12;
+const MAX_LIMIT = 120;
+const MAX_CONTENT_LENGTH = 3000;
+const SUMMARY_WORD_LIMIT = 80;
+
+type RawImage = {
+  photo?: string | null;
+  photoLink?: string | null;
+  altText?: string | null;
+  caption?: string | null;
+};
+
+type RawArticle = {
+  id: string;
+  slug: string;
+  title: string;
+  summary?: string | null;
+  content?: string | null;
+  createdDate?: string | null;
+  views?: number | null;
+  images?: RawImage[] | null;
+  countryName?: string | null;
+  comments?: unknown[] | null;
+  commentsCount?: number | null;
+  like?: unknown[] | null;
+  likesCount?: number | null;
+  likeCount?: number | null;
+  reactionsCount?: number | null;
+};
+
+function normalizeLimit(limit?: number): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit)) {
+    return DEFAULT_LIMIT;
+  }
+  const safe = Math.floor(limit);
+  if (safe < 1) return 1;
+  if (safe > MAX_LIMIT) return MAX_LIMIT;
+  return safe;
+}
+
+function normalizeImages(images?: RawImage[] | null): ArticleImage[] | undefined {
+  if (!Array.isArray(images) || images.length === 0) {
+    return undefined;
+  }
+
+  const first = images.find(
+    (img): img is RawImage => Boolean(img && (img.photoLink || img.photo)),
+  );
+  if (!first) {
+    return undefined;
+  }
+
+  const sanitized: ArticleImage = {
+    photoLink: first.photoLink ?? undefined,
+    altText: first.altText ?? undefined,
+    caption: first.caption ?? undefined,
+  };
+
+  if (!sanitized.photoLink && typeof first.photo === 'string' && first.photo.length > 0) {
+    sanitized.photo = first.photo;
+  }
+
+  return [sanitized];
+}
+
+function deriveSummary(article: RawArticle, fallback: string): string {
+  const source =
+    typeof article.summary === 'string' && article.summary.trim().length > 0
+      ? article.summary
+      : fallback;
+  const plain = stripHtml(source ?? '').trim();
+  if (!plain) return '';
+  return truncateWords(plain, SUMMARY_WORD_LIMIT);
+}
+
+function computeCommentsCount(article: RawArticle): number | undefined {
+  if (typeof article.commentsCount === 'number' && Number.isFinite(article.commentsCount)) {
+    return article.commentsCount;
+  }
+  if (Array.isArray(article.comments)) {
+    return article.comments.length;
+  }
+  return undefined;
+}
+
+function computeReactionCounts(article: RawArticle): {
+  reactionsCount?: number;
+  likesCount?: number;
+  likeCount?: number;
+} {
+  const likeArrayCount = Array.isArray(article.like) ? article.like.length : undefined;
+  const likesCount =
+    typeof article.likesCount === 'number' && Number.isFinite(article.likesCount)
+      ? article.likesCount
+      : likeArrayCount;
+  const likeCount =
+    typeof article.likeCount === 'number' && Number.isFinite(article.likeCount)
+      ? article.likeCount
+      : undefined;
+  const reactionsCount =
+    typeof article.reactionsCount === 'number' && Number.isFinite(article.reactionsCount)
+      ? article.reactionsCount
+      : likesCount ?? likeCount ?? likeArrayCount;
+
+  return {
+    reactionsCount,
+    likesCount,
+    likeCount,
+  };
+}
+
+function sanitizeArticle(article: RawArticle): Article {
+  const trimmedHtml =
+    typeof article.content === 'string' && article.content.length > 0
+      ? article.content.slice(0, MAX_CONTENT_LENGTH)
+      : '';
+
+  const summary = deriveSummary(article, trimmedHtml);
+
+  const { reactionsCount, likesCount, likeCount } = computeReactionCounts(article);
+
+  return {
+    id: article.id,
+    slug: article.slug,
+    title: article.title,
+    summary,
+    content: trimmedHtml || summary,
+    createdDate: article.createdDate ?? undefined,
+    views:
+      typeof article.views === 'number' && Number.isFinite(article.views)
+        ? article.views
+        : undefined,
+    images: normalizeImages(article.images),
+    countryName: article.countryName ?? undefined,
+    commentsCount: computeCommentsCount(article),
+    reactionsCount,
+    likesCount,
+    likeCount,
+  };
+}
+
+const fetchCategoryArticles = unstable_cache(
+  async (category: string, limit: number): Promise<Article[]> => {
+    const trimmedCategory = category.trim();
+    if (!trimmedCategory) {
+      return [];
+    }
+
+    const url = new URL(API_ROUTES.ARTICLE.SEARCH_ADVANCED);
+    url.searchParams.set('category', trimmedCategory);
+
+    let response: Response;
+    try {
+      response = await fetch(url.toString(), {
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      });
+    } catch {
+      return [];
+    }
+
+    if (!response.ok) {
+      return [];
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      return [];
+    }
+
+    if (!Array.isArray(payload)) {
+      return [];
+    }
+
+    const articles = (payload as RawArticle[])
+      .filter((item) => item && typeof item.id === 'string' && typeof item.slug === 'string')
+      .sort((a, b) => {
+        const aTime = new Date(a.createdDate ?? 0).getTime();
+        const bTime = new Date(b.createdDate ?? 0).getTime();
+        return bTime - aTime;
+      })
+      .slice(0, limit)
+      .map(sanitizeArticle);
+
+    return articles;
+  },
+  ['articles-by-category'],
+  { revalidate: 180 },
+);
+
+export async function getArticlesByCategory(
+  category: string,
+  options: { limit?: number } = {},
+): Promise<Article[]> {
+  const trimmedCategory = category.trim();
+  if (!trimmedCategory) {
+    return [];
+  }
+
+  const limit = normalizeLimit(options.limit);
+  return fetchCategoryArticles(trimmedCategory, limit);
+}

--- a/WT4Q/src/app/category/[category]/page.tsx
+++ b/WT4Q/src/app/category/[category]/page.tsx
@@ -1,7 +1,6 @@
 import Script from 'next/script';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { API_ROUTES } from '@/lib/api';
 import type { Article } from '@/components/ArticleCard';
 import CategoryArticleCard from '@/components/CategoryArticleCard';
 import baseStyles from '../../page.module.css';
@@ -17,6 +16,7 @@ import {
   getCategoryDetails,
   normalizeCategoryName,
 } from '@/lib/categories';
+import { getArticlesByCategory } from '@/lib/server/articles';
 
 const CATEGORY_FETCH_LIMIT = 60;
 
@@ -29,17 +29,7 @@ export function generateStaticParams() {
 
 async function fetchArticles(cat: string): Promise<Article[]> {
   try {
-    const url = new URL(API_ROUTES.ARTICLE.SEARCH_ADVANCED);
-    url.searchParams.set('category', cat);
-    url.searchParams.set('limit', String(CATEGORY_FETCH_LIMIT));
-    const res = await fetch(url, { next: { revalidate: 180 } });
-    if (!res.ok) return [];
-    const data: Article[] = await res.json();
-    return data.sort(
-      (a, b) =>
-        new Date(b.createdDate ?? 0).getTime() -
-        new Date(a.createdDate ?? 0).getTime(),
-    );
+    return await getArticlesByCategory(cat, { limit: CATEGORY_FETCH_LIMIT });
   } catch {
     return [];
   }

--- a/WT4Q/src/app/page.tsx
+++ b/WT4Q/src/app/page.tsx
@@ -10,6 +10,7 @@ import type { ArticleImage } from '@/lib/models';
 import { API_ROUTES } from '@/lib/api';
 import { CATEGORIES } from '@/lib/categories';
 import { chunk } from '@/lib/chunk';
+import { getArticlesByCategory } from '@/lib/server/articles';
 import type { Metadata } from 'next';
 import styles from './page.module.css';
 import LocalArticleSection from '@/components/LocalArticleSection';
@@ -104,22 +105,7 @@ export default async function Home() {
 
 async function fetchArticlesByCategory(cat: string): Promise<Article[]> {
   try {
-    // Only fetch what we render: top 12 is enough to show 3 immediately and have some buffer
-    const url = `${API_ROUTES.ARTICLE.SEARCH_ADVANCED}?category=${encodeURIComponent(cat)}&limit=12`;
-    // Avoid Next.js 2MB data-cache limit for very large categories like "Info"
-    const res = await fetch(
-      url,
-      cat.toLowerCase() === 'info'
-        ? { cache: 'no-store' }
-        : { next: { revalidate: 180 } }
-    );
-    if (!res.ok) return [];
-    const data: Article[] = await res.json();
-    return data.sort(
-      (a, b) =>
-        new Date(b.createdDate ?? 0).getTime() -
-        new Date(a.createdDate ?? 0).getTime(),
-    );
+    return await getArticlesByCategory(cat, { limit: 12 });
   } catch {
     return [];
   }

--- a/WT4Q/src/app/tools/typing-practice/page.tsx
+++ b/WT4Q/src/app/tools/typing-practice/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import TypingPracticeClient from './components/TypingPracticeClient';
-import { API_ROUTES } from '@/lib/api';
+import { getArticlesByCategory } from '@/lib/server/articles';
 import { stripHtml } from '@/lib/text';
 
 export const metadata: Metadata = {
@@ -17,28 +17,9 @@ export const metadata: Metadata = {
   ],
 };
 
-interface Article {
-  createdDate?: string;
-  content?: string;
-  summary?: string;
-}
-
 async function fetchLatestTechText(): Promise<string> {
   try {
-    const res = await fetch(
-      `${API_ROUTES.ARTICLE.SEARCH_ADVANCED}?category=Technology`,
-      {
-        cache: 'no-store',
-      },
-    );
-    if (!res.ok) return 'Welcome to typing practice';
-    const articles: Article[] = await res.json();
-    const latest = articles
-      .sort(
-        (a, b) =>
-          new Date(b.createdDate ?? 0).getTime() -
-          new Date(a.createdDate ?? 0).getTime(),
-      )[0];
+    const [latest] = await getArticlesByCategory('Technology', { limit: 10 });
     const text = stripHtml(latest?.content || latest?.summary || '');
     return (
       text.replace(/\s+/g, ' ').trim().slice(0, 2000) ||


### PR DESCRIPTION
## Summary
- add a server-only helper that fetches advanced article listings, trims large fields, and caches the reduced payload to stay below Next.js data cache limits
- switch the homepage, category page, and typing practice tool to use the new helper so large categories no longer overflow the 2MB cache limit

## Testing
- npm run lint
- npm test *(fails: tests/engine.test.ts has pre-existing expectation failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cee662a19c8327a4ed7a3158a85313