### PR TITLE
Fix crypto lint errors and tighten typings

### DIFF
--- a/WT4Q/src/app/api/crypto/coin/route.ts
+++ b/WT4Q/src/app/api/crypto/coin/route.ts
@@ -7,7 +7,36 @@ type SearchResult = {
   coins: { id: string; name: string; symbol: string }[];
 };
 
-let cache: Record<string, { at: number; data: any }> = {};
+type CoinResponse = {
+  id: string;
+  name: string;
+  symbol?: string;
+  image: string | null;
+  homepage: string | null;
+  description: string | null;
+  rank: number | null;
+  categories: string[];
+  links: { website: string | null; twitter: string | null; reddit: string | null; github: string[]; explorers: string[] };
+  marketCap: number | null;
+  fdv: number | null;
+  currentPrice: number | null;
+  totalVolume: number | null;
+  high24h: number | null;
+  low24h: number | null;
+  ath: number | null;
+  athDate: string | null;
+  atl: number | null;
+  atlDate: string | null;
+  supply: { circulating: number | null; total: number | null; max: number | null };
+  priceChange1h: number | null;
+  priceChange24h: number | null;
+  priceChange7d: number | null;
+  priceChange30d: number | null;
+  priceChange1y: number | null;
+  lastUpdated: string | null;
+};
+
+const cache: Record<string, { at: number; data: CoinResponse }> = {};
 const TTL_MS = 120_000;
 
 export async function GET(req: Request) {
@@ -33,7 +62,7 @@ export async function GET(req: Request) {
 
     const md = cjson.market_data || {};
     const links = cjson.links || {};
-    const out = {
+    const out: CoinResponse = {
       id: cjson.id,
       name: cjson.name,
       symbol: cjson.symbol?.toUpperCase(),
@@ -74,7 +103,7 @@ export async function GET(req: Request) {
 
     cache[key] = { at: now, data: out };
     return NextResponse.json(out, { headers: cacheHeaders(TTL_MS) });
-  } catch (e) {
+  } catch {
     return NextResponse.json({ error: 'failed' }, { status: 500 });
   }
 }

--- a/WT4Q/src/app/api/crypto/klines/route.ts
+++ b/WT4Q/src/app/api/crypto/klines/route.ts
@@ -5,6 +5,16 @@ import { NextResponse } from 'next/server';
 
 const BINANCE_KLINES_URL = 'https://api.binance.com/api/v3/klines';
 
+type BinanceCandle = [
+  number | string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  ...unknown[]
+];
+
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
@@ -31,14 +41,14 @@ export async function GET(req: Request) {
     if (!res.ok) {
       return NextResponse.json({ error: `Upstream error ${res.status}` }, { status: 502 });
     }
-    const raw = (await res.json()) as unknown[];
-    const candles = (raw as any[]).map((c) => ({
-      time: Math.floor(Number(c[0]) / 1000),
-      open: Number(c[1]),
-      high: Number(c[2]),
-      low: Number(c[3]),
-      close: Number(c[4]),
-      volume: Number(c[5]),
+    const raw = (await res.json()) as BinanceCandle[];
+    const candles = raw.map((candle) => ({
+      time: Math.floor(Number(candle[0]) / 1000),
+      open: Number(candle[1]),
+      high: Number(candle[2]),
+      low: Number(candle[3]),
+      close: Number(candle[4]),
+      volume: Number(candle[5]),
     }));
 
     return NextResponse.json(candles, {
@@ -48,7 +58,7 @@ export async function GET(req: Request) {
         'Vercel-CDN-Cache-Control': `public, s-maxage=${ttl}, stale-while-revalidate=${Math.max(2 * ttl, 60)}`,
       },
     });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: 'Failed to load klines' }, { status: 500 });
   }
 }

--- a/WT4Q/src/app/api/crypto/names/route.ts
+++ b/WT4Q/src/app/api/crypto/names/route.ts
@@ -38,7 +38,7 @@ export async function GET(req: Request) {
         'Cache-Control': `public, max-age=0, s-maxage=${ttl}, stale-while-revalidate=${ttl}`,
       },
     });
-  } catch (e) {
+  } catch {
     return NextResponse.json([], { status: 200 });
   }
 }

--- a/WT4Q/src/app/api/crypto/news/route.ts
+++ b/WT4Q/src/app/api/crypto/news/route.ts
@@ -4,7 +4,16 @@ const FEED = (q: string) =>
   `https://news.google.com/rss/search?q=${encodeURIComponent(q)}%20when:7d&hl=en-US&gl=US&ceid=US:en`;
 
 const TTL_MS = 10 * 60 * 1000; // 10 minutes
