### PR TITLE
Fix metrotrade engine LearningAgent import path

### DIFF
--- a/WT4Q/export/games-tools/lib/metrotrade/engine.ts
+++ b/WT4Q/export/games-tools/lib/metrotrade/engine.ts
@@ -2,7 +2,7 @@ import type { GameState, InitOptions, Player } from "./types";
 import { BOARD, START_CASH, PASS_START_BONUS } from "./constants";
 import { rollDice, wrap, nextSeed } from "./utils";
 import { adjustNetWorth, computeRent, jailPlayer, leaveJail } from "./rules";
-import { LearningAgent } from "../../services/metrotrade/LearningAgent";
+import { LearningAgent } from "@/services/metrotrade/LearningAgent";
 
 function clone<T>(x:T):T { return JSON.parse(JSON.stringify(x)); }
 


### PR DESCRIPTION
## Summary
- update the metrotrade engine to import the learning agent via the configured services alias

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ba0278508327a616499f21666497