### PR TITLE
Replace paper background image with CSS gradients

### DIFF
--- a/WT4Q/next.config.ts
+++ b/WT4Q/next.config.ts
@@ -35,7 +35,7 @@ const nextConfig: NextConfig = {
         source: "/_next/image",
         headers: [{ key: "Cache-Control", value: "public, max-age=86400, must-revalidate" }],
       },
-      // Public images (e.g., /images/paper_background.webp): long-lived cache
+      // Public images (e.g., icons and logos served from /public): long-lived cache
       {
         // Match common image extensions served from /public
         source: "/:path*\.(png|jpg|jpeg|gif|svg|webp|avif|ico)",

--- a/WT4Q/src/app/articles/article.module.css
+++ b/WT4Q/src/app/articles/article.module.css
@@ -1,8 +1,10 @@
 
 /* Container for the article page with a newspaper-like layout */
 .newspaper {
-  background: #f7f5ef;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   color: #111;
   padding: 1.5rem clamp(1rem, 3vw, 1rem) 2rem;
   margin: 0 auto;

--- a/WT4Q/src/app/global-styles.tsx
+++ b/WT4Q/src/app/global-styles.tsx
@@ -121,7 +121,12 @@ body::before {
   inset: 0;
   z-index: -1;
   /* Decorative paper texture is lazy-applied via CSS var to avoid blocking paint */
-  background-image: var(--paper-bg, none);
+  background-color: #EEE9DA;
+  background-image: var(
+    --paper-bg,
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px)
+  );
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -130,17 +135,22 @@ body::before {
 
 /* For the purple site background variant */
 body.site-bg--purple::before {
+  background-color: #EEE9DA;
   background-image:
     radial-gradient(900px circle at 60% 15%, rgba(255,255,255,0.12), transparent 45%),
     radial-gradient(1400px circle at 80% 0, #3a17a7 0, #2b0a86 55%, #1f085f 85%, #14043d 100%),
-    var(--paper-bg, none);
+    var(
+      --paper-bg,
+      radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+      radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px)
+    );
 }
 
 /* Respect data-saver preferences: never load the decorative background */
 @media (prefers-reduced-data: reduce) {
   body::before,
   body.site-bg--purple::before {
-    background-image: none !important;
+    background: none !important;
   }
 }
 

--- a/WT4Q/src/app/layout.tsx
+++ b/WT4Q/src/app/layout.tsx
@@ -106,7 +106,10 @@ export default function RootLayout({
               var reduce = false;
               try { reduce = window.matchMedia('(prefers-reduced-data: reduce)').matches; } catch {}
               if (!reduce) {
-                docEl.style.setProperty('--paper-bg', "url('/images/paper_background.webp')");
+                docEl.style.setProperty(
+                  '--paper-bg',
+                  "radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px), radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px)"
+                );
               }
             } catch (e) { /* no-op */ }
           `}

--- a/WT4Q/src/app/login/Login.module.css
+++ b/WT4Q/src/app/login/Login.module.css
@@ -6,7 +6,10 @@
   align-items: center;
   justify-content: center;
   font-family: Georgia, "Times New Roman", serif;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   background-size: cover;
   background-position: center top;
   background-repeat: no-repeat;

--- a/WT4Q/src/app/page.module.css
+++ b/WT4Q/src/app/page.module.css
@@ -13,8 +13,10 @@
   --gutter: 2rem;
   --col-gap: 2.25rem;
 
-  background: var(--paper);
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   color: var(--ink);
   padding: 1.5rem clamp(1rem, 3vw, 1rem) 2rem;
   margin: 0 auto;

--- a/WT4Q/src/app/register/Register.module.css
+++ b/WT4Q/src/app/register/Register.module.css
@@ -6,7 +6,10 @@
   align-items: center;
   justify-content: center;
   font-family: Georgia, "Times New Roman", serif;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   background-size: cover;
   background-position: center top;
   background-repeat: no-repeat;

--- a/WT4Q/src/components/CommentsSection.module.css
+++ b/WT4Q/src/components/CommentsSection.module.css
@@ -1,7 +1,9 @@
 .section {
   margin-top: 2rem;
-  background: #f7f5ef;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   padding: 1rem;
   border: 1px solid #ddd;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
@@ -23,8 +25,10 @@
 .comment {
   padding: 0.75rem;
   margin-bottom: 0.75rem;
-  background: #f7f5ef;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   border: 3px double var(--ink);
   color: var(--ink);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
@@ -37,8 +41,10 @@
 .reply {
   margin-top: 0.5rem;
   padding: 0.5rem;
-  background: #f7f5ef;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   border: 3px double var(--ink);
   color: var(--ink);
 }
@@ -153,8 +159,10 @@
   resize: vertical;
   padding: 0.5rem;
   font-family: "Georgia", "Times New Roman", serif;
-  background: #f7f5ef;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   border: 1px solid #ddd;
   color: var(--ink);
   line-height: 1.4;

--- a/WT4Q/src/components/Footer.module.css
+++ b/WT4Q/src/components/Footer.module.css
@@ -1,9 +1,11 @@
 .footer {
-  background: var(--primary);
-  color: #ffffff;
+  background-color: #EEE9DA;
+  color: var(--ink);
   padding: 1rem;
   font-family: var(--font-inter), system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  background-image: url('/images/paper_background.webp');
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
 }
 
 .inner {

--- a/WT4Q/src/components/Header.module.css
+++ b/WT4Q/src/components/Header.module.css
@@ -12,7 +12,10 @@
   
   box-shadow: 0 0.1rem 0.2rem rgba(0, 0, 0, 0.1);
   animation: slideIn 0.6s ease-out;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;

--- a/WT4Q/src/components/UserMenu.module.css
+++ b/WT4Q/src/components/UserMenu.module.css
@@ -59,7 +59,10 @@
   position: absolute;
   top: 110%;
   right: 0;
-  background-image: url('/images/paper_background.webp');
+  background-color: #EEE9DA;
+  background-image:
+    radial-gradient(1px 1px at 30% 40%, rgba(0,0,0,.03), transparent 2px),
+    radial-gradient(1px 1px at 70% 60%, rgba(0,0,0,.02), transparent 2px);
   border: 1px solid var(--secondary);
   border-radius: 8px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);

--- a/WT4Q/tmp_layout.txt
+++ b/WT4Q/tmp_layout.txt
@@ -61,8 +61,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <GlobalStyles />
-        {/* Preload background texture used on homepage to avoid late paint */}
-        <link rel="preload" as="image" href="/images/paper_background.webp" />
+        {/* Paper texture now rendered with CSS gradients; no preload required */}
         {/* Structured data for brand synonyms */}
         <Script id="ld-org" type="application/ld+json" strategy="afterInteractive">
           {JSON.stringify({


### PR DESCRIPTION
## Summary
- replace every usage of the heavy paper texture image with a lightweight CSS radial gradient across layout, article, landing, authentication, and comment styles
- update the global background helper and supporting script to emit the same gradient and drop the unused preload reference
- refresh documentation/comments to remove stale references to the deleted asset

## Testing
- npm run lint
- npm test *(fails: existing engine tests already failing in main)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b415f05483279fe5150e5951967d