-let cache: Record<string, { at: number; items: any[] }> = {};
+
+type RssItem = {
+  title?: string;
+  link?: string;
+  pubDate?: string;
+  source?: string;
+  description?: string;
+};
+
+const cache: Record<string, { at: number; items: RssItem[] }> = {};
 
 export async function GET(req: Request) {
   try {
@@ -22,7 +31,7 @@ export async function GET(req: Request) {
     const items = parseRssItems(xml).slice(0, 40);
     cache[key] = { at: now, items };
     return NextResponse.json(items, { headers: cacheHeaders(TTL_MS) });
-  } catch (e) {
+  } catch {
     return NextResponse.json({ error: 'failed' }, { status: 500 });
   }
 }

--- a/WT4Q/src/app/api/crypto/tickers/route.ts
+++ b/WT4Q/src/app/api/crypto/tickers/route.ts
@@ -82,7 +82,7 @@ export async function GET(req: Request) {
         'Vercel-CDN-Cache-Control': `public, s-maxage=${TTL_MS / 1000}, stale-while-revalidate=30`,
       },
     });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: 'Failed to load tickers' }, { status: 500 });
   }
 }

--- a/WT4Q/src/app/api/crypto/top/route.ts
+++ b/WT4Q/src/app/api/crypto/top/route.ts
@@ -38,7 +38,22 @@ const STABLES = new Set([
 ]);
 
 let exInfoCache: { at: number; usdtPairs: Set<string> } | null = null;
-let topCache: { at: number; items: any[] } | null = null;
+type TopItem = {
+  symbol: string;
+  lastPrice: number;
+  priceChangePercent: number;
+  highPrice: number;
+  lowPrice: number;
+  volume: number;
+  quoteVolume: number;
+  openPrice: number;
+  prevClosePrice: number;
+  name: string;
+  marketCap: number;
+  marketCapRank: number | null;
+};
+
+let topCache: { at: number; items: TopItem[] } | null = null;
 
 async function getUsdtPairs(): Promise<Set<string>> {
   const now = Date.now();
@@ -73,7 +88,7 @@ export async function GET(req: Request) {
     if (!cgRes.ok) return NextResponse.json({ error: 'coingecko error' }, { status: 502 });
     const coins = (await cgRes.json()) as CGCoin[];
 
-    const items: any[] = [];
+    const items: TopItem[] = [];
     for (const c of coins) {
       const base = c.symbol.toUpperCase().replace(/[^A-Z0-9]/g, '');
       if (STABLES.has(base)) continue;
@@ -98,7 +113,7 @@ export async function GET(req: Request) {
 
     topCache = { at: now, items };
     return NextResponse.json(items.slice(0, limit), { headers: cacheHeaders(TOP_TTL_MS) });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: 'Failed to load top list' }, { status: 500 });
   }
 }

--- a/WT4Q/src/components/BreakingNewsSlider.tsx
+++ b/WT4Q/src/components/BreakingNewsSlider.tsx
@@ -300,18 +300,6 @@ export default function BreakingNewsSlider({
     setManualPause(false);
   };
 
-  const handleTickerMouseEnter = () => {
-    if (!isTickerMode) return;
-    clearTickerPauseTimeout();
-    setTickerPaused(true);
-  };
-
-  const handleTickerMouseLeave = () => {
-    if (!isTickerMode) return;
-    clearTickerPauseTimeout();
-    setTickerPaused(false);
-  };
-
   const handleTickerPointerDown = () => {
     if (!isTickerMode) return;
     clearTickerPauseTimeout();

--- a/WT4Q/src/components/CryptoAllPage.tsx
+++ b/WT4Q/src/components/CryptoAllPage.tsx
@@ -127,10 +127,6 @@ export default function CryptoAllPage() {
   );
 }
 
-function prettySymbol(s: string) {
-  return s.replace('USDT', '/USDT');
-}
-
 function formatNumber(n: number) {
   if (!isFinite(n)) return '-';
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
@@ -155,12 +151,6 @@ function renderMiniRange(t: Row) {
       <span className={styles.miniMarker} style={{ left: `${pos * 100}%` }} />
     </div>
   );
-}
-
-function renderName(t: Row, map: Record<string, string>) {
-  const base = t.symbol.replace(/USDT$/, '').toUpperCase();
-  const n = map[base];
-  return n ? ` (${n})` : '';
 }
 
 function renderDisplayName(t: Row, map: Record<string, string>) {

--- a/WT4Q/src/components/CryptoChart.tsx
+++ b/WT4Q/src/components/CryptoChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from 'react';
-import { createChart, ColorType, UTCTimestamp, Time } from 'lightweight-charts';
+import { createChart, ColorType, UTCTimestamp } from 'lightweight-charts';
 
 export type Candle = {
   time: number; // seconds since epoch
@@ -60,7 +60,7 @@ export default function CryptoChart({ data, symbol, interval, className }: Props
       color: 'rgba(0,0,0,0.2)',
     });
     try {
-      chart.priceScale('').applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } as any });
+      chart.priceScale('').applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
     } catch {}
 
     chartRef.current = chart;
@@ -94,7 +94,7 @@ export default function CryptoChart({ data, symbol, interval, className }: Props
     v.setData(data.map((c) => ({
       time: c.time as UTCTimestamp,
       value: c.volume ?? 0,
-      color: (c.close >= c.open ? 'rgba(38,166,154,0.4)' : 'rgba(239,83,80,0.4)') as any,
+      color: c.close >= c.open ? 'rgba(38,166,154,0.4)' : 'rgba(239,83,80,0.4)',
     })));
     chartRef.current?.timeScale().fitContent();
   }, [data]);

--- a/WT4Q/src/components/CryptoDetailPage.tsx
+++ b/WT4Q/src/components/CryptoDetailPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import CryptoChart, { Candle } from './CryptoChart';
 import styles from './CryptoDetail.module.css';
@@ -111,7 +112,9 @@ export default function CryptoDetailPage({ symbol }: { symbol: string }) {
         </button>
       </div>
       <div className={styles.header}>
-        {coin?.image ? <img src={coin.image} alt="" width={36} height={36} /> : null}
+        {coin?.image ? (
+          <Image src={coin.image} alt={`${coin?.name ?? base} logo`} width={36} height={36} />
+        ) : null}
         <h1 className={styles.title}>{(coin?.name || base)} ({base})</h1>
         {coin ? <span className={styles.meta}>Mkt cap: {coin.marketCap ? formatCurrency(coin.marketCap) : '—'}</span> : null}
       </div>

--- a/WT4Q/src/components/CryptoPage.tsx
+++ b/WT4Q/src/components/CryptoPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import CryptoTicker, { TickerItem } from './CryptoTicker';
 import CryptoChart, { Candle } from './CryptoChart';
 import styles from './CryptoPage.module.css';
@@ -18,7 +19,6 @@ export default function CryptoPage() {
   const [tf, setTf] = useState<Timeframe>('1h');
   const [candles, setCandles] = useState<Candle[]>([]);
   const [q, setQ] = useState('');
-  const [loading, setLoading] = useState(false);
 
   // Pull top 10 tickers for table by default
   useEffect(() => {
@@ -71,7 +71,6 @@ export default function CryptoPage() {
   useEffect(() => {
     if (!symbol) return;
     let active = true;
-    setLoading(true);
     const load = async () => {
       try {
         const limit = tf === '1m' ? 1200 : tf === '5m' ? 1200 : tf === '1h' ? 1000 : tf === '1d' ? 700 : tf === '1w' ? 800 : tf === '1M' ? 600 : 365;
@@ -80,9 +79,6 @@ export default function CryptoPage() {
         const data = (await res.json()) as Candle[];
         if (active) setCandles(data);
       } catch {}
-      finally {
-        if (active) setLoading(false);
-      }
     };
     load();
     return () => { active = false; };
@@ -153,13 +149,13 @@ export default function CryptoPage() {
             >
               Top 10
             </button>
-            <a
+            <Link
               className={`${styles.btn} ${!showTopOnly ? styles.btnActive : ''}`}
               href="/crypto/all"
               title="Open the full list"
             >
               Show all
-            </a>
+            </Link>
             <span className={styles.muted}>{showTopOnly ? 'Showing top 10 by volume' : `Showing ${tickers.length} coins`}</span>
           </div>
           <div className={styles.searchRow}>
@@ -234,12 +230,6 @@ function renderMiniRange(t: TickerItem) {
       <span className={styles.miniMarker} style={{ left: `${pos * 100}%` }} />
     </div>
   );
-}
-
-function renderName(t: TickerItem, map: Record<string, string>) {
-  const base = t.symbol.replace(/USDT$/, '').toUpperCase();
-  const n = t.name || map[base];
-  return n ? ` (${n})` : '';
 }
 
 function renderDisplayName(t: TickerItem, map: Record<string, string>) {


### PR DESCRIPTION
## Summary
- tighten typings and caches across the crypto API routes so lint no longer reports `any` usage
- update crypto UI components to rely on Next.js primitives and drop unused helpers flagged by eslint
- clean up the chart rendering logic by removing `any` casts in favor of concrete types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03c3b0c0c832784d1b4fae2a84571